### PR TITLE
ci(claude): skip code review for renovate PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,8 +12,9 @@ on:
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
+    if: |
+      !startsWith(github.event.pull_request.head.ref, 'renovate/')
+    #   !startsWith(github.event.pull_request.head.ref, 'renovate/') &&
     #   github.event.pull_request.user.login == 'external-contributor' ||
     #   github.event.pull_request.user.login == 'new-developer' ||
     #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
@@ -36,9 +37,8 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
-          plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          plugin_marketplaces: "https://github.com/anthropics/claude-code.git"
+          plugins: "code-review@claude-code-plugins"
+          prompt: "/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}"
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-


### PR DESCRIPTION
## Context/Motivation

Renovate PRs are automated dependency updates that don't require Claude code review. Running the review workflow on these PRs wastes CI resources and creates unnecessary noise.

## Description of Changes

- Added conditional filter to `.github/workflows/claude-code-review.yml` to skip Claude code review for PRs from `renovate/*` branches
- Cleaned up quote style consistency in workflow configuration (single quotes → double quotes for `plugin_marketplaces`, `plugins`, and `prompt` parameters)

## Testing Information

- [x] Manual testing completed

**Test steps:**
1. Verify workflow runs on regular PRs (non-renovate branches)
2. Verify workflow is skipped for renovate/* branch PRs
3. Confirm workflow syntax is valid

## Screenshots/Videos

N/A - CI configuration change only

## Relevant Links

- Related to [PR #62](https://github.com/samjmarshall/www/pull/62) (Claude Code automation expansion)

## Breaking Changes

- [x] No breaking changes
- [ ] Breaking changes documented below