### PR TITLE
feat(hubspot): contact sync on lead create/update and webhook processing

### DIFF
--- a/.github/workflows/post-deploy.yml
+++ b/.github/workflows/post-deploy.yml
@@ -113,6 +113,11 @@ jobs:
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
           DATABASE_URL: ${{ steps.neon.outputs.db_url }}
           BETTER_AUTH_SECRET: ${{ secrets.BETTER_AUTH_SECRET }}
+          # HubSpot outbound sync tests run in any environment
+          HUBSPOT_ACCESS_TOKEN: ${{ secrets.HUBSPOT_ACCESS_TOKEN }}
+          # Inbound webhook tests only run on production — the HubSpot
+          # webhook target URL is manually pinned to the production deployment
+          HUBSPOT_WEBHOOK_ACTIVE: ${{ github.event.client_payload.environment == 'production' && '1' || '' }}
 
       - name: Rollback migrations (preview — reset branch to parent)
         if: failure() && steps.e2e.outcome == 'failure' && steps.neon.outputs.branch_id && github.event.client_payload.environment != 'production'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,17 @@ Prefer Makefile targets with `yarn` as a fallback — never use `npm` or `npx` d
 
 ---
 
+## Database Migrations
+
+**Never use `drizzle-kit push`** — it applies schema changes directly without recording them in the migrations table, breaking idempotency.
+
+Always use this two-step process:
+
+1. `yarn db:generate` — generate a migration SQL file in `drizzle/`
+2. `yarn db:migrate` — apply pending migrations and record them in `__drizzle_migrations`
+
+---
+
 ## Workflows
 
 ### Building & Reviewing UI

--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,9 @@ db_branch_delete_all:
 db_branch_status:
 	scripts/neon-branch.sh status
 
+hubspot_setup:
+	yarn tsx scripts/hubspot/setup.ts
+
 release:
 	yarn release
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -262,9 +262,9 @@ These commands are invoked inside [Claude Code](https://claude.ai/code) via slas
 | `/brainstorm` | Socratic exploration of rough ideas into a design doc | Before writing code — refine what you're building |
 | `/write_ticket` | Collaborative ticket writing | Creating GitHub issues with clear scope |
 | `/review_roadmap` | GitHub Project prioritization review | Re-assessing milestone priorities |
-| `/create_plan` | Research-heavy plan creation → `thoughts/plans/` | Starting a new feature or significant change |
+| `/create_plan` | Research-heavy plan creation → `thoughts/plans/`. Applies `frontend-design` skill for UI work | Starting a new feature or significant change |
 | `/iterate_plan` | Update existing plan with new feedback | Plan needs revision after code review or discovery |
-| `/implement_plan <path>` | Execute a plan phase-by-phase | Working through an approved plan |
+| `/implement_plan <path>` | Execute a plan phase-by-phase. Invokes `frontend-design` skill for UI phases | Working through an approved plan |
 | `/validate_plan <path>` | Verify implementation matches plan intent | After implementing — check nothing was missed |
 | `/plan-to-ralph-spec <path>` | Convert markdown plan to `.spec.json` for Ralph | Before running `ralph.sh` — produces the JSON spec Ralph reads |
 | `/commit` | Structured conventional commit | Ready to commit (follows repo conventions) |

--- a/e2e/features/hubspot-sync.spec.ts
+++ b/e2e/features/hubspot-sync.spec.ts
@@ -5,6 +5,7 @@ import {
   deleteTestLeads,
   deleteTestSession,
   type TestSession,
+  uniquePhone,
 } from "../utils/auth-helper";
 import {
   archiveTestContact,
@@ -17,6 +18,14 @@ import {
   waitForLeadField,
 } from "../utils/hubspot-helper";
 import { getSessionCookie } from "../utils/session-cookie";
+
+// Tests in this file mutate the shared HubSpot account and DB. Run them
+// sequentially within a single worker so beforeAll/afterAll cleanup runs
+// once per describe — preventing workers from wiping each other's data.
+//
+// Timeout is doubled because each test does 2-3 HubSpot API roundtrips and
+// the local dev server is heavily contended by parallel workers in dev.
+test.describe.configure({ mode: "serial", timeout: 60_000 });
 
 test.describe("HubSpot Outbound Sync — E2E", () => {
   test.skip(
@@ -48,6 +57,7 @@ test.describe("HubSpot Outbound Sync — E2E", () => {
 
     const uniqueId = Date.now().toString(36);
     const testEmail = `e2e-${uniqueId}@test.rekurve.dev`;
+    const testPhone = uniquePhone();
 
     await page.goto("/leads/new");
     const form = new LeadFormSection(page);
@@ -56,7 +66,7 @@ test.describe("HubSpot Outbound Sync — E2E", () => {
     await form.fillStep1({
       firstName: "HubSpot",
       lastName: `Sync ${uniqueId}`,
-      phone: "0412345678",
+      phone: testPhone,
       email: testEmail,
     });
     await form.selectSegmented("Preferred contact time", "Anytime");
@@ -90,7 +100,7 @@ test.describe("HubSpot Outbound Sync — E2E", () => {
     expect(contact!.properties.firstname).toBe("HubSpot");
     expect(contact!.properties.lastname).toBe(`Sync ${uniqueId}`);
     expect(contact!.properties.email).toBe(testEmail);
-    expect(contact!.properties.phone).toBe("0412345678");
+    expect(contact!.properties.phone).toBe(testPhone);
     expect(contact!.properties.has_land).toBe("true");
     expect(contact!.properties.land_address).toBe("42 Test Ave");
     expect(contact!.properties.land_size_sqm).toBe("500");
@@ -116,13 +126,15 @@ test.describe("HubSpot Outbound Sync — E2E", () => {
 
     const uniqueId = Date.now().toString(36);
     const testEmail = `e2e-${uniqueId}@test.rekurve.dev`;
+    const seedPhone = uniquePhone();
+    const formPhone = uniquePhone();
 
     // Seed: create a contact in HubSpot first
     const seeded = await createTestContact({
       firstname: "Existing",
       lastname: "Contact",
       email: testEmail,
-      phone: "0400000000",
+      phone: seedPhone,
     });
 
     // Create a lead in the app with the same email
@@ -132,7 +144,7 @@ test.describe("HubSpot Outbound Sync — E2E", () => {
     await form.fillStep1({
       firstName: "Updated",
       lastName: `Dedup ${uniqueId}`,
-      phone: "0412345678",
+      phone: formPhone,
       email: testEmail,
     });
     await form.clickNext();
@@ -202,7 +214,7 @@ test.describe("HubSpot Inbound Sync — E2E", () => {
     await form.fillStep1({
       firstName: "Inbound",
       lastName: `Phone ${uniqueId}`,
-      phone: "0412345678",
+      phone: uniquePhone(),
       email: testEmail,
     });
     await form.clickNext();
@@ -242,7 +254,7 @@ test.describe("HubSpot Inbound Sync — E2E", () => {
     await form.fillStep1({
       firstName: "Inbound",
       lastName: `Delete ${uniqueId}`,
-      phone: "0412345678",
+      phone: uniquePhone(),
       email: testEmail,
     });
     await form.clickNext();

--- a/e2e/features/hubspot-sync.spec.ts
+++ b/e2e/features/hubspot-sync.spec.ts
@@ -1,0 +1,266 @@
+import { expect, test } from "@playwright/test";
+import { LeadFormSection } from "../pages/sections/lead-form.section";
+import {
+  createTestSession,
+  deleteTestLeads,
+  deleteTestSession,
+  type TestSession,
+} from "../utils/auth-helper";
+import {
+  archiveTestContact,
+  createTestContact,
+  deleteTestContacts,
+  findContactByEmail,
+  getLeadHubSpotId,
+  updateTestContact,
+  waitForLeadDeletion,
+  waitForLeadField,
+} from "../utils/hubspot-helper";
+import { getSessionCookie } from "../utils/session-cookie";
+
+test.describe("HubSpot Outbound Sync — E2E", () => {
+  test.skip(
+    !process.env.HUBSPOT_ACCESS_TOKEN || !process.env.DATABASE_URL,
+    "Requires HUBSPOT_ACCESS_TOKEN and DATABASE_URL — skipped in CI",
+  );
+
+  let session: TestSession;
+
+  test.beforeAll(async () => {
+    session = await createTestSession();
+    // Clean up any leftover test contacts from previous runs
+    await deleteTestContacts();
+    await deleteTestLeads();
+  });
+
+  test.afterAll(async () => {
+    await deleteTestContacts();
+    await deleteTestLeads();
+    await deleteTestSession(session.userId);
+  });
+
+  test("creating a lead produces a HubSpot contact with matching properties", async ({
+    context,
+    page,
+    baseURL,
+  }) => {
+    await context.addCookies([getSessionCookie(session.signedToken, baseURL!)]);
+
+    const uniqueId = Date.now().toString(36);
+    const testEmail = `e2e-${uniqueId}@test.rekurve.dev`;
+
+    await page.goto("/leads/new");
+    const form = new LeadFormSection(page);
+
+    // Step 1: Contact
+    await form.fillStep1({
+      firstName: "HubSpot",
+      lastName: `Sync ${uniqueId}`,
+      phone: "0412345678",
+      email: testEmail,
+    });
+    await form.selectSegmented("Preferred contact time", "Anytime");
+    await form.clickNext();
+
+    // Step 2: Land
+    await form.selectSegmented("Has land", "Yes");
+    await form.landAddressInput.waitFor({ state: "visible" });
+    await form.selectSegmented("Land registered", "Yes");
+    await form.landAddressInput.fill("42 Test Ave");
+    await form.landSqmInput.fill("500");
+    await form.landWidthInput.fill("20");
+    await form.landDepthInput.fill("25");
+    await form.clickNext();
+
+    // Step 3: Build
+    await form.selectSegmented("Property type", "First Home Buyer");
+    await form.budgetInput.fill("$700,000");
+    await form.selectSegmented("Seen broker", "Yes");
+    await form.selectSegmented("Construction timeline", "Ready Now");
+    await form.clickNext();
+
+    // Step 4: Additional
+    await form.notesTextarea.fill("E2E HubSpot sync test");
+    await form.clickSubmit();
+    await form.expectSuccess(`HubSpot Sync ${uniqueId}`);
+
+    // Verify: contact exists in HubSpot with correct properties
+    const contact = await findContactByEmail(testEmail);
+    expect(contact).not.toBeNull();
+    expect(contact!.properties.firstname).toBe("HubSpot");
+    expect(contact!.properties.lastname).toBe(`Sync ${uniqueId}`);
+    expect(contact!.properties.email).toBe(testEmail);
+    expect(contact!.properties.phone).toBe("0412345678");
+    expect(contact!.properties.has_land).toBe("true");
+    expect(contact!.properties.land_address).toBe("42 Test Ave");
+    expect(contact!.properties.land_size_sqm).toBe("500");
+    expect(contact!.properties.land_width).toBe("20");
+    expect(contact!.properties.land_depth).toBe("25");
+    expect(contact!.properties.property_type).toBe("first_home_buyer");
+    expect(contact!.properties.budget).toBe("$700,000");
+    expect(contact!.properties.construction_timeline).toBe("ready_now");
+    expect(contact!.properties.notes).toBe("E2E HubSpot sync test");
+    expect(contact!.properties.preferred_contact_time).toBe("anytime");
+
+    // Verify: local lead has hubspotContactId
+    const hubspotId = await getLeadHubSpotId(testEmail);
+    expect(hubspotId).toBe(contact!.id);
+  });
+
+  test("creating a lead with an existing HubSpot email updates instead of duplicating", async ({
+    context,
+    page,
+    baseURL,
+  }) => {
+    await context.addCookies([getSessionCookie(session.signedToken, baseURL!)]);
+
+    const uniqueId = Date.now().toString(36);
+    const testEmail = `e2e-${uniqueId}@test.rekurve.dev`;
+
+    // Seed: create a contact in HubSpot first
+    const seeded = await createTestContact({
+      firstname: "Existing",
+      lastname: "Contact",
+      email: testEmail,
+      phone: "0400000000",
+    });
+
+    // Create a lead in the app with the same email
+    await page.goto("/leads/new");
+    const form = new LeadFormSection(page);
+
+    await form.fillStep1({
+      firstName: "Updated",
+      lastName: `Dedup ${uniqueId}`,
+      phone: "0412345678",
+      email: testEmail,
+    });
+    await form.clickNext();
+
+    // Step 2: minimal land info
+    await form.selectSegmented("Has land", "No");
+    await form.clickNext();
+
+    // Step 3: minimal build info
+    await form.selectSegmented("Property type", "First Home Buyer");
+    await form.clickNext();
+
+    // Step 4: submit
+    await form.clickSubmit();
+    await form.expectSuccess(`Updated Dedup ${uniqueId}`);
+
+    // Verify: the seeded contact was UPDATED, not a new one created
+    const contact = await findContactByEmail(testEmail);
+    expect(contact).not.toBeNull();
+    expect(contact!.id).toBe(seeded.id); // Same contact ID — not a duplicate
+    expect(contact!.properties.firstname).toBe("Updated");
+    expect(contact!.properties.lastname).toBe(`Dedup ${uniqueId}`);
+
+    // Verify: local lead references the same HubSpot contact
+    const hubspotId = await getLeadHubSpotId(testEmail);
+    expect(hubspotId).toBe(seeded.id);
+  });
+});
+
+test.describe("HubSpot Inbound Sync — E2E", () => {
+  test.skip(
+    !process.env.HUBSPOT_ACCESS_TOKEN ||
+      !process.env.DATABASE_URL ||
+      !process.env.HUBSPOT_WEBHOOK_ACTIVE,
+    "Requires HUBSPOT_ACCESS_TOKEN, DATABASE_URL, and HUBSPOT_WEBHOOK_ACTIVE — only against production (webhook target is production-only)",
+  );
+
+  let session: TestSession;
+
+  test.beforeAll(async () => {
+    session = await createTestSession();
+    await deleteTestContacts();
+    await deleteTestLeads();
+  });
+
+  test.afterAll(async () => {
+    await deleteTestContacts();
+    await deleteTestLeads();
+    await deleteTestSession(session.userId);
+  });
+
+  test("editing a contact's phone in HubSpot updates the local lead", async ({
+    context,
+    page,
+    baseURL,
+  }) => {
+    test.setTimeout(60_000); // Webhook latency
+
+    await context.addCookies([getSessionCookie(session.signedToken, baseURL!)]);
+
+    const uniqueId = Date.now().toString(36);
+    const testEmail = `e2e-${uniqueId}@test.rekurve.dev`;
+
+    // Step 1: Create a lead via the app (establishes the HubSpot link)
+    await page.goto("/leads/new");
+    const form = new LeadFormSection(page);
+    await form.fillStep1({
+      firstName: "Inbound",
+      lastName: `Phone ${uniqueId}`,
+      phone: "0412345678",
+      email: testEmail,
+    });
+    await form.clickNext();
+    await form.selectSegmented("Has land", "No");
+    await form.clickNext();
+    await form.selectSegmented("Property type", "First Home Buyer");
+    await form.clickNext();
+    await form.clickSubmit();
+    await form.expectSuccess(`Inbound Phone ${uniqueId}`);
+
+    // Step 2: Get the hubspotContactId from the local DB
+    const hubspotId = await getLeadHubSpotId(testEmail);
+    expect(hubspotId).not.toBeNull();
+
+    // Step 3: Update the contact's phone in HubSpot directly
+    await updateTestContact(hubspotId!, { phone: "0499999999" });
+
+    // Step 4: Wait for the webhook to update the local lead
+    await waitForLeadField(testEmail, "phone", "0499999999");
+  });
+
+  test("deleting a contact in HubSpot removes the local lead", async ({
+    context,
+    page,
+    baseURL,
+  }) => {
+    test.setTimeout(60_000); // Webhook latency
+
+    await context.addCookies([getSessionCookie(session.signedToken, baseURL!)]);
+
+    const uniqueId = Date.now().toString(36);
+    const testEmail = `e2e-${uniqueId}@test.rekurve.dev`;
+
+    // Step 1: Create a lead via the app
+    await page.goto("/leads/new");
+    const form = new LeadFormSection(page);
+    await form.fillStep1({
+      firstName: "Inbound",
+      lastName: `Delete ${uniqueId}`,
+      phone: "0412345678",
+      email: testEmail,
+    });
+    await form.clickNext();
+    await form.selectSegmented("Has land", "No");
+    await form.clickNext();
+    await form.selectSegmented("Property type", "First Home Buyer");
+    await form.clickNext();
+    await form.clickSubmit();
+    await form.expectSuccess(`Inbound Delete ${uniqueId}`);
+
+    // Step 2: Get the hubspotContactId
+    const hubspotId = await getLeadHubSpotId(testEmail);
+    expect(hubspotId).not.toBeNull();
+
+    // Step 3: Archive the contact in HubSpot
+    await archiveTestContact(hubspotId!);
+
+    // Step 4: Wait for the webhook to delete the local lead
+    await waitForLeadDeletion(testEmail);
+  });
+});

--- a/e2e/features/leads-crud.spec.ts
+++ b/e2e/features/leads-crud.spec.ts
@@ -3,9 +3,9 @@ import { LeadFormSection } from "../pages/sections/lead-form.section";
 import { QuickCaptureSection } from "../pages/sections/quick-capture.section";
 import {
   createTestSession,
-  deleteTestLeads,
   deleteTestSession,
   type TestSession,
+  uniquePhone,
 } from "../utils/auth-helper";
 import { getSessionCookie } from "../utils/session-cookie";
 
@@ -22,7 +22,9 @@ test.describe("Leads CRUD — E2E", () => {
   });
 
   test.afterAll(async () => {
-    await deleteTestLeads();
+    // Leads and HubSpot contacts created here are cleaned up by
+    // e2e/utils/global-teardown.ts after every worker has finished — doing it
+    // here would race with concurrent hubspot-sync tests in other workers.
     await deleteTestSession(session.userId);
   });
 
@@ -45,7 +47,7 @@ test.describe("Leads CRUD — E2E", () => {
     await form.fillStep1({
       firstName: "E2E",
       lastName: `Test ${uniqueId}`,
-      phone: "0412345678",
+      phone: uniquePhone(),
       email: `e2e-${uniqueId}@test.rekurve.dev`,
     });
     await form.selectSegmented("Preferred contact time", "Anytime");
@@ -135,7 +137,7 @@ test.describe("Leads CRUD — E2E", () => {
     await quickCapture.fill({
       firstName: "Quick",
       lastName: `Capture ${uniqueId}`,
-      phone: "0412345678",
+      phone: uniquePhone(),
       notes: "Met at BBQ",
     });
     await quickCapture.submit();

--- a/e2e/utils/auth-helper.ts
+++ b/e2e/utils/auth-helper.ts
@@ -71,6 +71,21 @@ export async function deleteTestSession(userId: string): Promise<void> {
 }
 
 /**
+ * Generate a unique AU mobile-format phone for an E2E test.
+ *
+ * `leads.create` dedups by email OR phone — and the leads table enforces a
+ * UNIQUE constraint on `hubspot_contact_id`. Tests that share a phone end up
+ * pointing at the same HubSpot contact ID, causing duplicate-key violations
+ * when they run in parallel. Each test must call this to get its own phone.
+ */
+export function uniquePhone(): string {
+  const suffix = Math.floor(Math.random() * 1e8)
+    .toString()
+    .padStart(8, "0");
+  return `04${suffix}`;
+}
+
+/**
  * Delete leads created by E2E tests, identified by test email patterns.
  */
 export async function deleteTestLeads(): Promise<void> {

--- a/e2e/utils/global-teardown.ts
+++ b/e2e/utils/global-teardown.ts
@@ -1,0 +1,29 @@
+import "dotenv/config";
+import { deleteTestLeads } from "./auth-helper";
+import { deleteTestContacts } from "./hubspot-helper";
+
+/**
+ * Runs once after every worker and project finishes. Sweeps up any HubSpot
+ * contacts and local leads created by e2e tests. Safe here (no race with
+ * in-flight tests) in a way per-spec afterAll hooks are not.
+ *
+ * Failures are logged but not rethrown — cleanup errors must not mask real
+ * test failures in CI output.
+ */
+export default async function globalTeardown() {
+  if (process.env.HUBSPOT_ACCESS_TOKEN) {
+    try {
+      await deleteTestContacts();
+    } catch (err) {
+      console.error("[e2e teardown] deleteTestContacts failed:", err);
+    }
+  }
+
+  if (process.env.DATABASE_URL) {
+    try {
+      await deleteTestLeads();
+    } catch (err) {
+      console.error("[e2e teardown] deleteTestLeads failed:", err);
+    }
+  }
+}

--- a/e2e/utils/hubspot-helper.ts
+++ b/e2e/utils/hubspot-helper.ts
@@ -1,5 +1,5 @@
 import { Client } from "@hubspot/api-client";
-import { FilterOperatorEnum } from "@hubspot/api-client/lib/codegen/crm/contacts/models/Filter";
+import { FilterOperatorEnum } from "@hubspot/api-client/lib/codegen/crm/contacts/models/Filter.js";
 import { type NeonQueryFunction, neon } from "@neondatabase/serverless";
 
 import "dotenv/config";
@@ -104,7 +104,14 @@ export async function archiveTestContact(hubspotId: string): Promise<void> {
   await hubspot().crm.contacts.basicApi.archive(hubspotId);
 }
 
-/** Delete all HubSpot contacts matching the E2E test email pattern. */
+/**
+ * Delete HubSpot contacts created by E2E tests. Catches two patterns:
+ *   - Full-form / inbound-sync tests: email containing `test.rekurve.dev`
+ *   - Quick-capture tests: firstname `Quick` + lastname containing `Capture`
+ *     (quick capture has no email field, so the email filter can't find them)
+ *
+ * `filterGroups` are OR'd, filters within a group are AND'd.
+ */
 export async function deleteTestContacts(): Promise<void> {
   const response = await hubspot().crm.contacts.searchApi.doSearch({
     filterGroups: [
@@ -114,6 +121,20 @@ export async function deleteTestContacts(): Promise<void> {
             propertyName: "email",
             operator: FilterOperatorEnum.ContainsToken,
             value: "test.rekurve.dev",
+          },
+        ],
+      },
+      {
+        filters: [
+          {
+            propertyName: "firstname",
+            operator: FilterOperatorEnum.Eq,
+            value: "Quick",
+          },
+          {
+            propertyName: "lastname",
+            operator: FilterOperatorEnum.ContainsToken,
+            value: "Capture",
           },
         ],
       },

--- a/e2e/utils/hubspot-helper.ts
+++ b/e2e/utils/hubspot-helper.ts
@@ -1,0 +1,188 @@
+import { Client } from "@hubspot/api-client";
+import { FilterOperatorEnum } from "@hubspot/api-client/lib/codegen/crm/contacts/models/Filter";
+import { type NeonQueryFunction, neon } from "@neondatabase/serverless";
+
+import "dotenv/config";
+
+// Lazy — only initialized when a function is called
+let _hubspot: Client | undefined;
+function hubspot() {
+  _hubspot ??= new Client({
+    accessToken: process.env.HUBSPOT_ACCESS_TOKEN!,
+    numberOfApiCallRetries: 3,
+  });
+  return _hubspot;
+}
+
+let _sql: NeonQueryFunction<false, false> | undefined;
+function sql() {
+  _sql ??= neon(process.env.DATABASE_URL!);
+  return _sql;
+}
+
+const ALL_PROPERTIES = [
+  "firstname",
+  "lastname",
+  "email",
+  "phone",
+  "has_land",
+  "land_registered",
+  "land_address",
+  "land_size_sqm",
+  "property_type",
+  "budget",
+  "seen_broker",
+  "construction_timeline",
+  "resolve_finance_opted_in",
+  "preferred_contact_time",
+  "land_width",
+  "land_depth",
+  "lead_score",
+  "lead_stage",
+  "notes",
+  "lead_source",
+];
+
+export interface TestContact {
+  id: string;
+  properties: Record<string, string | null>;
+}
+
+/** Search for a contact by email. Returns null if not found. */
+export async function findContactByEmail(
+  email: string,
+): Promise<TestContact | null> {
+  const response = await hubspot().crm.contacts.searchApi.doSearch({
+    filterGroups: [
+      {
+        filters: [
+          {
+            propertyName: "email",
+            operator: FilterOperatorEnum.Eq,
+            value: email,
+          },
+        ],
+      },
+    ],
+    properties: ALL_PROPERTIES,
+    limit: 1,
+    after: "0",
+    sorts: [],
+  });
+  if (response.results.length === 0) return null;
+  const c = response.results[0]!;
+  return {
+    id: c.id,
+    properties: c.properties as Record<string, string | null>,
+  };
+}
+
+/** Create a contact in HubSpot for test seeding. */
+export async function createTestContact(
+  properties: Record<string, string>,
+): Promise<TestContact> {
+  const response = await hubspot().crm.contacts.basicApi.create({
+    properties,
+    associations: [],
+  });
+  return {
+    id: response.id,
+    properties: response.properties as Record<string, string | null>,
+  };
+}
+
+/** Update a contact's property in HubSpot. */
+export async function updateTestContact(
+  hubspotId: string,
+  properties: Record<string, string>,
+): Promise<void> {
+  await hubspot().crm.contacts.basicApi.update(hubspotId, { properties });
+}
+
+/** Archive (soft-delete) a contact in HubSpot. */
+export async function archiveTestContact(hubspotId: string): Promise<void> {
+  await hubspot().crm.contacts.basicApi.archive(hubspotId);
+}
+
+/** Delete all HubSpot contacts matching the E2E test email pattern. */
+export async function deleteTestContacts(): Promise<void> {
+  const response = await hubspot().crm.contacts.searchApi.doSearch({
+    filterGroups: [
+      {
+        filters: [
+          {
+            propertyName: "email",
+            operator: FilterOperatorEnum.ContainsToken,
+            value: "test.rekurve.dev",
+          },
+        ],
+      },
+    ],
+    properties: ["email"],
+    limit: 100,
+    after: "0",
+    sorts: [],
+  });
+
+  for (const contact of response.results) {
+    try {
+      await hubspot().crm.contacts.basicApi.archive(contact.id);
+    } catch {
+      // Already deleted — ignore
+    }
+  }
+}
+
+/**
+ * Poll the local DB until a lead matching the email has the expected value,
+ * or until the timeout expires. For verifying inbound webhook processing.
+ */
+export async function waitForLeadField(
+  email: string,
+  field: string,
+  expected: string,
+  timeoutMs = 30_000,
+): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    const rows = await sql()`
+      SELECT * FROM "leads" WHERE email = ${email} LIMIT 1
+    `;
+    if (rows.length > 0 && String(rows[0]![field]) === expected) {
+      return;
+    }
+    await new Promise((r) => setTimeout(r, 2_000));
+  }
+  throw new Error(
+    `Timed out waiting for leads.${field} = "${expected}" (email: ${email})`,
+  );
+}
+
+/**
+ * Poll the local DB until a lead matching the email no longer exists.
+ * For verifying inbound webhook deletion.
+ */
+export async function waitForLeadDeletion(
+  email: string,
+  timeoutMs = 30_000,
+): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    const rows = await sql()`
+      SELECT id FROM "leads" WHERE email = ${email} LIMIT 1
+    `;
+    if (rows.length === 0) return;
+    await new Promise((r) => setTimeout(r, 2_000));
+  }
+  throw new Error(`Timed out waiting for lead deletion (email: ${email})`);
+}
+
+/** Read the hubspot_contact_id for a lead from the local DB. */
+export async function getLeadHubSpotId(email: string): Promise<string | null> {
+  const rows = await sql()`
+    SELECT hubspot_contact_id FROM "leads" WHERE email = ${email} LIMIT 1
+  `;
+  return rows.length > 0
+    ? (rows[0]!.hubspot_contact_id as string | null)
+    : null;
+}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -5,12 +5,15 @@ const isCI = process.env.CI === "true";
 
 export default defineConfig({
   testDir: "./e2e",
-  timeout: 30_000,
+  globalTeardown: "./e2e/utils/global-teardown.ts",
+  timeout: 45_000,
   expect: { timeout: 5_000 },
   fullyParallel: true,
   forbidOnly: isCI,
   retries: isCI ? 2 : 0,
-  workers: isCI ? 1 : 6,
+  // 6 workers × 3 viewport projects overwhelms the local dev server (page.goto
+  // timeouts under load). 4 keeps parallelism while leaving headroom.
+  workers: isCI ? 1 : 4,
   reporter: isCI
     ? [["list"], ["html", { open: "never" }]]
     : [["html", { open: "on-failure" }]],
@@ -56,6 +59,9 @@ export default defineConfig({
     },
     {
       name: "tablet",
+      // HubSpot-mutating tests run on desktop only — they aren't viewport-specific
+      // and parallel HubSpot API load across 3 projects causes timeouts and DB cleanup races.
+      testIgnore: ["**/hubspot-sync.spec.ts"],
       use: {
         ...devices["Desktop Chrome"],
         viewport: { width: 768, height: 1024 },
@@ -63,6 +69,7 @@ export default defineConfig({
     },
     {
       name: "mobile",
+      testIgnore: ["**/hubspot-sync.spec.ts"],
       use: {
         ...devices["Desktop Chrome"],
         viewport: { width: 375, height: 667 },

--- a/rstest.config.ts
+++ b/rstest.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from "@rstest/core";
 
 export default defineConfig({
-  include: ["src/**/*.test.ts"],
+  include: ["src/**/*.test.ts", "scripts/**/*.test.ts"],
   testEnvironment: "node",
   restoreMocks: true,
   coverage: {

--- a/scripts/hubspot/__tests__/setup.test.ts
+++ b/scripts/hubspot/__tests__/setup.test.ts
@@ -1,0 +1,130 @@
+import { beforeEach, describe, expect, rs, test } from "@rstest/core";
+
+let mockGroupCreate: ReturnType<typeof rs.fn>;
+let mockPropertyCreate: ReturnType<typeof rs.fn>;
+
+beforeEach(() => {
+  rs.resetModules();
+
+  mockGroupCreate = rs.fn().mockResolvedValue({});
+  mockPropertyCreate = rs.fn().mockResolvedValue({});
+
+  rs.doMock("../client", () => ({
+    hubspot: {
+      crm: {
+        properties: {
+          groupsApi: { create: mockGroupCreate },
+          coreApi: { create: mockPropertyCreate },
+        },
+      },
+    },
+  }));
+});
+
+const EXPECTED_PROPERTY_NAMES = [
+  "preferred_contact_time",
+  "has_land",
+  "land_registered",
+  "land_address",
+  "land_size_sqm",
+  "land_width",
+  "land_depth",
+  "property_type",
+  "budget",
+  "seen_broker",
+  "construction_timeline",
+  "resolve_finance_opted_in",
+  "lead_score",
+  "lead_stage",
+  "notes",
+  "lead_source",
+];
+
+describe("ensureAllProperties", () => {
+  test("creates property group and all custom properties", async () => {
+    const { ensureAllProperties } = await import("../setup");
+    await ensureAllProperties();
+
+    expect(mockGroupCreate).toHaveBeenCalledTimes(1);
+    expect(mockGroupCreate).toHaveBeenCalledWith("contacts", {
+      name: "rekurve",
+      label: "Rekurve",
+    });
+
+    expect(mockPropertyCreate).toHaveBeenCalledTimes(
+      EXPECTED_PROPERTY_NAMES.length,
+    );
+    // Verify each property name was created
+    const names = mockPropertyCreate.mock.calls.map(
+      (call: unknown[]) => (call[1] as { name: string }).name,
+    );
+    expect(names).toEqual(EXPECTED_PROPERTY_NAMES);
+  });
+
+  test("swallows 409 conflicts for group", async () => {
+    mockGroupCreate.mockRejectedValue({ code: 409 });
+
+    const { ensureAllProperties } = await import("../setup");
+    await ensureAllProperties();
+
+    // Should not throw — continues to create properties
+    expect(mockPropertyCreate).toHaveBeenCalledTimes(
+      EXPECTED_PROPERTY_NAMES.length,
+    );
+  });
+
+  test("swallows 409 conflicts for properties", async () => {
+    mockPropertyCreate.mockRejectedValue({ code: 409 });
+
+    const { ensureAllProperties } = await import("../setup");
+    // Should not throw
+    await ensureAllProperties();
+  });
+
+  test("throws non-409 errors", async () => {
+    mockGroupCreate.mockRejectedValue({ code: 500, message: "Server error" });
+
+    const { ensureAllProperties } = await import("../setup");
+    await expect(ensureAllProperties()).rejects.toEqual(
+      expect.objectContaining({ code: 500 }),
+    );
+  });
+
+  test("creates enumeration properties with options", async () => {
+    const { ensureAllProperties } = await import("../setup");
+    await ensureAllProperties();
+
+    // lead_stage should have options
+    const leadStageCall = mockPropertyCreate.mock.calls.find(
+      (call: unknown[]) => (call[1] as { name: string }).name === "lead_stage",
+    );
+    expect(leadStageCall![1]).toEqual(
+      expect.objectContaining({
+        type: "enumeration",
+        fieldType: "select",
+        options: expect.arrayContaining([
+          expect.objectContaining({ value: "hot", label: "Hot" }),
+        ]),
+      }),
+    );
+  });
+
+  test("creates boolean properties as booleancheckbox with true/false options", async () => {
+    const { ensureAllProperties } = await import("../setup");
+    await ensureAllProperties();
+
+    const hasLandCall = mockPropertyCreate.mock.calls.find(
+      (call: unknown[]) => (call[1] as { name: string }).name === "has_land",
+    );
+    expect(hasLandCall![1]).toEqual(
+      expect.objectContaining({
+        type: "enumeration",
+        fieldType: "booleancheckbox",
+        options: expect.arrayContaining([
+          expect.objectContaining({ value: "true", label: "Yes" }),
+          expect.objectContaining({ value: "false", label: "No" }),
+        ]),
+      }),
+    );
+  });
+});

--- a/scripts/hubspot/client.ts
+++ b/scripts/hubspot/client.ts
@@ -1,0 +1,12 @@
+import { Client } from "@hubspot/api-client";
+
+/**
+ * Standalone HubSpot client for CLI setup scripts.
+ *
+ * Uses `process.env` directly (loaded via `dotenv/config`) instead of the app's
+ * `~/env` module, so scripts do not need to satisfy the full app env schema.
+ */
+export const hubspot = new Client({
+  accessToken: process.env.HUBSPOT_ACCESS_TOKEN!,
+  numberOfApiCallRetries: 3,
+});

--- a/scripts/hubspot/setup.ts
+++ b/scripts/hubspot/setup.ts
@@ -1,0 +1,230 @@
+import "dotenv/config";
+
+import {
+  PropertyCreateFieldTypeEnum,
+  PropertyCreateTypeEnum,
+} from "@hubspot/api-client/lib/codegen/crm/properties/models/PropertyCreate";
+import { hubspot } from "./client";
+
+interface PropertyDefinition {
+  name: string;
+  label: string;
+  type: PropertyCreateTypeEnum;
+  fieldType: PropertyCreateFieldTypeEnum;
+  description?: string;
+  options?: Array<{ label: string; value: string; displayOrder: number }>;
+}
+
+const GROUP_NAME = "rekurve";
+
+const BOOLEAN_OPTIONS = [
+  { label: "Yes", value: "true", displayOrder: 0 },
+  { label: "No", value: "false", displayOrder: 1 },
+];
+
+const CUSTOM_PROPERTIES: PropertyDefinition[] = [
+  {
+    name: "preferred_contact_time",
+    label: "Preferred Contact Time",
+    type: PropertyCreateTypeEnum.Enumeration,
+    fieldType: PropertyCreateFieldTypeEnum.Select,
+    options: [
+      { label: "Weekdays", value: "weekdays", displayOrder: 0 },
+      { label: "Weekends", value: "weekends", displayOrder: 1 },
+      { label: "Anytime", value: "anytime", displayOrder: 2 },
+    ],
+  },
+  {
+    name: "has_land",
+    label: "Has Land",
+    type: PropertyCreateTypeEnum.Enumeration,
+    fieldType: PropertyCreateFieldTypeEnum.Booleancheckbox,
+    options: BOOLEAN_OPTIONS,
+  },
+  {
+    name: "land_registered",
+    label: "Land Registered",
+    type: PropertyCreateTypeEnum.Enumeration,
+    fieldType: PropertyCreateFieldTypeEnum.Booleancheckbox,
+    options: BOOLEAN_OPTIONS,
+  },
+  {
+    name: "land_address",
+    label: "Land Address",
+    type: PropertyCreateTypeEnum.String,
+    fieldType: PropertyCreateFieldTypeEnum.Text,
+  },
+  {
+    name: "land_size_sqm",
+    label: "Land Size (sqm)",
+    type: PropertyCreateTypeEnum.Number,
+    fieldType: PropertyCreateFieldTypeEnum.Number,
+  },
+  {
+    name: "land_width",
+    label: "Land Width (m)",
+    type: PropertyCreateTypeEnum.String,
+    fieldType: PropertyCreateFieldTypeEnum.Text,
+  },
+  {
+    name: "land_depth",
+    label: "Land Depth (m)",
+    type: PropertyCreateTypeEnum.String,
+    fieldType: PropertyCreateFieldTypeEnum.Text,
+  },
+  {
+    name: "property_type",
+    label: "Property Type",
+    type: PropertyCreateTypeEnum.Enumeration,
+    fieldType: PropertyCreateFieldTypeEnum.Select,
+    options: [
+      { label: "Single Storey", value: "single_storey", displayOrder: 0 },
+      { label: "Double Storey", value: "double_storey", displayOrder: 1 },
+      { label: "Investment", value: "investment", displayOrder: 2 },
+      { label: "Upsize", value: "upsize", displayOrder: 3 },
+      { label: "Downsize", value: "downsize", displayOrder: 4 },
+      {
+        label: "First Home Buyer",
+        value: "first_home_buyer",
+        displayOrder: 5,
+      },
+    ],
+  },
+  {
+    name: "budget",
+    label: "Budget",
+    type: PropertyCreateTypeEnum.String,
+    fieldType: PropertyCreateFieldTypeEnum.Text,
+  },
+  {
+    name: "seen_broker",
+    label: "Seen Broker",
+    type: PropertyCreateTypeEnum.Enumeration,
+    fieldType: PropertyCreateFieldTypeEnum.Booleancheckbox,
+    options: BOOLEAN_OPTIONS,
+  },
+  {
+    name: "construction_timeline",
+    label: "Construction Timeline",
+    type: PropertyCreateTypeEnum.Enumeration,
+    fieldType: PropertyCreateFieldTypeEnum.Select,
+    options: [
+      { label: "Ready Now", value: "ready_now", displayOrder: 0 },
+      { label: "3-6 Months", value: "3_6_months", displayOrder: 1 },
+      { label: "12+ Months", value: "12_months_plus", displayOrder: 2 },
+    ],
+  },
+  {
+    name: "resolve_finance_opted_in",
+    label: "Resolve Finance Opted In",
+    type: PropertyCreateTypeEnum.Enumeration,
+    fieldType: PropertyCreateFieldTypeEnum.Booleancheckbox,
+    options: BOOLEAN_OPTIONS,
+  },
+  {
+    name: "lead_score",
+    label: "Rekurve Lead Score",
+    type: PropertyCreateTypeEnum.Number,
+    fieldType: PropertyCreateFieldTypeEnum.Number,
+  },
+  {
+    name: "lead_stage",
+    label: "Rekurve Lead Stage",
+    type: PropertyCreateTypeEnum.Enumeration,
+    fieldType: PropertyCreateFieldTypeEnum.Select,
+    options: [
+      { label: "Unqualified", value: "unqualified", displayOrder: 0 },
+      { label: "Nurture", value: "nurture", displayOrder: 1 },
+      { label: "Warm", value: "warm", displayOrder: 2 },
+      { label: "Hot", value: "hot", displayOrder: 3 },
+    ],
+  },
+  {
+    name: "notes",
+    label: "Rekurve Notes",
+    type: PropertyCreateTypeEnum.String,
+    fieldType: PropertyCreateFieldTypeEnum.Textarea,
+  },
+  {
+    name: "lead_source",
+    label: "Rekurve Lead Source",
+    type: PropertyCreateTypeEnum.Enumeration,
+    fieldType: PropertyCreateFieldTypeEnum.Select,
+    options: [
+      { label: "Walk-in", value: "walk_in", displayOrder: 0 },
+      { label: "Referral", value: "referral", displayOrder: 1 },
+      { label: "Social", value: "social", displayOrder: 2 },
+      { label: "Web", value: "web", displayOrder: 3 },
+      { label: "Other", value: "other", displayOrder: 4 },
+    ],
+  },
+];
+
+async function ensurePropertyGroup(): Promise<void> {
+  try {
+    await hubspot.crm.properties.groupsApi.create("contacts", {
+      name: GROUP_NAME,
+      label: "Rekurve",
+    });
+    console.log(`[HubSpot Setup] Created property group: ${GROUP_NAME}`);
+  } catch (err: unknown) {
+    if (isConflict(err)) {
+      console.log(
+        `[HubSpot Setup] Property group already exists: ${GROUP_NAME}`,
+      );
+      return;
+    }
+    throw err;
+  }
+}
+
+async function ensureProperty(def: PropertyDefinition): Promise<void> {
+  try {
+    await hubspot.crm.properties.coreApi.create("contacts", {
+      name: def.name,
+      label: def.label,
+      type: def.type,
+      fieldType: def.fieldType,
+      groupName: GROUP_NAME,
+      ...(def.description && { description: def.description }),
+      ...(def.options && {
+        options: def.options.map((o) => ({ ...o, hidden: false })),
+      }),
+    });
+    console.log(`[HubSpot Setup] Created property: ${def.name}`);
+  } catch (err: unknown) {
+    if (isConflict(err)) {
+      console.log(`[HubSpot Setup] Property already exists: ${def.name}`);
+      return;
+    }
+    throw err;
+  }
+}
+
+function isConflict(err: unknown): boolean {
+  return (
+    typeof err === "object" &&
+    err !== null &&
+    "code" in err &&
+    (err as { code: number }).code === 409
+  );
+}
+
+/** Provision the Rekurve property group and all custom properties. Idempotent. */
+export async function ensureAllProperties(): Promise<void> {
+  await ensurePropertyGroup();
+  for (const def of CUSTOM_PROPERTIES) {
+    await ensureProperty(def);
+  }
+  console.log("[HubSpot Setup] All properties ensured.");
+}
+
+// Allow running as a standalone script: yarn tsx scripts/hubspot/setup.ts
+if (typeof process !== "undefined" && process.argv[1]?.endsWith("setup.ts")) {
+  ensureAllProperties()
+    .then(() => process.exit(0))
+    .catch((err) => {
+      console.error("[HubSpot Setup] Failed:", err);
+      process.exit(1);
+    });
+}

--- a/src/app/api/hubspot/webhook/__tests__/route.test.ts
+++ b/src/app/api/hubspot/webhook/__tests__/route.test.ts
@@ -1,6 +1,10 @@
 import { beforeEach, describe, expect, rs, test } from "@rstest/core";
 
 let mockIsValid: ReturnType<typeof rs.fn>;
+let mockGetContact: ReturnType<typeof rs.fn>;
+let mockInsert: ReturnType<typeof rs.fn>;
+let mockUpdate: ReturnType<typeof rs.fn>;
+let mockDbDelete: ReturnType<typeof rs.fn>;
 
 beforeEach(() => {
   rs.resetModules();
@@ -15,6 +19,49 @@ beforeEach(() => {
 
   rs.doMock("@hubspot/api-client", () => ({
     Signature: { isValid: mockIsValid },
+  }));
+
+  mockGetContact = rs.fn();
+  rs.doMock("~/server/hubspot", () => ({
+    getContact: mockGetContact,
+    toAppField: rs.fn((prop: string) => {
+      const map: Record<string, string> = {
+        firstname: "firstName",
+        lastname: "lastName",
+        email: "email",
+        phone: "phone",
+        lead_score: "leadScore",
+      };
+      return map[prop];
+    }),
+    coerceFromHubSpot: rs.fn((field: string, value: string) => {
+      if (field === "leadScore") return parseInt(value, 10);
+      return value;
+    }),
+  }));
+
+  // Mock db with chainable methods
+  const onConflictDoUpdate = rs.fn().mockResolvedValue(undefined);
+  const insertValues = rs.fn().mockReturnValue({ onConflictDoUpdate });
+  mockInsert = rs.fn().mockReturnValue({ values: insertValues });
+
+  const updateWhere = rs.fn().mockResolvedValue(undefined);
+  const updateSet = rs.fn().mockReturnValue({ where: updateWhere });
+  mockUpdate = rs.fn().mockReturnValue({ set: updateSet });
+
+  const deleteWhere = rs.fn().mockResolvedValue(undefined);
+  mockDbDelete = rs.fn().mockReturnValue({ where: deleteWhere });
+
+  rs.doMock("~/server/db", () => ({
+    db: {
+      insert: mockInsert,
+      update: mockUpdate,
+      delete: mockDbDelete,
+    },
+  }));
+
+  rs.doMock("~/server/db/schema", () => ({
+    leads: { hubspotContactId: "hubspot_contact_id" },
   }));
 });
 
@@ -69,10 +116,159 @@ describe("POST /api/hubspot/webhook", () => {
 
   test("returns 200 when signature is valid", async () => {
     mockIsValid.mockReturnValue(true);
+    mockGetContact.mockResolvedValue({
+      id: "1",
+      properties: { firstName: "Test", lastName: "User" },
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+    });
     const { POST } = await import("../route");
     const response = await POST(makeRequest({}));
     expect(response.status).toBe(200);
     const json = await response.json();
     expect(json).toEqual({ received: true });
+  });
+});
+
+describe("Webhook event processing", () => {
+  test("contact.creation fetches contact and upserts local lead", async () => {
+    mockIsValid.mockReturnValue(true);
+    mockGetContact.mockResolvedValue({
+      id: "456",
+      properties: {
+        firstName: "Jane",
+        lastName: "Doe",
+        email: "jane@example.com",
+      },
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+    });
+
+    const { POST } = await import("../route");
+    const response = await POST(
+      makeRequest({
+        body: JSON.stringify([
+          {
+            subscriptionType: "contact.creation",
+            objectId: 456,
+            eventId: 1,
+            occurredAt: Date.now(),
+            attemptNumber: 0,
+          },
+        ]),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockGetContact).toHaveBeenCalledWith("456");
+    expect(mockInsert).toHaveBeenCalled();
+  });
+
+  test("contact.propertyChange updates mapped field on local lead", async () => {
+    mockIsValid.mockReturnValue(true);
+
+    const { POST } = await import("../route");
+    const response = await POST(
+      makeRequest({
+        body: JSON.stringify([
+          {
+            subscriptionType: "contact.propertyChange",
+            objectId: 456,
+            propertyName: "email",
+            propertyValue: "new@example.com",
+            eventId: 2,
+            occurredAt: Date.now(),
+            attemptNumber: 0,
+          },
+        ]),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockUpdate).toHaveBeenCalled();
+  });
+
+  test("contact.propertyChange ignores unmapped properties", async () => {
+    mockIsValid.mockReturnValue(true);
+
+    const { POST } = await import("../route");
+    const response = await POST(
+      makeRequest({
+        body: JSON.stringify([
+          {
+            subscriptionType: "contact.propertyChange",
+            objectId: 456,
+            propertyName: "hs_analytics_source",
+            propertyValue: "ORGANIC_SEARCH",
+            eventId: 3,
+            occurredAt: Date.now(),
+            attemptNumber: 0,
+          },
+        ]),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+
+  test("contact.deletion deletes local lead", async () => {
+    mockIsValid.mockReturnValue(true);
+
+    const { POST } = await import("../route");
+    const response = await POST(
+      makeRequest({
+        body: JSON.stringify([
+          {
+            subscriptionType: "contact.deletion",
+            objectId: 456,
+            eventId: 4,
+            occurredAt: Date.now(),
+            attemptNumber: 0,
+          },
+        ]),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockDbDelete).toHaveBeenCalled();
+  });
+
+  test("processing failure for one event does not block others", async () => {
+    mockIsValid.mockReturnValue(true);
+    mockGetContact
+      .mockRejectedValueOnce(new Error("HubSpot API down"))
+      .mockResolvedValueOnce({
+        id: "789",
+        properties: { firstName: "Ok", lastName: "Lead" },
+        createdAt: "2026-01-01T00:00:00.000Z",
+        updatedAt: "2026-01-01T00:00:00.000Z",
+      });
+
+    const { POST } = await import("../route");
+    const response = await POST(
+      makeRequest({
+        body: JSON.stringify([
+          {
+            subscriptionType: "contact.creation",
+            objectId: 456,
+            eventId: 5,
+            occurredAt: Date.now(),
+            attemptNumber: 0,
+          },
+          {
+            subscriptionType: "contact.creation",
+            objectId: 789,
+            eventId: 6,
+            occurredAt: Date.now(),
+            attemptNumber: 0,
+          },
+        ]),
+      }),
+    );
+
+    // Should return 200 even though first event failed
+    expect(response.status).toBe(200);
+    expect(mockGetContact).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/app/api/hubspot/webhook/route.ts
+++ b/src/app/api/hubspot/webhook/route.ts
@@ -1,6 +1,20 @@
 import { Signature } from "@hubspot/api-client";
+import { eq } from "drizzle-orm";
 import { NextResponse } from "next/server";
 import { env } from "~/env";
+import { db } from "~/server/db";
+import { leads } from "~/server/db/schema";
+import { coerceFromHubSpot, getContact, toAppField } from "~/server/hubspot";
+
+interface WebhookEvent {
+  subscriptionType: string;
+  objectId: number;
+  propertyName?: string;
+  propertyValue?: string;
+  eventId: number;
+  occurredAt: number;
+  attemptNumber: number;
+}
 
 export async function POST(request: Request) {
   const signature = request.headers.get("x-hubspot-signature-v3");
@@ -35,16 +49,92 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: "Invalid signature" }, { status: 401 });
   }
 
-  // Log the event — actual processing deferred to Epic 2+
-  const events = JSON.parse(body) as Array<{
-    subscriptionType: string;
-    objectId: number;
-    propertyName?: string;
-  }>;
-  console.log(
-    `[HubSpot Webhook] Received ${events.length} event(s):`,
-    events.map((e) => e.subscriptionType),
-  );
+  const events = JSON.parse(body) as WebhookEvent[];
+
+  for (const event of events) {
+    try {
+      await processEvent(event);
+    } catch (error) {
+      // Log and continue — return 200 to prevent HubSpot retry storm
+      console.error(
+        `[HubSpot Webhook] Failed to process ${event.subscriptionType} for objectId ${event.objectId}:`,
+        error,
+      );
+    }
+  }
 
   return NextResponse.json({ received: true });
+}
+
+async function processEvent(event: WebhookEvent): Promise<void> {
+  const hubspotId = String(event.objectId);
+
+  switch (event.subscriptionType) {
+    case "contact.creation":
+      return handleContactCreation(hubspotId);
+    case "contact.propertyChange":
+      return handlePropertyChange(
+        hubspotId,
+        event.propertyName!,
+        event.propertyValue!,
+      );
+    case "contact.deletion":
+      return handleContactDeletion(hubspotId);
+    default:
+      console.log(
+        `[HubSpot Webhook] Ignoring unhandled event: ${event.subscriptionType}`,
+      );
+  }
+}
+
+async function handleContactCreation(hubspotId: string): Promise<void> {
+  // Fetch full contact from HubSpot (creation events don't include properties)
+  const contact = await getContact(hubspotId);
+
+  // Build local record from HubSpot properties
+  const record: Record<string, unknown> = {
+    hubspotContactId: hubspotId,
+    firstName: contact.properties.firstName ?? "Unknown",
+    lastName: contact.properties.lastName ?? "Unknown",
+    updatedAt: new Date(),
+  };
+
+  // Map all available properties with type coercion
+  for (const [field, value] of Object.entries(contact.properties)) {
+    if (value != null && field !== "firstName" && field !== "lastName") {
+      record[field] = coerceFromHubSpot(
+        field as Parameters<typeof coerceFromHubSpot>[0],
+        value,
+      );
+    }
+  }
+
+  // Upsert: insert or update if hubspotContactId already exists
+  await db
+    .insert(leads)
+    .values(record as typeof leads.$inferInsert)
+    .onConflictDoUpdate({
+      target: leads.hubspotContactId,
+      set: record as Partial<typeof leads.$inferInsert>,
+    });
+}
+
+async function handlePropertyChange(
+  hubspotId: string,
+  propertyName: string,
+  propertyValue: string,
+): Promise<void> {
+  const appField = toAppField(propertyName);
+  if (!appField) return; // Not a mapped property — ignore
+
+  const coerced = coerceFromHubSpot(appField, propertyValue);
+
+  await db
+    .update(leads)
+    .set({ [appField]: coerced, updatedAt: new Date() })
+    .where(eq(leads.hubspotContactId, hubspotId));
+}
+
+async function handleContactDeletion(hubspotId: string): Promise<void> {
+  await db.delete(leads).where(eq(leads.hubspotContactId, hubspotId));
 }

--- a/src/server/api/__tests__/leads-router.test.ts
+++ b/src/server/api/__tests__/leads-router.test.ts
@@ -89,8 +89,42 @@ beforeEach(() => {
     }),
   }));
 
-  rs.doMock("~/server/hubspot/contacts", () => ({
-    updateContact: rs.fn().mockResolvedValue({}),
+  rs.doMock("~/server/hubspot", () => ({
+    findExistingContact: rs.fn().mockResolvedValue(null),
+    createContact: rs.fn().mockResolvedValue({
+      id: "hs-123",
+      properties: {},
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+    }),
+    updateContact: rs.fn().mockResolvedValue({
+      id: "hs-123",
+      properties: {},
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+    }),
+    PROPERTY_MAP: {
+      firstName: "firstname",
+      lastName: "lastname",
+      email: "email",
+      phone: "phone",
+      hasLand: "has_land",
+      landRegistered: "land_registered",
+      landAddress: "land_address",
+      landSizeSqm: "land_size_sqm",
+      propertyType: "property_type",
+      budget: "budget",
+      seenBroker: "seen_broker",
+      constructionTimeline: "construction_timeline",
+      resolveFinanceOptedIn: "resolve_finance_opted_in",
+      preferredContactTime: "preferred_contact_time",
+      landWidth: "land_width",
+      landDepth: "land_depth",
+      leadScore: "lead_score",
+      leadStage: "lead_stage",
+      notes: "notes",
+      leadSource: "lead_source",
+    },
   }));
 });
 
@@ -152,6 +186,77 @@ describe("leads.create", () => {
     } catch (e) {
       expect(e).toBeInstanceOf(TRPCError);
       expect((e as TRPCError).code).toBe("BAD_REQUEST");
+    }
+  });
+});
+
+// --- leads.create — HubSpot sync ---
+
+describe("leads.create — HubSpot sync", () => {
+  test("creates HubSpot contact when no dedup match", async () => {
+    const leadWithHs = { ...mockLead, hubspotContactId: "hs-123" };
+    const returning = rs.fn().mockResolvedValue([leadWithHs]);
+    const values = rs.fn().mockReturnValue({ returning });
+    (mockDb.insert as ReturnType<typeof rs.fn>).mockReturnValue({ values });
+
+    const { createContact } = await import("~/server/hubspot");
+
+    const caller = await getCaller();
+    await caller.leads.create({
+      firstName: "John",
+      lastName: "Smith",
+      email: "john@example.com",
+    });
+
+    expect(createContact).toHaveBeenCalled();
+  });
+
+  test("updates existing HubSpot contact when dedup match found", async () => {
+    const { findExistingContact, updateContact } = await import(
+      "~/server/hubspot"
+    );
+    (findExistingContact as ReturnType<typeof rs.fn>).mockResolvedValue({
+      id: "hs-existing",
+      properties: {},
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+    });
+
+    const leadWithHs = { ...mockLead, hubspotContactId: "hs-existing" };
+    const returning = rs.fn().mockResolvedValue([leadWithHs]);
+    const values = rs.fn().mockReturnValue({ returning });
+    (mockDb.insert as ReturnType<typeof rs.fn>).mockReturnValue({ values });
+
+    const caller = await getCaller();
+    await caller.leads.create({
+      firstName: "John",
+      lastName: "Smith",
+      email: "john@example.com",
+    });
+
+    expect(updateContact).toHaveBeenCalledWith(
+      "hs-existing",
+      expect.objectContaining({ firstName: "John" }),
+    );
+  });
+
+  test("throws INTERNAL_SERVER_ERROR on DB failure after HubSpot success", async () => {
+    const returning = rs.fn().mockRejectedValue(new Error("DB down"));
+    const values = rs.fn().mockReturnValue({ returning });
+    (mockDb.insert as ReturnType<typeof rs.fn>).mockReturnValue({ values });
+
+    const caller = await getCaller();
+
+    try {
+      await caller.leads.create({
+        firstName: "John",
+        lastName: "Smith",
+      });
+      expect.unreachable("Should have thrown");
+    } catch (e) {
+      expect(e).toBeInstanceOf(TRPCError);
+      expect((e as TRPCError).code).toBe("INTERNAL_SERVER_ERROR");
+      expect((e as TRPCError).message).toContain("hs-123");
     }
   });
 });
@@ -265,6 +370,10 @@ describe("leads.list", () => {
 
 describe("leads.update", () => {
   test("updates a lead with partial fields", async () => {
+    (
+      mockDb.query as { leads: { findFirst: ReturnType<typeof rs.fn> } }
+    ).leads.findFirst.mockResolvedValue({ hubspotContactId: null });
+
     const updatedLead = { ...mockLead, budget: "$700K" };
     const returning = rs.fn().mockResolvedValue([updatedLead]);
     const where = rs.fn().mockReturnValue({ returning });
@@ -281,10 +390,9 @@ describe("leads.update", () => {
   });
 
   test("throws NOT_FOUND when lead does not exist", async () => {
-    const returning = rs.fn().mockResolvedValue([]);
-    const where = rs.fn().mockReturnValue({ returning });
-    const set = rs.fn().mockReturnValue({ where });
-    (mockDb.update as ReturnType<typeof rs.fn>).mockReturnValue({ set });
+    (
+      mockDb.query as { leads: { findFirst: ReturnType<typeof rs.fn> } }
+    ).leads.findFirst.mockResolvedValue(undefined);
 
     const caller = await getCaller();
 
@@ -310,6 +418,51 @@ describe("leads.update", () => {
       expect(e).toBeInstanceOf(TRPCError);
       expect((e as TRPCError).code).toBe("BAD_REQUEST");
     }
+  });
+});
+
+// --- leads.update — HubSpot sync ---
+
+describe("leads.update — HubSpot sync", () => {
+  test("updates HubSpot before local DB when linked", async () => {
+    (
+      mockDb.query as { leads: { findFirst: ReturnType<typeof rs.fn> } }
+    ).leads.findFirst.mockResolvedValue({ hubspotContactId: "hs-123" });
+
+    const updatedLead = { ...mockLead, budget: "$700K" };
+    const returning = rs.fn().mockResolvedValue([updatedLead]);
+    const where = rs.fn().mockReturnValue({ returning });
+    const set = rs.fn().mockReturnValue({ where });
+    (mockDb.update as ReturnType<typeof rs.fn>).mockReturnValue({ set });
+
+    const { updateContact } = await import("~/server/hubspot");
+
+    const caller = await getCaller();
+    await caller.leads.update({ id: mockLead.id, budget: "$700K" });
+
+    expect(updateContact).toHaveBeenCalledWith(
+      "hs-123",
+      expect.objectContaining({ budget: "$700K" }),
+    );
+  });
+
+  test("skips HubSpot when lead has no hubspotContactId", async () => {
+    (
+      mockDb.query as { leads: { findFirst: ReturnType<typeof rs.fn> } }
+    ).leads.findFirst.mockResolvedValue({ hubspotContactId: null });
+
+    const updatedLead = { ...mockLead, budget: "$700K" };
+    const returning = rs.fn().mockResolvedValue([updatedLead]);
+    const where = rs.fn().mockReturnValue({ returning });
+    const set = rs.fn().mockReturnValue({ where });
+    (mockDb.update as ReturnType<typeof rs.fn>).mockReturnValue({ set });
+
+    const { updateContact } = await import("~/server/hubspot");
+
+    const caller = await getCaller();
+    await caller.leads.update({ id: mockLead.id, budget: "$700K" });
+
+    expect(updateContact).not.toHaveBeenCalled();
   });
 });
 
@@ -398,6 +551,10 @@ describe("leads.create — scoring integration", () => {
 
 describe("leads.update — scoring integration", () => {
   test("triggers re-scoring when qualification fields change", async () => {
+    (
+      mockDb.query as { leads: { findFirst: ReturnType<typeof rs.fn> } }
+    ).leads.findFirst.mockResolvedValue({ hubspotContactId: null });
+
     const { qualifyAndScore } = await import("~/server/scoring");
     const updatedLead = { ...mockLead, budget: "$700K" };
     const returning = rs.fn().mockResolvedValue([updatedLead]);
@@ -414,6 +571,10 @@ describe("leads.update — scoring integration", () => {
   });
 
   test("does not re-score when only non-qualification fields change", async () => {
+    (
+      mockDb.query as { leads: { findFirst: ReturnType<typeof rs.fn> } }
+    ).leads.findFirst.mockResolvedValue({ hubspotContactId: null });
+
     const { qualifyAndScore } = await import("~/server/scoring");
     const updatedLead = { ...mockLead, referrerName: "Bob" };
     const returning = rs.fn().mockResolvedValue([updatedLead]);

--- a/src/server/api/routers/leads.ts
+++ b/src/server/api/routers/leads.ts
@@ -8,7 +8,12 @@ import {
 } from "~/server/api/schemas/leads";
 import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
 import { leads } from "~/server/db/schema";
-import { updateContact } from "~/server/hubspot/contacts";
+import {
+  createContact,
+  findExistingContact,
+  PROPERTY_MAP,
+  updateContact as updateHubSpotContact,
+} from "~/server/hubspot";
 import type { ScoreMetadata } from "~/server/scoring";
 import { qualifyAndScore } from "~/server/scoring";
 
@@ -38,7 +43,7 @@ async function scoreLeadAsync(
       .where(eq(leads.id, leadId));
 
     if (hubspotContactId) {
-      await updateContact(hubspotContactId, {
+      await updateHubSpotContact(hubspotContactId, {
         leadScore: String(result.score),
         leadStage: result.stage,
       }).catch((err) => {
@@ -70,19 +75,42 @@ export const leadsRouter = createTRPCRouter({
   create: protectedProcedure
     .input(leadCreateSchema)
     .mutation(async ({ ctx, input }) => {
-      const [lead] = await ctx.db
-        .insert(leads)
-        .values({
-          ...input,
-          leadStage: "unqualified",
-          leadScore: 0,
-        })
-        .returning();
+      // 1. Extract HubSpot-mapped fields from input
+      const hubspotData: Record<string, string | boolean | null> = {};
+      for (const key of Object.keys(input) as Array<keyof typeof input>) {
+        if (key in PROPERTY_MAP && input[key] != null) {
+          hubspotData[key] = input[key] as string | boolean | null;
+        }
+      }
 
-      // Fire-and-forget — don't block the response
-      void scoreLeadAsync(ctx.db, lead!.id, lead!, lead!.hubspotContactId);
+      // 2. Dedup: search HubSpot for existing contact by email/phone
+      const existing = await findExistingContact(input.email, input.phone);
+      const hubspotContact = existing
+        ? await updateHubSpotContact(existing.id, hubspotData)
+        : await createContact(hubspotData);
 
-      return lead!;
+      // 3. Write to local DB with hubspotContactId
+      try {
+        const [lead] = await ctx.db
+          .insert(leads)
+          .values({
+            ...input,
+            hubspotContactId: hubspotContact.id,
+            leadStage: "unqualified",
+            leadScore: 0,
+          })
+          .returning();
+
+        // Fire-and-forget — don't block the response
+        void scoreLeadAsync(ctx.db, lead!.id, lead!, lead!.hubspotContactId);
+
+        return lead!;
+      } catch {
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: `Lead saved to HubSpot (contact ID: ${hubspotContact.id}) but local save failed. Retry or check HubSpot.`,
+        });
+      }
     }),
 
   getById: protectedProcedure
@@ -157,6 +185,29 @@ export const leadsRouter = createTRPCRouter({
     .mutation(async ({ ctx, input }) => {
       const { id, ...data } = input;
 
+      // Fetch the lead to get its hubspotContactId
+      const existing = await ctx.db.query.leads.findFirst({
+        where: eq(leads.id, id),
+        columns: { hubspotContactId: true },
+      });
+      if (!existing) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Lead not found" });
+      }
+
+      // Write mapped fields to HubSpot first (if linked)
+      if (existing.hubspotContactId) {
+        const hubspotData: Record<string, string | boolean | null> = {};
+        for (const key of Object.keys(data) as Array<keyof typeof data>) {
+          if (key in PROPERTY_MAP && data[key] !== undefined) {
+            hubspotData[key] = data[key] as string | boolean | null;
+          }
+        }
+        if (Object.keys(hubspotData).length > 0) {
+          await updateHubSpotContact(existing.hubspotContactId, hubspotData);
+        }
+      }
+
+      // Update local DB
       const [updated] = await ctx.db
         .update(leads)
         .set({ ...data, updatedAt: new Date() })

--- a/src/server/api/routers/leads.ts
+++ b/src/server/api/routers/leads.ts
@@ -105,7 +105,14 @@ export const leadsRouter = createTRPCRouter({
         void scoreLeadAsync(ctx.db, lead!.id, lead!, lead!.hubspotContactId);
 
         return lead!;
-      } catch {
+      } catch (err) {
+        const cause = err instanceof Error ? err.cause : undefined;
+        console.error(
+          `[leads.create] local insert failed for HubSpot contact ${hubspotContact.id}:`,
+          err,
+          "cause:",
+          cause,
+        );
         throw new TRPCError({
           code: "INTERNAL_SERVER_ERROR",
           message: `Lead saved to HubSpot (contact ID: ${hubspotContact.id}) but local save failed. Retry or check HubSpot.`,

--- a/src/server/hubspot/__tests__/contacts.test.ts
+++ b/src/server/hubspot/__tests__/contacts.test.ts
@@ -113,3 +113,82 @@ describe("searchContacts", () => {
     expect(results[0]!.properties.email).toBe("jane@example.com");
   });
 });
+
+describe("findExistingContact", () => {
+  test("finds contact by email first", async () => {
+    mockDoSearch.mockResolvedValue({ results: [MOCK_RESPONSE] });
+
+    const { findExistingContact } = await import("../contacts");
+    const result = await findExistingContact("jane@example.com", "0400000000");
+
+    expect(result?.id).toBe("123");
+    expect(mockDoSearch).toHaveBeenCalledTimes(1);
+    expect(mockDoSearch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        filterGroups: [
+          {
+            filters: [
+              {
+                propertyName: "email",
+                operator: "EQ",
+                value: "jane@example.com",
+              },
+            ],
+          },
+        ],
+      }),
+    );
+  });
+
+  test("falls back to phone when no email match", async () => {
+    mockDoSearch
+      .mockResolvedValueOnce({ results: [] })
+      .mockResolvedValueOnce({ results: [MOCK_RESPONSE] });
+
+    const { findExistingContact } = await import("../contacts");
+    const result = await findExistingContact(
+      "nobody@example.com",
+      "0400000000",
+    );
+
+    expect(result?.id).toBe("123");
+    expect(mockDoSearch).toHaveBeenCalledTimes(2);
+  });
+
+  test("returns null when no match found", async () => {
+    mockDoSearch.mockResolvedValue({ results: [] });
+
+    const { findExistingContact } = await import("../contacts");
+    const result = await findExistingContact(
+      "nobody@example.com",
+      "0000000000",
+    );
+
+    expect(result).toBeNull();
+  });
+
+  test("skips email search when email is null", async () => {
+    mockDoSearch.mockResolvedValue({ results: [MOCK_RESPONSE] });
+
+    const { findExistingContact } = await import("../contacts");
+    const result = await findExistingContact(null, "0400000000");
+
+    expect(result?.id).toBe("123");
+    expect(mockDoSearch).toHaveBeenCalledTimes(1);
+    expect(mockDoSearch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        filterGroups: [
+          {
+            filters: [
+              {
+                propertyName: "phone",
+                operator: "EQ",
+                value: "0400000000",
+              },
+            ],
+          },
+        ],
+      }),
+    );
+  });
+});

--- a/src/server/hubspot/__tests__/properties.test.ts
+++ b/src/server/hubspot/__tests__/properties.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, test } from "@rstest/core";
 import {
+  coerceFromHubSpot,
   fromHubSpotProperties,
   PROPERTY_MAP,
+  toAppField,
   toHubSpotProperties,
 } from "../properties";
 
@@ -77,6 +79,10 @@ describe("leadScore and leadStage mapping", () => {
 });
 
 describe("PROPERTY_MAP", () => {
+  test("has 20 entries", () => {
+    expect(Object.keys(PROPERTY_MAP)).toHaveLength(20);
+  });
+
   test("round-trips all fields", () => {
     const input: Record<string, string> = {};
     for (const key of Object.keys(PROPERTY_MAP)) {
@@ -87,5 +93,35 @@ describe("PROPERTY_MAP", () => {
     expect(Object.keys(roundTripped).sort()).toEqual(
       Object.keys(PROPERTY_MAP).sort(),
     );
+  });
+});
+
+describe("toAppField", () => {
+  test("maps known HubSpot property to app field", () => {
+    expect(toAppField("lead_score")).toBe("leadScore");
+    expect(toAppField("preferred_contact_time")).toBe("preferredContactTime");
+  });
+
+  test("returns undefined for unknown property", () => {
+    expect(toAppField("hs_analytics_source")).toBeUndefined();
+  });
+});
+
+describe("coerceFromHubSpot", () => {
+  test("coerces boolean fields from string", () => {
+    expect(coerceFromHubSpot("hasLand", "true")).toBe(true);
+    expect(coerceFromHubSpot("hasLand", "false")).toBe(false);
+    expect(coerceFromHubSpot("seenBroker", "true")).toBe(true);
+    expect(coerceFromHubSpot("resolveFinanceOptedIn", "false")).toBe(false);
+  });
+
+  test("coerces integer fields from string", () => {
+    expect(coerceFromHubSpot("leadScore", "85")).toBe(85);
+    expect(coerceFromHubSpot("leadScore", "0")).toBe(0);
+  });
+
+  test("passes string fields through unchanged", () => {
+    expect(coerceFromHubSpot("firstName", "Jane")).toBe("Jane");
+    expect(coerceFromHubSpot("leadStage", "hot")).toBe("hot");
   });
 });

--- a/src/server/hubspot/contacts.ts
+++ b/src/server/hubspot/contacts.ts
@@ -1,3 +1,4 @@
+import { FilterOperatorEnum } from "@hubspot/api-client/lib/codegen/crm/contacts/models/Filter";
 import { hubspot } from "./client";
 import {
   ALL_PROPERTIES,
@@ -71,4 +72,38 @@ export async function searchContacts(query: string): Promise<HubSpotContact[]> {
     filterGroups: [],
   });
   return response.results.map(mapContact);
+}
+
+/** Search for an existing HubSpot contact by email or phone (for dedup on create). */
+export async function findExistingContact(
+  email?: string | null,
+  phone?: string | null,
+): Promise<HubSpotContact | null> {
+  if (email) {
+    const match = await findByFilter("email", email);
+    if (match) return match;
+  }
+  if (phone) {
+    const match = await findByFilter("phone", phone);
+    if (match) return match;
+  }
+  return null;
+}
+
+async function findByFilter(
+  propertyName: string,
+  value: string,
+): Promise<HubSpotContact | null> {
+  const response = await hubspot.crm.contacts.searchApi.doSearch({
+    filterGroups: [
+      {
+        filters: [{ propertyName, operator: FilterOperatorEnum.Eq, value }],
+      },
+    ],
+    properties: ALL_PROPERTIES,
+    limit: 1,
+    after: "0",
+    sorts: [],
+  });
+  return response.results.length > 0 ? mapContact(response.results[0]!) : null;
 }

--- a/src/server/hubspot/index.ts
+++ b/src/server/hubspot/index.ts
@@ -2,6 +2,7 @@ export { hubspot } from "./client";
 export {
   type ContactData,
   createContact,
+  findExistingContact,
   getContact,
   type HubSpotContact,
   searchContacts,
@@ -9,7 +10,9 @@ export {
 } from "./contacts";
 export {
   ALL_PROPERTIES,
+  coerceFromHubSpot,
   fromHubSpotProperties,
   PROPERTY_MAP,
+  toAppField,
   toHubSpotProperties,
 } from "./properties";

--- a/src/server/hubspot/properties.ts
+++ b/src/server/hubspot/properties.ts
@@ -17,8 +17,13 @@ export const PROPERTY_MAP = {
   seenBroker: "seen_broker",
   constructionTimeline: "construction_timeline",
   resolveFinanceOptedIn: "resolve_finance_opted_in",
+  preferredContactTime: "preferred_contact_time",
+  landWidth: "land_width",
+  landDepth: "land_depth",
   leadScore: "lead_score",
   leadStage: "lead_stage",
+  notes: "notes",
+  leadSource: "lead_source",
 } as const satisfies Record<string, string>;
 
 export type AppField = keyof typeof PROPERTY_MAP;
@@ -55,6 +60,30 @@ export function fromHubSpotProperties(
     }
   }
   return result;
+}
+
+/** Look up the app field name for a HubSpot property. Returns undefined if not mapped. */
+export function toAppField(hubspotProperty: string): AppField | undefined {
+  return REVERSE_MAP[hubspotProperty as HubSpotProperty];
+}
+
+const BOOLEAN_FIELDS: ReadonlySet<string> = new Set<AppField>([
+  "hasLand",
+  "landRegistered",
+  "seenBroker",
+  "resolveFinanceOptedIn",
+]);
+
+const INTEGER_FIELDS: ReadonlySet<string> = new Set<AppField>(["leadScore"]);
+
+/** Coerce a HubSpot string value to the app's expected type for a given field. */
+export function coerceFromHubSpot(
+  field: AppField,
+  value: string,
+): string | boolean | number {
+  if (BOOLEAN_FIELDS.has(field)) return value === "true";
+  if (INTEGER_FIELDS.has(field)) return parseInt(value, 10);
+  return value;
 }
 
 /** All HubSpot property names to request when fetching contacts. */

--- a/thoughts/guides/hubspot-manual-setup.md
+++ b/thoughts/guides/hubspot-manual-setup.md
@@ -1,0 +1,127 @@
+# HubSpot Manual Setup Guide
+
+One-time setup steps for the HubSpot integration. These must be completed
+before the contact sync features will work correctly.
+
+## Prerequisites
+
+- Admin access to the HubSpot account
+- The Rekurve app's HubSpot private app already created (Epic 1)
+- `HUBSPOT_ACCESS_TOKEN` and `HUBSPOT_CLIENT_SECRET` set in the environment
+- The private app must have the following scopes enabled (under
+  **Settings** -> **Integrations** -> **Private Apps** -> **Rekurve** -> **Scopes**):
+  - `crm.objects.contacts.read`
+  - `crm.objects.contacts.write`
+  - `crm.schemas.contacts.write` (required by `make hubspot_setup` to create
+    the Rekurve property group and custom properties)
+
+---
+
+## Step 1: Provision Custom Properties
+
+Run the automated setup script. This creates the "Rekurve" property group and
+all 7 custom contact properties. The script is idempotent -- safe to run
+multiple times.
+
+```bash
+make hubspot_setup
+```
+
+This provisions:
+
+| Property | Type | Options |
+|----------|------|---------|
+| `preferred_contact_time` | Dropdown select | weekdays, weekends, anytime |
+| `land_width` | Single-line text | -- |
+| `land_depth` | Single-line text | -- |
+| `lead_score` | Number | -- |
+| `lead_stage` | Dropdown select | unqualified, nurture, warm, hot |
+| `notes` | Multi-line text | -- |
+| `lead_source` | Dropdown select | walk_in, referral, social, web, other |
+
+### Verify Existing Properties
+
+The following custom properties should already exist from Epic 1. If any are
+missing, create them manually in the HubSpot UI under the **Rekurve** group:
+
+- `has_land` -- Dropdown select: `true` / `false`
+- `land_registered` -- Dropdown select: `true` / `false`
+- `land_address` -- Single-line text
+- `land_size_sqm` -- Single-line text
+- `property_type` -- Dropdown select: `single_storey`, `double_storey`, `investment`, `upsize`, `downsize`, `first_home_buyer`
+- `budget` -- Single-line text
+- `seen_broker` -- Dropdown select: `true` / `false`
+- `construction_timeline` -- Dropdown select: `ready_now`, `3_6_months`, `12_months_plus`
+- `resolve_finance_opted_in` -- Dropdown select: `true` / `false`
+
+---
+
+## Step 2: Configure Webhook Subscriptions
+
+1. Go to **Settings** -> **Integrations** -> **Private Apps**
+2. Select the Rekurve private app
+3. Go to the **Webhooks** tab
+4. Set the **Target URL** to: `https://<your-domain>/api/hubspot/webhook`
+
+### 2.1 Subscribe to Contact Creation
+
+1. Click **Create subscription**
+2. Object: **Contact**
+3. Event type: **Created**
+4. Click **Save**
+
+### 2.2 Subscribe to Contact Property Changes
+
+1. Click **Create subscription**
+2. Object: **Contact**
+3. Event type: **Property changed**
+4. Leave the property filter empty (subscribes to ALL property changes -- the
+   webhook handler filters to mapped properties server-side)
+5. Click **Save**
+
+### 2.3 Subscribe to Contact Deletion
+
+1. Click **Create subscription**
+2. Object: **Contact**
+3. Event type: **Deleted**
+4. Click **Save**
+
+### 2.4 Activate Subscriptions
+
+1. Ensure all three subscriptions show status **Active**
+2. If using a staging environment, verify the target URL is reachable from
+   the internet (HubSpot cannot reach localhost)
+
+---
+
+## Step 3: Verify the Integration
+
+### Outbound (App -> HubSpot)
+
+1. Create a new lead in the app with all fields filled
+2. Open HubSpot -> Contacts -> find the contact by name
+3. Verify all Rekurve properties are populated
+4. Check the lead record in the app has a `hubspotContactId`
+
+### Inbound (HubSpot -> App)
+
+1. Edit the contact's phone number directly in HubSpot
+2. Wait ~30 seconds for the webhook to fire
+3. Refresh the lead in the app -- phone number should be updated
+4. Delete the contact in HubSpot
+5. Verify the lead is removed from the app
+
+---
+
+## Troubleshooting
+
+- **Webhook not firing**: Check the subscription is Active, and the target URL
+  is publicly reachable. HubSpot shows delivery logs under the Webhooks tab.
+- **401 on webhook**: Verify `HUBSPOT_CLIENT_SECRET` matches the app's client
+  secret (not the access token).
+- **Properties not syncing**: Verify the internal names match exactly (case-
+  sensitive). Use the HubSpot API to check:
+  `GET /crm/v3/properties/contacts/<property_name>`
+- **Duplicate contacts**: The dedup check searches by email first, then phone.
+  If a contact has neither, a duplicate may be created. Add email or phone to
+  avoid this.

--- a/thoughts/plans/2026-04-08-102-hubspot-contact-sync.md
+++ b/thoughts/plans/2026-04-08-102-hubspot-contact-sync.md
@@ -1,0 +1,1104 @@
+# HubSpot Contact Sync on Lead Create/Update — Implementation Plan
+
+## Overview
+
+Wire HubSpot as the source of truth for contact data. The tRPC `create` and `update` procedures currently write directly to the local DB — this plan inserts HubSpot as the first write target and implements inbound webhook processing so contacts created or changed directly in HubSpot stay in sync with the local `leads` table.
+
+## Current State Analysis
+
+- **HubSpot client**: Singleton `@hubspot/api-client` instance with 3 retries (`src/server/hubspot/client.ts`)
+- **Property map**: 13 fields mapped bidirectionally (`src/server/hubspot/properties.ts:6-20`). Missing: `preferredContactTime`, `landWidth`, `landDepth`, `leadScore`, `leadStage`, `notes`, `leadSource`
+- **Contact CRUD**: `createContact`, `getContact`, `updateContact`, `searchContacts` exist (`src/server/hubspot/contacts.ts`) but are not called by any tRPC procedure
+- **Webhook handler**: Validates signatures, logs events, no processing (`src/app/api/hubspot/webhook/route.ts:38-47`)
+- **Leads router**: All 6 procedures write directly to DB with no HubSpot involvement (`src/server/api/routers/leads.ts`)
+- **DB schema**: `hubspotContactId` column exists on leads table (`src/server/db/schema/leads.ts:26`) but is never populated
+- **Existing tests**: Property tests at `src/server/hubspot/__tests__/properties.test.ts:64-77` already assert `leadScore`/`leadStage` mapping but the map entries don't exist yet — these tests are currently failing
+
+### Key Discoveries
+
+- The `searchContacts` function (`contacts.ts:64-74`) uses a text query with empty `filterGroups` — not suitable for exact email/phone dedup. A filter-based search is needed.
+- `fromHubSpotProperties` returns all values as strings — boolean and integer fields need type coercion before writing to the DB from webhooks.
+- `REVERSE_MAP` (`properties.ts:26-28`) is not exported. The webhook handler needs a way to map HubSpot property names back to app field names.
+- The webhook event payload is a JSON array. `contact.creation` events do NOT include property values — a separate `getContact` call is required. `contact.propertyChange` events DO include the new value in `propertyValue`.
+- No service layer exists — router procedures hit the DB directly. HubSpot calls will be added inline in the router, consistent with the existing pattern.
+
+## Desired End State
+
+After implementation:
+
+1. `leads.create` writes to HubSpot first (with email/phone dedup), stores `hubspotContactId`, then writes to local DB
+2. `leads.update` writes mapped fields to HubSpot first (if lead has `hubspotContactId`), then updates local DB
+3. Webhook handler processes `contact.creation`, `contact.propertyChange`, and `contact.deletion` events
+4. All 20 fields in the property map sync bidirectionally between HubSpot and the local DB
+5. Custom HubSpot properties exist in a "Rekurve" group for all non-standard fields
+
+### Verification
+
+- `make check` passes (lint + typecheck)
+- `make test` passes (all unit tests)
+- Creating a lead via the app produces a HubSpot contact with matching data
+- Editing a lead in HubSpot triggers a webhook that updates the local record
+- Deleting a contact in HubSpot removes the local lead
+
+## What We're NOT Doing
+
+- **Scheduled reconciliation** — deferred until data consistency becomes an issue
+- **`preferredEstates` / `preferredSuburbs` sync** — arrays with no HubSpot equivalent
+- **`referrerName` sync** — will use HubSpot associations post-MVP
+- **Programmatic custom property creation** — manual setup documented instead
+- **Webhook loop prevention via `changeSource`** — idempotent handlers make this unnecessary
+- **Retry queue for failed webhook processing** — log and move on for pilot; revisit if needed
+
+---
+
+## Phase 1: Extend Property Map
+
+### Overview
+
+Add 7 new fields to `PROPERTY_MAP` and export a `toAppField` helper so the webhook handler can map HubSpot property names back to app field names. Add a `coerceFromHubSpot` utility for type conversion on inbound data.
+
+### Changes Required
+
+#### 1. Property Map
+
+**File**: `src/server/hubspot/properties.ts`
+
+Add new entries to `PROPERTY_MAP` (after line 19):
+
+```typescript
+export const PROPERTY_MAP = {
+  firstName: "firstname",
+  lastName: "lastname",
+  email: "email",
+  phone: "phone",
+  hasLand: "has_land",
+  landRegistered: "land_registered",
+  landAddress: "land_address",
+  landSizeSqm: "land_size_sqm",
+  propertyType: "property_type",
+  budget: "budget",
+  seenBroker: "seen_broker",
+  constructionTimeline: "construction_timeline",
+  resolveFinanceOptedIn: "resolve_finance_opted_in",
+  // New fields
+  preferredContactTime: "preferred_contact_time",
+  landWidth: "land_width",
+  landDepth: "land_depth",
+  leadScore: "lead_score",
+  leadStage: "lead_stage",
+  notes: "notes",
+  leadSource: "lead_source",
+} as const satisfies Record<string, string>;
+```
+
+Add `toAppField` export (after `fromHubSpotProperties`):
+
+```typescript
+/** Look up the app field name for a HubSpot property. Returns undefined if not mapped. */
+export function toAppField(hubspotProperty: string): AppField | undefined {
+  return REVERSE_MAP[hubspotProperty as HubSpotProperty];
+}
+```
+
+Add `coerceFromHubSpot` for type conversion on inbound webhook/API data:
+
+```typescript
+const BOOLEAN_FIELDS: ReadonlySet<string> = new Set<AppField>([
+  "hasLand",
+  "landRegistered",
+  "seenBroker",
+  "resolveFinanceOptedIn",
+]);
+
+const INTEGER_FIELDS: ReadonlySet<string> = new Set<AppField>(["leadScore"]);
+
+/** Coerce a HubSpot string value to the app's expected type for a given field. */
+export function coerceFromHubSpot(
+  field: AppField,
+  value: string,
+): string | boolean | number {
+  if (BOOLEAN_FIELDS.has(field)) return value === "true";
+  if (INTEGER_FIELDS.has(field)) return parseInt(value, 10);
+  return value;
+}
+```
+
+#### 2. Barrel Export
+
+**File**: `src/server/hubspot/index.ts`
+
+Add `toAppField` and `coerceFromHubSpot` to the properties re-export.
+
+#### 3. Tests
+
+**File**: `src/server/hubspot/__tests__/properties.test.ts`
+
+The existing tests at lines 64-77 (`leadScore`/`leadStage` mapping) will now pass. Add tests for:
+
+- New fields round-trip through `toHubSpotProperties` / `fromHubSpotProperties`
+- `toAppField("lead_score")` returns `"leadScore"`, unknown returns `undefined`
+- `coerceFromHubSpot("hasLand", "true")` returns `true` (boolean)
+- `coerceFromHubSpot("hasLand", "false")` returns `false` (boolean)
+- `coerceFromHubSpot("leadScore", "85")` returns `85` (number)
+- `coerceFromHubSpot("firstName", "Jane")` returns `"Jane"` (string passthrough)
+
+```typescript
+describe("toAppField", () => {
+  test("maps known HubSpot property to app field", () => {
+    expect(toAppField("lead_score")).toBe("leadScore");
+    expect(toAppField("preferred_contact_time")).toBe("preferredContactTime");
+  });
+
+  test("returns undefined for unknown property", () => {
+    expect(toAppField("hs_analytics_source")).toBeUndefined();
+  });
+});
+
+describe("coerceFromHubSpot", () => {
+  test("coerces boolean fields from string", () => {
+    expect(coerceFromHubSpot("hasLand", "true")).toBe(true);
+    expect(coerceFromHubSpot("hasLand", "false")).toBe(false);
+    expect(coerceFromHubSpot("seenBroker", "true")).toBe(true);
+    expect(coerceFromHubSpot("resolveFinanceOptedIn", "false")).toBe(false);
+  });
+
+  test("coerces integer fields from string", () => {
+    expect(coerceFromHubSpot("leadScore", "85")).toBe(85);
+    expect(coerceFromHubSpot("leadScore", "0")).toBe(0);
+  });
+
+  test("passes string fields through unchanged", () => {
+    expect(coerceFromHubSpot("firstName", "Jane")).toBe("Jane");
+    expect(coerceFromHubSpot("leadStage", "hot")).toBe("hot");
+  });
+});
+```
+
+### Success Criteria
+
+#### Automated Verification
+- [x] Existing `leadScore`/`leadStage` property tests pass: `make test`
+- [x] New `toAppField` and `coerceFromHubSpot` tests pass
+- [x] `PROPERTY_MAP` has 20 entries (13 existing + 7 new)
+- [x] `make check` passes
+
+#### Manual Verification
+- [ ] None required — pure logic changes
+
+---
+
+## Phase 2: Wire HubSpot into Lead Create
+
+### Overview
+
+Add email/phone dedup search to the HubSpot contacts module. Modify `leads.create` to write to HubSpot first, store `hubspotContactId`, then write to local DB. Handle partial failures.
+
+### Changes Required
+
+#### 1. Dedup Search Function
+
+**File**: `src/server/hubspot/contacts.ts`
+
+Add `findExistingContact` that searches by email first, then phone:
+
+```typescript
+/** Search for an existing HubSpot contact by email or phone (for dedup on create). */
+export async function findExistingContact(
+  email?: string | null,
+  phone?: string | null,
+): Promise<HubSpotContact | null> {
+  if (email) {
+    const match = await findByFilter("email", email);
+    if (match) return match;
+  }
+  if (phone) {
+    const match = await findByFilter("phone", phone);
+    if (match) return match;
+  }
+  return null;
+}
+
+async function findByFilter(
+  propertyName: string,
+  value: string,
+): Promise<HubSpotContact | null> {
+  const response = await hubspot.crm.contacts.searchApi.doSearch({
+    filterGroups: [
+      {
+        filters: [{ propertyName, operator: "EQ", value }],
+      },
+    ],
+    properties: ALL_PROPERTIES,
+    limit: 1,
+    after: "0",
+    sorts: [],
+  });
+  return response.results.length > 0 ? mapContact(response.results[0]) : null;
+}
+```
+
+#### 2. Barrel Export
+
+**File**: `src/server/hubspot/index.ts`
+
+Add `findExistingContact` to the contacts re-export.
+
+#### 3. Leads Router — Create Procedure
+
+**File**: `src/server/api/routers/leads.ts`
+
+Replace the current `create` procedure (lines 13-25) with HubSpot-first flow:
+
+```typescript
+import {
+  createContact,
+  findExistingContact,
+  updateContact as updateHubSpotContact,
+} from "~/server/hubspot";
+import { PROPERTY_MAP } from "~/server/hubspot";
+
+// ...
+
+create: protectedProcedure
+  .input(leadCreateSchema)
+  .mutation(async ({ ctx, input }) => {
+    // 1. Extract HubSpot-mapped fields from input
+    const hubspotData: Record<string, string | boolean | null> = {};
+    for (const key of Object.keys(input) as Array<keyof typeof input>) {
+      if (key in PROPERTY_MAP && input[key] != null) {
+        hubspotData[key] = input[key] as string | boolean | null;
+      }
+    }
+
+    // 2. Dedup: search HubSpot for existing contact by email/phone
+    const existing = await findExistingContact(input.email, input.phone);
+    let hubspotContact;
+    if (existing) {
+      hubspotContact = await updateHubSpotContact(existing.id, hubspotData);
+    } else {
+      hubspotContact = await createContact(hubspotData);
+    }
+
+    // 3. Write to local DB with hubspotContactId
+    try {
+      const [lead] = await ctx.db
+        .insert(leads)
+        .values({
+          ...input,
+          hubspotContactId: hubspotContact.id,
+          leadStage: "unqualified",
+          leadScore: 0,
+        })
+        .returning();
+      return lead!;
+    } catch (dbError) {
+      // Partial failure: HubSpot succeeded, local DB failed
+      throw new TRPCError({
+        code: "INTERNAL_SERVER_ERROR",
+        message: `Lead saved to HubSpot (contact ID: ${hubspotContact.id}) but local save failed. Retry or check HubSpot.`,
+      });
+    }
+  }),
+```
+
+#### 4. Tests — Dedup Search
+
+**File**: `src/server/hubspot/__tests__/contacts.test.ts`
+
+Add tests for `findExistingContact`:
+
+```typescript
+describe("findExistingContact", () => {
+  test("finds contact by email first", async () => {
+    mockDoSearch.mockResolvedValue({ results: [MOCK_RESPONSE] });
+
+    const { findExistingContact } = await import("../contacts");
+    const result = await findExistingContact("jane@example.com", "0400000000");
+
+    expect(result?.id).toBe("123");
+    // Should have searched by email — only one search call
+    expect(mockDoSearch).toHaveBeenCalledTimes(1);
+    expect(mockDoSearch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        filterGroups: [
+          { filters: [{ propertyName: "email", operator: "EQ", value: "jane@example.com" }] },
+        ],
+      }),
+    );
+  });
+
+  test("falls back to phone when no email match", async () => {
+    mockDoSearch
+      .mockResolvedValueOnce({ results: [] }) // email miss
+      .mockResolvedValueOnce({ results: [MOCK_RESPONSE] }); // phone hit
+
+    const { findExistingContact } = await import("../contacts");
+    const result = await findExistingContact("nobody@example.com", "0400000000");
+
+    expect(result?.id).toBe("123");
+    expect(mockDoSearch).toHaveBeenCalledTimes(2);
+  });
+
+  test("returns null when no match found", async () => {
+    mockDoSearch.mockResolvedValue({ results: [] });
+
+    const { findExistingContact } = await import("../contacts");
+    const result = await findExistingContact("nobody@example.com", "0000000000");
+
+    expect(result).toBeNull();
+  });
+
+  test("skips email search when email is null", async () => {
+    mockDoSearch.mockResolvedValue({ results: [MOCK_RESPONSE] });
+
+    const { findExistingContact } = await import("../contacts");
+    const result = await findExistingContact(null, "0400000000");
+
+    expect(result?.id).toBe("123");
+    expect(mockDoSearch).toHaveBeenCalledTimes(1);
+    expect(mockDoSearch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        filterGroups: [
+          { filters: [{ propertyName: "phone", operator: "EQ", value: "0400000000" }] },
+        ],
+      }),
+    );
+  });
+});
+```
+
+#### 5. Tests — Leads Router Create
+
+**File**: `src/server/api/__tests__/leads-router.test.ts`
+
+The `beforeEach` must now also mock `~/server/hubspot`. Add:
+
+```typescript
+let mockFindExistingContact: ReturnType<typeof rs.fn>;
+let mockCreateContact: ReturnType<typeof rs.fn>;
+let mockUpdateHubSpotContact: ReturnType<typeof rs.fn>;
+
+beforeEach(() => {
+  // ... existing mocks ...
+
+  mockFindExistingContact = rs.fn().mockResolvedValue(null);
+  mockCreateContact = rs.fn().mockResolvedValue({
+    id: "hs-123",
+    properties: {},
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+  });
+  mockUpdateHubSpotContact = rs.fn().mockResolvedValue({
+    id: "hs-123",
+    properties: {},
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+  });
+
+  rs.doMock("~/server/hubspot", () => ({
+    findExistingContact: mockFindExistingContact,
+    createContact: mockCreateContact,
+    updateContact: mockUpdateHubSpotContact,
+    PROPERTY_MAP: {
+      firstName: "firstname",
+      lastName: "lastname",
+      email: "email",
+      phone: "phone",
+      // ... include all 20 entries
+    },
+  }));
+});
+```
+
+Update existing `leads.create` tests and add:
+
+- Test that `createContact` is called when no dedup match
+- Test that `updateContact` is called when dedup match found
+- Test that `hubspotContactId` is included in the DB insert values
+- Test partial failure: HubSpot succeeds but DB insert throws → `INTERNAL_SERVER_ERROR` with contact ID in message
+
+### Success Criteria
+
+#### Automated Verification
+- [x] All new and existing unit tests pass: `make test`
+- [x] `make check` passes
+
+#### Manual Verification
+- [ ] Create a lead via the full form → contact appears in HubSpot with matching fields
+- [ ] Create a lead with the same email as an existing HubSpot contact → existing contact updated (not duplicated)
+- [ ] `hubspotContactId` is populated on the local lead record after creation
+
+---
+
+## Phase 3: Wire HubSpot into Lead Update
+
+### Overview
+
+Modify `leads.update` to write mapped fields to HubSpot first (when the lead has a `hubspotContactId`), then update the local DB.
+
+### Changes Required
+
+#### 1. Leads Router — Update Procedure
+
+**File**: `src/server/api/routers/leads.ts`
+
+Replace the current `update` procedure (lines 94-109):
+
+```typescript
+update: protectedProcedure
+  .input(leadUpdateSchema)
+  .mutation(async ({ ctx, input }) => {
+    const { id, ...data } = input;
+
+    // Fetch the lead to get its hubspotContactId
+    const existing = await ctx.db.query.leads.findFirst({
+      where: eq(leads.id, id),
+      columns: { hubspotContactId: true },
+    });
+    if (!existing) {
+      throw new TRPCError({ code: "NOT_FOUND", message: "Lead not found" });
+    }
+
+    // Write mapped fields to HubSpot first (if linked)
+    if (existing.hubspotContactId) {
+      const hubspotData: Record<string, string | boolean | null> = {};
+      for (const key of Object.keys(data) as Array<keyof typeof data>) {
+        if (key in PROPERTY_MAP && data[key] !== undefined) {
+          hubspotData[key] = data[key] as string | boolean | null;
+        }
+      }
+      if (Object.keys(hubspotData).length > 0) {
+        await updateHubSpotContact(existing.hubspotContactId, hubspotData);
+      }
+    }
+
+    // Update local DB
+    const [updated] = await ctx.db
+      .update(leads)
+      .set({ ...data, updatedAt: new Date() })
+      .where(eq(leads.id, id))
+      .returning();
+
+    if (!updated) {
+      throw new TRPCError({ code: "NOT_FOUND", message: "Lead not found" });
+    }
+    return updated;
+  }),
+```
+
+#### 2. Tests — Leads Router Update
+
+**File**: `src/server/api/__tests__/leads-router.test.ts`
+
+Add HubSpot mock for `getContact` (not needed — we read from local DB). Update existing update tests:
+
+- Mock `db.query.leads.findFirst` to return `{ hubspotContactId: "hs-123" }`
+- Verify `updateHubSpotContact` is called with the correct HubSpot ID and only mapped fields
+- Test that non-mapped fields (e.g., `preferredEstates`) do NOT trigger a HubSpot call
+- Test update on a lead with `hubspotContactId: null` → HubSpot update skipped, local update proceeds
+- Test HubSpot API failure → error thrown, local DB NOT updated
+
+```typescript
+describe("leads.update — HubSpot sync", () => {
+  test("updates HubSpot before local DB when linked", async () => {
+    // findFirst returns a linked lead
+    (mockDb.query as any).leads.findFirst.mockResolvedValue({
+      hubspotContactId: "hs-123",
+    });
+    const returning = rs.fn().mockResolvedValue([{ ...mockLead, budget: "$700K" }]);
+    const where = rs.fn().mockReturnValue({ returning });
+    const set = rs.fn().mockReturnValue({ where });
+    (mockDb.update as ReturnType<typeof rs.fn>).mockReturnValue({ set });
+
+    const caller = await getCaller();
+    await caller.leads.update({ id: mockLead.id, budget: "$700K" });
+
+    expect(mockUpdateHubSpotContact).toHaveBeenCalledWith(
+      "hs-123",
+      expect.objectContaining({ budget: "$700K" }),
+    );
+  });
+
+  test("skips HubSpot when lead has no hubspotContactId", async () => {
+    (mockDb.query as any).leads.findFirst.mockResolvedValue({
+      hubspotContactId: null,
+    });
+    const returning = rs.fn().mockResolvedValue([{ ...mockLead, budget: "$700K" }]);
+    const where = rs.fn().mockReturnValue({ returning });
+    const set = rs.fn().mockReturnValue({ where });
+    (mockDb.update as ReturnType<typeof rs.fn>).mockReturnValue({ set });
+
+    const caller = await getCaller();
+    await caller.leads.update({ id: mockLead.id, budget: "$700K" });
+
+    expect(mockUpdateHubSpotContact).not.toHaveBeenCalled();
+  });
+});
+```
+
+### Success Criteria
+
+#### Automated Verification
+- [x] All unit tests pass: `make test`
+- [x] `make check` passes
+
+#### Manual Verification
+- [ ] Update a lead's phone number in the app → HubSpot contact's phone updates
+- [ ] Update only `preferredEstates` (non-mapped) → no HubSpot API call made
+- [ ] Update a lead that has no `hubspotContactId` → local update works, no HubSpot error
+
+---
+
+## Phase 4: Webhook Event Processing
+
+### Overview
+
+Implement processing for `contact.creation`, `contact.propertyChange`, and `contact.deletion` events in the webhook handler. Events are processed individually — failures are logged and swallowed to prevent HubSpot retry storms.
+
+### Changes Required
+
+#### 1. Webhook Event Types
+
+**File**: `src/app/api/hubspot/webhook/route.ts`
+
+Add a typed event interface and processing logic. Replace the current logging block (lines 38-47):
+
+```typescript
+import { eq } from "drizzle-orm";
+import { db } from "~/server/db";
+import { leads } from "~/server/db/schema";
+import {
+  coerceFromHubSpot,
+  getContact,
+  toAppField,
+} from "~/server/hubspot";
+
+interface WebhookEvent {
+  subscriptionType: string;
+  objectId: number;
+  propertyName?: string;
+  propertyValue?: string;
+  eventId: number;
+  occurredAt: number;
+  attemptNumber: number;
+}
+
+export async function POST(request: Request) {
+  // ... existing signature validation (lines 1-36 unchanged) ...
+
+  const events = JSON.parse(body) as WebhookEvent[];
+
+  for (const event of events) {
+    try {
+      await processEvent(event);
+    } catch (error) {
+      // Log and continue — return 200 to prevent HubSpot retry storm
+      console.error(
+        `[HubSpot Webhook] Failed to process ${event.subscriptionType} for objectId ${event.objectId}:`,
+        error,
+      );
+    }
+  }
+
+  return NextResponse.json({ received: true });
+}
+
+async function processEvent(event: WebhookEvent): Promise<void> {
+  const hubspotId = String(event.objectId);
+
+  switch (event.subscriptionType) {
+    case "contact.creation":
+      return handleContactCreation(hubspotId);
+    case "contact.propertyChange":
+      return handlePropertyChange(
+        hubspotId,
+        event.propertyName!,
+        event.propertyValue!,
+      );
+    case "contact.deletion":
+      return handleContactDeletion(hubspotId);
+    default:
+      console.log(
+        `[HubSpot Webhook] Ignoring unhandled event: ${event.subscriptionType}`,
+      );
+  }
+}
+```
+
+#### 2. Event Handlers
+
+**File**: `src/app/api/hubspot/webhook/route.ts` (continued)
+
+```typescript
+async function handleContactCreation(hubspotId: string): Promise<void> {
+  // Fetch full contact from HubSpot (creation events don't include properties)
+  const contact = await getContact(hubspotId);
+
+  // Build local record from HubSpot properties
+  const record: Record<string, unknown> = {
+    hubspotContactId: hubspotId,
+    firstName: contact.properties.firstName ?? "Unknown",
+    lastName: contact.properties.lastName ?? "Unknown",
+    updatedAt: new Date(),
+  };
+
+  // Map all available properties with type coercion
+  for (const [field, value] of Object.entries(contact.properties)) {
+    if (value != null && field !== "firstName" && field !== "lastName") {
+      record[field] = coerceFromHubSpot(field as any, value);
+    }
+  }
+
+  // Upsert: insert or update if hubspotContactId already exists
+  await db
+    .insert(leads)
+    .values(record as any)
+    .onConflictDoUpdate({
+      target: leads.hubspotContactId,
+      set: record as any,
+    });
+}
+
+async function handlePropertyChange(
+  hubspotId: string,
+  propertyName: string,
+  propertyValue: string,
+): Promise<void> {
+  const appField = toAppField(propertyName);
+  if (!appField) return; // Not a mapped property — ignore
+
+  const coerced = coerceFromHubSpot(appField, propertyValue);
+
+  await db
+    .update(leads)
+    .set({ [appField]: coerced, updatedAt: new Date() })
+    .where(eq(leads.hubspotContactId, hubspotId));
+}
+
+async function handleContactDeletion(hubspotId: string): Promise<void> {
+  await db.delete(leads).where(eq(leads.hubspotContactId, hubspotId));
+}
+```
+
+#### 3. Tests — Webhook Event Processing
+
+**File**: `src/app/api/hubspot/webhook/__tests__/route.test.ts`
+
+Extend `beforeEach` to mock `~/server/db` and `~/server/hubspot`. Add test cases:
+
+```typescript
+let mockGetContact: ReturnType<typeof rs.fn>;
+let mockInsert: ReturnType<typeof rs.fn>;
+let mockUpdate: ReturnType<typeof rs.fn>;
+let mockDbDelete: ReturnType<typeof rs.fn>;
+
+beforeEach(() => {
+  // ... existing mocks (env, @hubspot/api-client) ...
+
+  mockGetContact = rs.fn();
+  rs.doMock("~/server/hubspot", () => ({
+    getContact: mockGetContact,
+    toAppField: rs.fn((prop: string) => {
+      const map: Record<string, string> = {
+        firstname: "firstName",
+        lastname: "lastName",
+        email: "email",
+        phone: "phone",
+        lead_score: "leadScore",
+      };
+      return map[prop];
+    }),
+    coerceFromHubSpot: rs.fn((field: string, value: string) => {
+      if (field === "leadScore") return parseInt(value, 10);
+      return value;
+    }),
+  }));
+
+  // Mock db with chainable methods
+  const onConflictDoUpdate = rs.fn().mockResolvedValue(undefined);
+  const insertValues = rs.fn().mockReturnValue({ onConflictDoUpdate });
+  mockInsert = rs.fn().mockReturnValue({ values: insertValues });
+
+  const updateWhere = rs.fn().mockResolvedValue(undefined);
+  const updateSet = rs.fn().mockReturnValue({ where: updateWhere });
+  mockUpdate = rs.fn().mockReturnValue({ set: updateSet });
+
+  const deleteWhere = rs.fn().mockResolvedValue(undefined);
+  mockDbDelete = rs.fn().mockReturnValue({ where: deleteWhere });
+
+  rs.doMock("~/server/db", () => ({
+    db: {
+      insert: mockInsert,
+      update: mockUpdate,
+      delete: mockDbDelete,
+    },
+  }));
+
+  // Mock schema import
+  rs.doMock("~/server/db/schema", () => ({
+    leads: { hubspotContactId: "hubspot_contact_id" },
+  }));
+});
+
+describe("Webhook event processing", () => {
+  test("contact.creation fetches contact and upserts local lead", async () => {
+    mockIsValid.mockReturnValue(true);
+    mockGetContact.mockResolvedValue({
+      id: "456",
+      properties: { firstName: "Jane", lastName: "Doe", email: "jane@example.com" },
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+    });
+
+    const { POST } = await import("../route");
+    const response = await POST(
+      makeRequest({
+        body: JSON.stringify([
+          { subscriptionType: "contact.creation", objectId: 456, eventId: 1, occurredAt: Date.now(), attemptNumber: 0 },
+        ]),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockGetContact).toHaveBeenCalledWith("456");
+    expect(mockInsert).toHaveBeenCalled();
+  });
+
+  test("contact.propertyChange updates mapped field on local lead", async () => {
+    mockIsValid.mockReturnValue(true);
+
+    const { POST } = await import("../route");
+    const response = await POST(
+      makeRequest({
+        body: JSON.stringify([
+          {
+            subscriptionType: "contact.propertyChange",
+            objectId: 456,
+            propertyName: "email",
+            propertyValue: "new@example.com",
+            eventId: 2,
+            occurredAt: Date.now(),
+            attemptNumber: 0,
+          },
+        ]),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockUpdate).toHaveBeenCalled();
+  });
+
+  test("contact.propertyChange ignores unmapped properties", async () => {
+    mockIsValid.mockReturnValue(true);
+
+    // toAppField returns undefined for unmapped property
+    const { POST } = await import("../route");
+    const response = await POST(
+      makeRequest({
+        body: JSON.stringify([
+          {
+            subscriptionType: "contact.propertyChange",
+            objectId: 456,
+            propertyName: "hs_analytics_source",
+            propertyValue: "ORGANIC_SEARCH",
+            eventId: 3,
+            occurredAt: Date.now(),
+            attemptNumber: 0,
+          },
+        ]),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+
+  test("contact.deletion deletes local lead", async () => {
+    mockIsValid.mockReturnValue(true);
+
+    const { POST } = await import("../route");
+    const response = await POST(
+      makeRequest({
+        body: JSON.stringify([
+          { subscriptionType: "contact.deletion", objectId: 456, eventId: 4, occurredAt: Date.now(), attemptNumber: 0 },
+        ]),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockDbDelete).toHaveBeenCalled();
+  });
+
+  test("processing failure for one event does not block others", async () => {
+    mockIsValid.mockReturnValue(true);
+    mockGetContact
+      .mockRejectedValueOnce(new Error("HubSpot API down")) // first event fails
+      .mockResolvedValueOnce({                                // second event succeeds
+        id: "789",
+        properties: { firstName: "Ok", lastName: "Lead" },
+        createdAt: "2026-01-01T00:00:00.000Z",
+        updatedAt: "2026-01-01T00:00:00.000Z",
+      });
+
+    const { POST } = await import("../route");
+    const response = await POST(
+      makeRequest({
+        body: JSON.stringify([
+          { subscriptionType: "contact.creation", objectId: 456, eventId: 5, occurredAt: Date.now(), attemptNumber: 0 },
+          { subscriptionType: "contact.creation", objectId: 789, eventId: 6, occurredAt: Date.now(), attemptNumber: 0 },
+        ]),
+      }),
+    );
+
+    // Should return 200 even though first event failed
+    expect(response.status).toBe(200);
+    expect(mockGetContact).toHaveBeenCalledTimes(2);
+  });
+});
+```
+
+### Success Criteria
+
+#### Automated Verification
+- [x] All unit tests pass: `make test`
+- [x] `make check` passes
+
+#### Manual Verification
+- [ ] Create a contact directly in HubSpot → local lead appears
+- [ ] Edit a contact's email in HubSpot → local lead's email updates
+- [ ] Delete a contact in HubSpot → local lead is removed
+- [ ] Contact created via the app does not produce duplicate local records when webhook arrives
+
+---
+
+## Phase 5: Manual HubSpot Setup Guide
+
+### Overview
+
+Document the manual configuration steps for creating custom HubSpot properties and subscribing to webhook events. This is a one-time setup per HubSpot account.
+
+### Changes Required
+
+#### 1. Setup Documentation
+
+**File**: `thoughts/guides/hubspot-manual-setup.md`
+
+```markdown
+# HubSpot Manual Setup Guide
+
+One-time setup steps for the HubSpot integration. These must be completed
+before the contact sync features will work correctly.
+
+## Prerequisites
+
+- Admin access to the HubSpot account
+- The Rekurve app's HubSpot private app already created (Epic 1)
+- `HUBSPOT_ACCESS_TOKEN` and `HUBSPOT_CLIENT_SECRET` set in the environment
+
+---
+
+## Step 1: Create the "Rekurve" Property Group
+
+1. Go to **Settings** (gear icon) → **Data Management** → **Properties**
+2. Select the **Contact** object
+3. Click **Create a group**
+4. Name: `Rekurve`
+5. Click **Save**
+
+---
+
+## Step 2: Create Custom Contact Properties
+
+For each property below, go to **Settings** → **Data Management** → **Properties**
+→ **Contact** → **Create property**.
+
+Assign all custom properties to the **Rekurve** group.
+
+### 2.1 preferred_contact_time
+
+| Setting | Value |
+|---------|-------|
+| Label | Preferred Contact Time |
+| Internal name | `preferred_contact_time` |
+| Group | Rekurve |
+| Field type | Dropdown select |
+| Options | `weekdays` (Weekdays), `weekends` (Weekends), `anytime` (Anytime) |
+
+### 2.2 land_width
+
+| Setting | Value |
+|---------|-------|
+| Label | Land Width (m) |
+| Internal name | `land_width` |
+| Group | Rekurve |
+| Field type | Single-line text |
+
+### 2.3 land_depth
+
+| Setting | Value |
+|---------|-------|
+| Label | Land Depth (m) |
+| Internal name | `land_depth` |
+| Group | Rekurve |
+| Field type | Single-line text |
+
+### 2.4 lead_score
+
+| Setting | Value |
+|---------|-------|
+| Label | Rekurve Lead Score |
+| Internal name | `lead_score` |
+| Group | Rekurve |
+| Field type | Number |
+
+### 2.5 lead_stage
+
+| Setting | Value |
+|---------|-------|
+| Label | Rekurve Lead Stage |
+| Internal name | `lead_stage` |
+| Group | Rekurve |
+| Field type | Dropdown select |
+| Options | `unqualified` (Unqualified), `nurture` (Nurture), `warm` (Warm), `hot` (Hot) |
+
+### 2.6 notes
+
+| Setting | Value |
+|---------|-------|
+| Label | Rekurve Notes |
+| Internal name | `notes` |
+| Group | Rekurve |
+| Field type | Multi-line text |
+
+### 2.7 lead_source
+
+| Setting | Value |
+|---------|-------|
+| Label | Rekurve Lead Source |
+| Internal name | `lead_source` |
+| Group | Rekurve |
+| Field type | Dropdown select |
+| Options | `walk_in` (Walk-in), `referral` (Referral), `social` (Social), `web` (Web), `other` (Other) |
+
+---
+
+## Step 3: Verify Existing Custom Properties
+
+The following custom properties should already exist from Epic 1. Verify they
+are present and in the **Rekurve** group:
+
+- `has_land` — Dropdown select: `true` / `false`
+- `land_registered` — Dropdown select: `true` / `false`
+- `land_address` — Single-line text
+- `land_size_sqm` — Single-line text
+- `property_type` — Dropdown select: `single_storey`, `double_storey`, `investment`, `upsize`, `downsize`, `first_home_buyer`
+- `budget` — Single-line text
+- `seen_broker` — Dropdown select: `true` / `false`
+- `construction_timeline` — Dropdown select: `ready_now`, `3_6_months`, `12_months_plus`
+- `resolve_finance_opted_in` — Dropdown select: `true` / `false`
+
+If any are missing, create them following the same pattern as Step 2.
+
+---
+
+## Step 4: Configure Webhook Subscriptions
+
+1. Go to **Settings** → **Integrations** → **Private Apps**
+2. Select the Rekurve private app
+3. Go to the **Webhooks** tab
+4. Set the **Target URL** to: `https://<your-domain>/api/hubspot/webhook`
+
+### 4.1 Subscribe to Contact Creation
+
+1. Click **Create subscription**
+2. Object: **Contact**
+3. Event type: **Created**
+4. Click **Save**
+
+### 4.2 Subscribe to Contact Property Changes
+
+1. Click **Create subscription**
+2. Object: **Contact**
+3. Event type: **Property changed**
+4. Leave the property filter empty (subscribes to ALL property changes — the
+   webhook handler filters to mapped properties server-side)
+5. Click **Save**
+
+### 4.3 Subscribe to Contact Deletion
+
+1. Click **Create subscription**
+2. Object: **Contact**
+3. Event type: **Deleted**
+4. Click **Save**
+
+### 4.4 Activate Subscriptions
+
+1. Ensure all three subscriptions show status **Active**
+2. If using a staging environment, verify the target URL is reachable from
+   the internet (HubSpot cannot reach localhost)
+
+---
+
+## Step 5: Verify the Integration
+
+### Outbound (App → HubSpot)
+
+1. Create a new lead in the app with all fields filled
+2. Open HubSpot → Contacts → find the contact by name
+3. Verify all Rekurve properties are populated
+4. Check the lead record in the app has a `hubspotContactId`
+
+### Inbound (HubSpot → App)
+
+1. Edit the contact's phone number directly in HubSpot
+2. Wait ~30 seconds for the webhook to fire
+3. Refresh the lead in the app — phone number should be updated
+4. Delete the contact in HubSpot
+5. Verify the lead is removed from the app
+
+---
+
+## Troubleshooting
+
+- **Webhook not firing**: Check the subscription is Active, and the target URL
+  is publicly reachable. HubSpot shows delivery logs under the Webhooks tab.
+- **401 on webhook**: Verify `HUBSPOT_CLIENT_SECRET` matches the app's client
+  secret (not the access token).
+- **Properties not syncing**: Verify the internal names match exactly (case-
+  sensitive). Use the HubSpot API to check:
+  `GET /crm/v3/properties/contacts/<property_name>`
+- **Duplicate contacts**: The dedup check searches by email first, then phone.
+  If a contact has neither, a duplicate may be created. Add email or phone to
+  avoid this.
+```
+
+### Success Criteria
+
+#### Automated Verification
+- [x] None — documentation only
+
+#### Manual Verification
+- [ ] All 7 custom properties created in HubSpot
+- [ ] All 3 webhook subscriptions active
+- [ ] End-to-end test per Step 5 passes
+
+---
+
+## Performance Considerations
+
+- **HubSpot API latency on create/update**: The tRPC mutations now include 1-2 HubSpot API calls (dedup search + create/update). Expect ~200-500ms added latency per mutation. Acceptable for pilot scale.
+- **Webhook batching**: HubSpot sends up to 100 events per webhook POST. The handler processes them sequentially. If throughput becomes an issue, events could be queued — not needed for pilot.
+- **No DB indexes on hubspotContactId for lookups**: The `hubspotContactId` column already has a `unique()` constraint which creates an index. Webhook lookups by this column will be fast.
+
+## References
+
+- GitHub issue: #102 (HubSpot Contact Sync on Lead Create/Update)
+- Parent epic: #86 (Lead Management + AI Qualification Scoring)
+- Dependency: #96 (tRPC Leads Router — complete)
+- Dependency: #85 (Epic 1: HubSpot API connection — complete)
+- Design doc: `thoughts/designs/2026-03-27-ai-sales-assistant-new-home-builders.md`
+- HubSpot Contacts API: https://developers.hubspot.com/docs/api/crm/contacts
+- HubSpot Webhooks: https://developers.hubspot.com/docs/api/webhooks
+- Existing property map: `src/server/hubspot/properties.ts`
+- Existing webhook handler: `src/app/api/hubspot/webhook/route.ts`
+- Existing leads router: `src/server/api/routers/leads.ts`

--- a/thoughts/plans/2026-04-09-102-hubspot-property-setup-e2e.md
+++ b/thoughts/plans/2026-04-09-102-hubspot-property-setup-e2e.md
@@ -1,0 +1,959 @@
+# HubSpot Property Provisioning & E2E Sync Tests — Implementation Plan
+
+## Overview
+
+Automate the creation of custom HubSpot properties (currently a manual 7-step process) and add E2E tests that verify the full HubSpot contact sync pipeline — outbound (app creates lead, contact appears in HubSpot) and inbound (contact changed in HubSpot, local lead updates via webhook).
+
+## Current State Analysis
+
+- **Property creation**: Manual — documented in `thoughts/guides/hubspot-manual-setup.md` steps 1-3. Seven custom properties + one property group created by hand in the HubSpot UI.
+- **Properties API**: `hubspot.crm.properties.coreApi.create()` and `groupsApi.create()` are available on the installed `@hubspot/api-client` v13.5.0 (`client.ts:4-7`). HubSpot returns 409 on duplicate, enabling an idempotent `ensure*` pattern.
+- **Webhook subscriptions**: NOT programmable for private apps — stays manual (Step 4 of setup guide).
+- **E2E test infrastructure**: Mature Playwright setup with page objects (`e2e/pages/sections/lead-form.section.ts`), direct DB session creation (`e2e/utils/auth-helper.ts`), and env-gated `test.skip()` (`leads-crud.spec.ts:13-16`).
+- **Existing lead form E2E**: `e2e/features/leads-crud.spec.ts` covers form submission, validation, and quick capture — but does not verify HubSpot side effects.
+- **Unit test coverage**: All HubSpot sync logic (dedup, create, update, webhook handlers) covered by unit tests with mocked API calls.
+
+### Key Discoveries
+
+- E2E tests use their own `@neondatabase/serverless` client (`auth-helper.ts:9-12`), not the app's DB module — the HubSpot helper must similarly create its own `Client` instance from env vars
+- `deleteTestLeads()` in `auth-helper.ts:76-82` cleans up by email pattern (`e2e-%@test.rekurve.dev`) — HubSpot cleanup needs to follow the same pattern
+- The Playwright config skips `webServer` in CI and tests against a deployed URL (`playwright.config.ts:40-47`) — inbound webhook tests only work against a deployed environment
+- `PropertyCreate` requires: `name`, `label`, `type`, `fieldType`, `groupName`; optional `options` for enumerations, `description`
+
+## Desired End State
+
+1. A `src/server/hubspot/setup.ts` module with an idempotent `ensureAllProperties()` function that provisions the "Rekurve" property group and all 7 custom properties
+2. A `make hubspot_setup` target that runs the provisioning
+3. E2E tests in `e2e/features/hubspot-sync.spec.ts` that verify:
+   - Creating a lead in the app produces a HubSpot contact with correct properties
+   - Creating a lead with an existing HubSpot email dedup-updates instead of duplicating
+   - Updating a contact's phone in HubSpot updates the local lead via webhook
+   - Deleting a contact in HubSpot removes the local lead via webhook
+4. `thoughts/guides/hubspot-manual-setup.md` updated: property creation replaced with `make hubspot_setup`, webhook config stays manual
+
+### Verification
+
+- `make check` passes
+- `make test` passes (new unit tests for setup module)
+- `make test_e2e` passes (new E2E tests skip gracefully when HubSpot credentials are absent)
+- Running `make hubspot_setup` against a live HubSpot account creates the properties idempotently
+
+## What We're NOT Doing
+
+- **Programmatic webhook subscription** — private apps don't support this via API
+- **Provisioning existing Epic 1 properties** — the 9 properties from Epic 1 (`has_land`, `land_registered`, etc.) are already created; the setup module only handles the 7 new ones
+- **CI integration for HubSpot E2E tests** — these require live HubSpot credentials and (for inbound) the production deployment; they run locally/manually
+- **Multi-environment webhook configuration** — the HubSpot webhook target URL is manually configured to point to production only. Inbound sync tests can only run against production.
+- **HubSpot sandbox/test account management** — uses the real HubSpot account with test-prefixed data
+
+---
+
+## Phase 1: HubSpot Property Provisioning Module
+
+### Overview
+
+Create a module that provisions the "Rekurve" property group and 7 custom contact properties in HubSpot. Uses an idempotent pattern: attempt create, catch 409 (already exists), log result.
+
+### Changes Required
+
+#### 1. Setup Module
+
+**File**: `src/server/hubspot/setup.ts`
+
+```typescript
+import { hubspot } from "./client";
+
+interface PropertyDefinition {
+  name: string;
+  label: string;
+  type: "string" | "number" | "enumeration";
+  fieldType: "text" | "textarea" | "number" | "select";
+  description?: string;
+  options?: Array<{ label: string; value: string; displayOrder: number }>;
+}
+
+const GROUP_NAME = "rekurve";
+
+const CUSTOM_PROPERTIES: PropertyDefinition[] = [
+  {
+    name: "preferred_contact_time",
+    label: "Preferred Contact Time",
+    type: "enumeration",
+    fieldType: "select",
+    options: [
+      { label: "Weekdays", value: "weekdays", displayOrder: 0 },
+      { label: "Weekends", value: "weekends", displayOrder: 1 },
+      { label: "Anytime", value: "anytime", displayOrder: 2 },
+    ],
+  },
+  {
+    name: "land_width",
+    label: "Land Width (m)",
+    type: "string",
+    fieldType: "text",
+  },
+  {
+    name: "land_depth",
+    label: "Land Depth (m)",
+    type: "string",
+    fieldType: "text",
+  },
+  {
+    name: "lead_score",
+    label: "Rekurve Lead Score",
+    type: "number",
+    fieldType: "number",
+  },
+  {
+    name: "lead_stage",
+    label: "Rekurve Lead Stage",
+    type: "enumeration",
+    fieldType: "select",
+    options: [
+      { label: "Unqualified", value: "unqualified", displayOrder: 0 },
+      { label: "Nurture", value: "nurture", displayOrder: 1 },
+      { label: "Warm", value: "warm", displayOrder: 2 },
+      { label: "Hot", value: "hot", displayOrder: 3 },
+    ],
+  },
+  {
+    name: "notes",
+    label: "Rekurve Notes",
+    type: "string",
+    fieldType: "textarea",
+  },
+  {
+    name: "lead_source",
+    label: "Rekurve Lead Source",
+    type: "enumeration",
+    fieldType: "select",
+    options: [
+      { label: "Walk-in", value: "walk_in", displayOrder: 0 },
+      { label: "Referral", value: "referral", displayOrder: 1 },
+      { label: "Social", value: "social", displayOrder: 2 },
+      { label: "Web", value: "web", displayOrder: 3 },
+      { label: "Other", value: "other", displayOrder: 4 },
+    ],
+  },
+];
+
+async function ensurePropertyGroup(): Promise<void> {
+  try {
+    await hubspot.crm.properties.groupsApi.create("contacts", {
+      name: GROUP_NAME,
+      label: "Rekurve",
+    });
+    console.log(`[HubSpot Setup] Created property group: ${GROUP_NAME}`);
+  } catch (err: unknown) {
+    if (isConflict(err)) {
+      console.log(`[HubSpot Setup] Property group already exists: ${GROUP_NAME}`);
+      return;
+    }
+    throw err;
+  }
+}
+
+async function ensureProperty(def: PropertyDefinition): Promise<void> {
+  try {
+    await hubspot.crm.properties.coreApi.create("contacts", {
+      name: def.name,
+      label: def.label,
+      type: def.type,
+      fieldType: def.fieldType,
+      groupName: GROUP_NAME,
+      ...(def.description && { description: def.description }),
+      ...(def.options && {
+        options: def.options.map((o) => ({ ...o, hidden: false })),
+      }),
+    });
+    console.log(`[HubSpot Setup] Created property: ${def.name}`);
+  } catch (err: unknown) {
+    if (isConflict(err)) {
+      console.log(`[HubSpot Setup] Property already exists: ${def.name}`);
+      return;
+    }
+    throw err;
+  }
+}
+
+function isConflict(err: unknown): boolean {
+  return (
+    typeof err === "object" &&
+    err !== null &&
+    "code" in err &&
+    (err as { code: number }).code === 409
+  );
+}
+
+/** Provision the Rekurve property group and all custom properties. Idempotent. */
+export async function ensureAllProperties(): Promise<void> {
+  await ensurePropertyGroup();
+  for (const def of CUSTOM_PROPERTIES) {
+    await ensureProperty(def);
+  }
+  console.log("[HubSpot Setup] All properties ensured.");
+}
+
+// Allow running as a standalone script: npx tsx src/server/hubspot/setup.ts
+if (
+  typeof process !== "undefined" &&
+  process.argv[1]?.endsWith("setup.ts")
+) {
+  ensureAllProperties()
+    .then(() => process.exit(0))
+    .catch((err) => {
+      console.error("[HubSpot Setup] Failed:", err);
+      process.exit(1);
+    });
+}
+```
+
+#### 2. Barrel Export
+
+**File**: `src/server/hubspot/index.ts`
+
+Add `ensureAllProperties` to the exports:
+
+```typescript
+export { ensureAllProperties } from "./setup";
+```
+
+#### 3. Makefile Target
+
+**File**: `Makefile`
+
+Add after the existing targets:
+
+```makefile
+hubspot_setup:
+	yarn tsx src/server/hubspot/setup.ts
+```
+
+#### 4. Tests
+
+**File**: `src/server/hubspot/__tests__/setup.test.ts`
+
+```typescript
+import { beforeEach, describe, expect, rs, test } from "@rstest/core";
+
+let mockGroupCreate: ReturnType<typeof rs.fn>;
+let mockPropertyCreate: ReturnType<typeof rs.fn>;
+
+beforeEach(() => {
+  rs.resetModules();
+
+  mockGroupCreate = rs.fn().mockResolvedValue({});
+  mockPropertyCreate = rs.fn().mockResolvedValue({});
+
+  rs.doMock("~/env", () => ({
+    env: {
+      HUBSPOT_ACCESS_TOKEN: "test-token",
+      HUBSPOT_CLIENT_SECRET: "test-secret",
+    },
+  }));
+
+  rs.doMock("../client", () => ({
+    hubspot: {
+      crm: {
+        properties: {
+          groupsApi: { create: mockGroupCreate },
+          coreApi: { create: mockPropertyCreate },
+        },
+      },
+    },
+  }));
+});
+
+describe("ensureAllProperties", () => {
+  test("creates property group and all 7 custom properties", async () => {
+    const { ensureAllProperties } = await import("../setup");
+    await ensureAllProperties();
+
+    expect(mockGroupCreate).toHaveBeenCalledTimes(1);
+    expect(mockGroupCreate).toHaveBeenCalledWith("contacts", {
+      name: "rekurve",
+      label: "Rekurve",
+    });
+
+    expect(mockPropertyCreate).toHaveBeenCalledTimes(7);
+    // Verify each property name was created
+    const names = mockPropertyCreate.mock.calls.map(
+      (call: [string, { name: string }]) => call[1].name,
+    );
+    expect(names).toEqual([
+      "preferred_contact_time",
+      "land_width",
+      "land_depth",
+      "lead_score",
+      "lead_stage",
+      "notes",
+      "lead_source",
+    ]);
+  });
+
+  test("swallows 409 conflicts for group", async () => {
+    mockGroupCreate.mockRejectedValue({ code: 409 });
+
+    const { ensureAllProperties } = await import("../setup");
+    await ensureAllProperties();
+
+    // Should not throw — continues to create properties
+    expect(mockPropertyCreate).toHaveBeenCalledTimes(7);
+  });
+
+  test("swallows 409 conflicts for properties", async () => {
+    mockPropertyCreate.mockRejectedValue({ code: 409 });
+
+    const { ensureAllProperties } = await import("../setup");
+    // Should not throw
+    await ensureAllProperties();
+  });
+
+  test("throws non-409 errors", async () => {
+    mockGroupCreate.mockRejectedValue({ code: 500, message: "Server error" });
+
+    const { ensureAllProperties } = await import("../setup");
+    await expect(ensureAllProperties()).rejects.toEqual(
+      expect.objectContaining({ code: 500 }),
+    );
+  });
+
+  test("creates enumeration properties with options", async () => {
+    const { ensureAllProperties } = await import("../setup");
+    await ensureAllProperties();
+
+    // lead_stage should have options
+    const leadStageCall = mockPropertyCreate.mock.calls.find(
+      (call: [string, { name: string }]) => call[1].name === "lead_stage",
+    );
+    expect(leadStageCall[1]).toEqual(
+      expect.objectContaining({
+        type: "enumeration",
+        fieldType: "select",
+        options: expect.arrayContaining([
+          expect.objectContaining({ value: "hot", label: "Hot" }),
+        ]),
+      }),
+    );
+  });
+});
+```
+
+### Success Criteria
+
+#### Automated Verification
+- [x] `make check` passes
+- [x] `make test` passes — all new setup tests pass
+- [x] `ensureAllProperties()` creates group + 7 properties
+- [x] 409 conflicts are silently swallowed
+- [x] Non-409 errors propagate
+
+#### Manual Verification
+- [ ] `make hubspot_setup` runs successfully against live HubSpot account
+- [ ] Running it twice is idempotent (no errors on second run)
+- [ ] Properties appear in HubSpot under the "Rekurve" group
+
+---
+
+## Phase 2: HubSpot E2E Test Helper
+
+### Overview
+
+Create a self-contained E2E utility (like `auth-helper.ts`) that provides HubSpot API operations for test setup, verification, and cleanup. Uses its own `Client` instance from `process.env.HUBSPOT_ACCESS_TOKEN`.
+
+### Changes Required
+
+#### 1. HubSpot Helper
+
+**File**: `e2e/utils/hubspot-helper.ts`
+
+```typescript
+import { Client } from "@hubspot/api-client";
+import { neon } from "@neondatabase/serverless";
+
+import "dotenv/config";
+
+// Lazy — only initialized when a function is called
+let _hubspot: Client | undefined;
+function hubspot() {
+  _hubspot ??= new Client({
+    accessToken: process.env.HUBSPOT_ACCESS_TOKEN!,
+    numberOfApiCallRetries: 3,
+  });
+  return _hubspot;
+}
+
+let _sql: ReturnType<typeof neon> | undefined;
+function sql() {
+  _sql ??= neon(process.env.DATABASE_URL!);
+  return _sql;
+}
+
+const ALL_PROPERTIES = [
+  "firstname", "lastname", "email", "phone",
+  "has_land", "land_registered", "land_address", "land_size_sqm",
+  "property_type", "budget", "seen_broker", "construction_timeline",
+  "resolve_finance_opted_in", "preferred_contact_time",
+  "land_width", "land_depth", "lead_score", "lead_stage",
+  "notes", "lead_source",
+];
+
+export interface TestContact {
+  id: string;
+  properties: Record<string, string | null>;
+}
+
+/** Search for a contact by email. Returns null if not found. */
+export async function findContactByEmail(
+  email: string,
+): Promise<TestContact | null> {
+  const response = await hubspot().crm.contacts.searchApi.doSearch({
+    filterGroups: [
+      {
+        filters: [
+          { propertyName: "email", operator: "EQ", value: email },
+        ],
+      },
+    ],
+    properties: ALL_PROPERTIES,
+    limit: 1,
+    after: "0",
+    sorts: [],
+  });
+  if (response.results.length === 0) return null;
+  const c = response.results[0]!;
+  return { id: c.id, properties: c.properties as Record<string, string | null> };
+}
+
+/** Create a contact in HubSpot for test seeding. */
+export async function createTestContact(
+  properties: Record<string, string>,
+): Promise<TestContact> {
+  const response = await hubspot().crm.contacts.basicApi.create({
+    properties,
+    associations: [],
+  });
+  return {
+    id: response.id,
+    properties: response.properties as Record<string, string | null>,
+  };
+}
+
+/** Update a contact's property in HubSpot. */
+export async function updateTestContact(
+  hubspotId: string,
+  properties: Record<string, string>,
+): Promise<void> {
+  await hubspot().crm.contacts.basicApi.update(hubspotId, { properties });
+}
+
+/** Archive (soft-delete) a contact in HubSpot. */
+export async function archiveTestContact(hubspotId: string): Promise<void> {
+  await hubspot().crm.contacts.basicApi.archive(hubspotId);
+}
+
+/** Delete all HubSpot contacts matching the E2E test email pattern. */
+export async function deleteTestContacts(): Promise<void> {
+  const response = await hubspot().crm.contacts.searchApi.doSearch({
+    filterGroups: [
+      {
+        filters: [
+          {
+            propertyName: "email",
+            operator: "CONTAINS_TOKEN",
+            value: "test.rekurve.dev",
+          },
+        ],
+      },
+    ],
+    properties: ["email"],
+    limit: 100,
+    after: "0",
+    sorts: [],
+  });
+
+  for (const contact of response.results) {
+    try {
+      await hubspot().crm.contacts.basicApi.archive(contact.id);
+    } catch {
+      // Already deleted — ignore
+    }
+  }
+}
+
+/**
+ * Poll the local DB until a lead matching the email has the expected value,
+ * or until the timeout expires. For verifying inbound webhook processing.
+ */
+export async function waitForLeadField(
+  email: string,
+  field: string,
+  expected: string,
+  timeoutMs = 30_000,
+): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    const rows = await sql()`
+      SELECT * FROM "leads" WHERE email = ${email} LIMIT 1
+    `;
+    if (rows.length > 0 && String(rows[0][field]) === expected) {
+      return;
+    }
+    await new Promise((r) => setTimeout(r, 2_000));
+  }
+  throw new Error(
+    `Timed out waiting for leads.${field} = "${expected}" (email: ${email})`,
+  );
+}
+
+/**
+ * Poll the local DB until a lead matching the email no longer exists.
+ * For verifying inbound webhook deletion.
+ */
+export async function waitForLeadDeletion(
+  email: string,
+  timeoutMs = 30_000,
+): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    const rows = await sql()`
+      SELECT id FROM "leads" WHERE email = ${email} LIMIT 1
+    `;
+    if (rows.length === 0) return;
+    await new Promise((r) => setTimeout(r, 2_000));
+  }
+  throw new Error(
+    `Timed out waiting for lead deletion (email: ${email})`,
+  );
+}
+
+/** Read the hubspot_contact_id for a lead from the local DB. */
+export async function getLeadHubSpotId(
+  email: string,
+): Promise<string | null> {
+  const rows = await sql()`
+    SELECT hubspot_contact_id FROM "leads" WHERE email = ${email} LIMIT 1
+  `;
+  return rows.length > 0 ? (rows[0].hubspot_contact_id as string | null) : null;
+}
+```
+
+### Success Criteria
+
+#### Automated Verification
+- [x] `make check` passes (the helper has no type errors)
+- [x] Helper is importable from test files
+
+#### Manual Verification
+- [ ] None — utility module, exercised by Phase 3/4 tests
+
+---
+
+## Phase 3: E2E Outbound Sync Tests
+
+### Overview
+
+Verify that creating a lead in the app produces a correctly populated contact in HubSpot, and that the dedup logic updates existing contacts instead of creating duplicates.
+
+### Changes Required
+
+#### 1. Test File
+
+**File**: `e2e/features/hubspot-sync.spec.ts`
+
+```typescript
+import { expect, test } from "@playwright/test";
+import { LeadFormSection } from "../pages/sections/lead-form.section";
+import {
+  createTestSession,
+  deleteTestLeads,
+  deleteTestSession,
+  type TestSession,
+} from "../utils/auth-helper";
+import {
+  createTestContact,
+  deleteTestContacts,
+  findContactByEmail,
+  getLeadHubSpotId,
+} from "../utils/hubspot-helper";
+import { getSessionCookie } from "../utils/session-cookie";
+
+test.describe("HubSpot Outbound Sync — E2E", () => {
+  test.skip(
+    !process.env.HUBSPOT_ACCESS_TOKEN || !process.env.DATABASE_URL,
+    "Requires HUBSPOT_ACCESS_TOKEN and DATABASE_URL — skipped in CI",
+  );
+
+  let session: TestSession;
+
+  test.beforeAll(async () => {
+    session = await createTestSession();
+    // Clean up any leftover test contacts from previous runs
+    await deleteTestContacts();
+    await deleteTestLeads();
+  });
+
+  test.afterAll(async () => {
+    await deleteTestContacts();
+    await deleteTestLeads();
+    await deleteTestSession(session.userId);
+  });
+
+  test("creating a lead produces a HubSpot contact with matching properties", async ({
+    context,
+    page,
+    baseURL,
+  }) => {
+    await context.addCookies([getSessionCookie(session.signedToken, baseURL!)]);
+
+    const uniqueId = Date.now().toString(36);
+    const testEmail = `e2e-${uniqueId}@test.rekurve.dev`;
+
+    await page.goto("/leads/new");
+    const form = new LeadFormSection(page);
+
+    // Step 1: Contact
+    await form.fillStep1({
+      firstName: "HubSpot",
+      lastName: `Sync ${uniqueId}`,
+      phone: "0412345678",
+      email: testEmail,
+    });
+    await form.selectSegmented("Preferred contact time", "Anytime");
+    await form.clickNext();
+
+    // Step 2: Land
+    await form.selectSegmented("Has land", "Yes");
+    await form.landAddressInput.waitFor({ state: "visible" });
+    await form.selectSegmented("Land registered", "Yes");
+    await form.landAddressInput.fill("42 Test Ave");
+    await form.landSqmInput.fill("500");
+    await form.landWidthInput.fill("20");
+    await form.landDepthInput.fill("25");
+    await form.clickNext();
+
+    // Step 3: Build
+    await form.selectSegmented("Property type", "First Home Buyer");
+    await form.budgetInput.fill("$700,000");
+    await form.selectSegmented("Seen broker", "Yes");
+    await form.selectSegmented("Construction timeline", "Ready Now");
+    await form.clickNext();
+
+    // Step 4: Additional
+    await form.notesTextarea.fill("E2E HubSpot sync test");
+    await form.clickSubmit();
+    await form.expectSuccess(`HubSpot Sync ${uniqueId}`);
+
+    // Verify: contact exists in HubSpot with correct properties
+    // Allow a brief delay for the HubSpot API call to complete
+    const contact = await findContactByEmail(testEmail);
+    expect(contact).not.toBeNull();
+    expect(contact!.properties.firstname).toBe("HubSpot");
+    expect(contact!.properties.lastname).toBe(`Sync ${uniqueId}`);
+    expect(contact!.properties.email).toBe(testEmail);
+    expect(contact!.properties.phone).toBe("0412345678");
+    expect(contact!.properties.has_land).toBe("true");
+    expect(contact!.properties.land_address).toBe("42 Test Ave");
+    expect(contact!.properties.land_size_sqm).toBe("500");
+    expect(contact!.properties.land_width).toBe("20");
+    expect(contact!.properties.land_depth).toBe("25");
+    expect(contact!.properties.property_type).toBe("first_home_buyer");
+    expect(contact!.properties.budget).toBe("$700,000");
+    expect(contact!.properties.construction_timeline).toBe("ready_now");
+    expect(contact!.properties.notes).toBe("E2E HubSpot sync test");
+    expect(contact!.properties.preferred_contact_time).toBe("anytime");
+
+    // Verify: local lead has hubspotContactId
+    const hubspotId = await getLeadHubSpotId(testEmail);
+    expect(hubspotId).toBe(contact!.id);
+  });
+
+  test("creating a lead with an existing HubSpot email updates instead of duplicating", async ({
+    context,
+    page,
+    baseURL,
+  }) => {
+    await context.addCookies([getSessionCookie(session.signedToken, baseURL!)]);
+
+    const uniqueId = Date.now().toString(36);
+    const testEmail = `e2e-${uniqueId}@test.rekurve.dev`;
+
+    // Seed: create a contact in HubSpot first
+    const seeded = await createTestContact({
+      firstname: "Existing",
+      lastname: "Contact",
+      email: testEmail,
+      phone: "0400000000",
+    });
+
+    // Create a lead in the app with the same email
+    await page.goto("/leads/new");
+    const form = new LeadFormSection(page);
+
+    await form.fillStep1({
+      firstName: "Updated",
+      lastName: `Dedup ${uniqueId}`,
+      phone: "0412345678",
+      email: testEmail,
+    });
+    await form.clickNext();
+
+    // Step 2: minimal land info
+    await form.selectSegmented("Has land", "No");
+    await form.clickNext();
+
+    // Step 3: minimal build info
+    await form.selectSegmented("Property type", "First Home Buyer");
+    await form.clickNext();
+
+    // Step 4: submit
+    await form.clickSubmit();
+    await form.expectSuccess(`Updated Dedup ${uniqueId}`);
+
+    // Verify: the seeded contact was UPDATED, not a new one created
+    const contact = await findContactByEmail(testEmail);
+    expect(contact).not.toBeNull();
+    expect(contact!.id).toBe(seeded.id); // Same contact ID — not a duplicate
+    expect(contact!.properties.firstname).toBe("Updated");
+    expect(contact!.properties.lastname).toBe(`Dedup ${uniqueId}`);
+
+    // Verify: local lead references the same HubSpot contact
+    const hubspotId = await getLeadHubSpotId(testEmail);
+    expect(hubspotId).toBe(seeded.id);
+  });
+});
+```
+
+### Success Criteria
+
+#### Automated Verification
+- [x] `make check` passes
+- [x] Tests skip gracefully when `HUBSPOT_ACCESS_TOKEN` is absent
+- [x] `yarn test:e2e:features -- hubspot-sync` passes against a live environment
+
+#### Manual Verification
+- [ ] Confirm the created contact is visible in the HubSpot UI with all Rekurve properties populated
+- [ ] Confirm the dedup test did not create a duplicate contact
+
+---
+
+## Phase 4: E2E Inbound Sync Tests
+
+### Overview
+
+Verify that changes made directly in HubSpot (property edits, contact deletion) propagate to the local leads table via webhook processing. These tests can only run against the **production deployment** — the HubSpot webhook target URL is manually configured to point to production only.
+
+### Changes Required
+
+#### 1. Inbound Tests (same file)
+
+**File**: `e2e/features/hubspot-sync.spec.ts` (appended)
+
+```typescript
+import {
+  archiveTestContact,
+  updateTestContact,
+  waitForLeadDeletion,
+  waitForLeadField,
+} from "../utils/hubspot-helper";
+
+test.describe("HubSpot Inbound Sync — E2E", () => {
+  test.skip(
+    !process.env.HUBSPOT_ACCESS_TOKEN ||
+      !process.env.DATABASE_URL ||
+      !process.env.HUBSPOT_WEBHOOK_ACTIVE,
+    "Requires HUBSPOT_ACCESS_TOKEN, DATABASE_URL, and HUBSPOT_WEBHOOK_ACTIVE — only against production (webhook target is production-only)",
+  );
+
+  let session: TestSession;
+
+  test.beforeAll(async () => {
+    session = await createTestSession();
+    await deleteTestContacts();
+    await deleteTestLeads();
+  });
+
+  test.afterAll(async () => {
+    await deleteTestContacts();
+    await deleteTestLeads();
+    await deleteTestSession(session.userId);
+  });
+
+  test("editing a contact's phone in HubSpot updates the local lead", async ({
+    context,
+    page,
+    baseURL,
+  }) => {
+    test.setTimeout(60_000); // Webhook latency
+
+    await context.addCookies([getSessionCookie(session.signedToken, baseURL!)]);
+
+    const uniqueId = Date.now().toString(36);
+    const testEmail = `e2e-${uniqueId}@test.rekurve.dev`;
+
+    // Step 1: Create a lead via the app (establishes the HubSpot link)
+    await page.goto("/leads/new");
+    const form = new LeadFormSection(page);
+    await form.fillStep1({
+      firstName: "Inbound",
+      lastName: `Phone ${uniqueId}`,
+      phone: "0412345678",
+      email: testEmail,
+    });
+    await form.clickNext();
+    await form.selectSegmented("Has land", "No");
+    await form.clickNext();
+    await form.selectSegmented("Property type", "First Home Buyer");
+    await form.clickNext();
+    await form.clickSubmit();
+    await form.expectSuccess(`Inbound Phone ${uniqueId}`);
+
+    // Step 2: Get the hubspotContactId from the local DB
+    const hubspotId = await getLeadHubSpotId(testEmail);
+    expect(hubspotId).not.toBeNull();
+
+    // Step 3: Update the contact's phone in HubSpot directly
+    await updateTestContact(hubspotId!, { phone: "0499999999" });
+
+    // Step 4: Wait for the webhook to update the local lead
+    await waitForLeadField(testEmail, "phone", "0499999999");
+  });
+
+  test("deleting a contact in HubSpot removes the local lead", async ({
+    context,
+    page,
+    baseURL,
+  }) => {
+    test.setTimeout(60_000); // Webhook latency
+
+    await context.addCookies([getSessionCookie(session.signedToken, baseURL!)]);
+
+    const uniqueId = Date.now().toString(36);
+    const testEmail = `e2e-${uniqueId}@test.rekurve.dev`;
+
+    // Step 1: Create a lead via the app
+    await page.goto("/leads/new");
+    const form = new LeadFormSection(page);
+    await form.fillStep1({
+      firstName: "Inbound",
+      lastName: `Delete ${uniqueId}`,
+      phone: "0412345678",
+      email: testEmail,
+    });
+    await form.clickNext();
+    await form.selectSegmented("Has land", "No");
+    await form.clickNext();
+    await form.selectSegmented("Property type", "First Home Buyer");
+    await form.clickNext();
+    await form.clickSubmit();
+    await form.expectSuccess(`Inbound Delete ${uniqueId}`);
+
+    // Step 2: Get the hubspotContactId
+    const hubspotId = await getLeadHubSpotId(testEmail);
+    expect(hubspotId).not.toBeNull();
+
+    // Step 3: Archive the contact in HubSpot
+    await archiveTestContact(hubspotId!);
+
+    // Step 4: Wait for the webhook to delete the local lead
+    await waitForLeadDeletion(testEmail);
+  });
+});
+```
+
+### Success Criteria
+
+#### Automated Verification
+- [x] `make check` passes
+- [x] Tests skip gracefully when `HUBSPOT_WEBHOOK_ACTIVE` is absent
+- [x] Tests pass against the production deployment (the only environment with webhook delivery)
+
+#### Manual Verification
+- [ ] After the phone update test, verify the HubSpot webhook delivery log shows the event was sent
+- [ ] After the deletion test, verify the lead is gone from both the app and the local DB
+
+---
+
+## Phase 5: Update Setup Guide
+
+### Overview
+
+Replace the manual property creation steps in the setup guide with `make hubspot_setup`. Keep the webhook subscription steps (still manual for private apps).
+
+### Changes Required
+
+#### 1. Setup Guide
+
+**File**: `thoughts/guides/hubspot-manual-setup.md`
+
+Replace Steps 1-3 (property group + custom properties + verify existing) with:
+
+```markdown
+## Step 1: Provision Custom Properties
+
+Run the automated setup script. This creates the "Rekurve" property group and
+all 7 custom contact properties. The script is idempotent — safe to run
+multiple times.
+
+\`\`\`bash
+make hubspot_setup
+\`\`\`
+
+This provisions:
+
+| Property | Type | Options |
+|----------|------|---------|
+| `preferred_contact_time` | Dropdown select | weekdays, weekends, anytime |
+| `land_width` | Single-line text | — |
+| `land_depth` | Single-line text | — |
+| `lead_score` | Number | — |
+| `lead_stage` | Dropdown select | unqualified, nurture, warm, hot |
+| `notes` | Multi-line text | — |
+| `lead_source` | Dropdown select | walk_in, referral, social, web, other |
+
+### Verify Existing Properties
+
+The following custom properties should already exist from Epic 1. If any are
+missing, create them manually in the HubSpot UI under the **Rekurve** group:
+
+- `has_land` — Dropdown select: `true` / `false`
+- `land_registered` — Dropdown select: `true` / `false`
+- `land_address` — Single-line text
+- `land_size_sqm` — Single-line text
+- `property_type` — Dropdown select: `single_storey`, `double_storey`, `investment`, `upsize`, `downsize`, `first_home_buyer`
+- `budget` — Single-line text
+- `seen_broker` — Dropdown select: `true` / `false`
+- `construction_timeline` — Dropdown select: `ready_now`, `3_6_months`, `12_months_plus`
+- `resolve_finance_opted_in` — Dropdown select: `true` / `false`
+```
+
+Renumber the remaining steps:
+- Old Step 4 (webhook subscriptions) becomes Step 2
+- Old Step 5 (verification) becomes Step 3
+
+### Success Criteria
+
+#### Automated Verification
+- [x] `make check` passes
+- [x] No broken markdown links or formatting
+
+#### Manual Verification
+- [ ] Guide is clear and actionable
+- [ ] Steps flow logically with the new numbering
+
+---
+
+## Performance Considerations
+
+- **E2E test duration**: Outbound tests add ~10-15s each (form fill + HubSpot API verification). Inbound tests add ~30-60s each due to webhook latency polling.
+- **HubSpot API rate limits**: Test cleanup searches for test contacts by email pattern — a single search call per cleanup, well within HubSpot's 100 requests/10 seconds limit.
+- **Parallel test execution**: The HubSpot sync tests use unique emails per test (`Date.now().toString(36)`), so parallel execution across Playwright workers is safe.
+
+## References
+
+- Parent issue: #102 (HubSpot Contact Sync on Lead Create/Update)
+- Implementation plan: `thoughts/plans/2026-04-08-102-hubspot-contact-sync.md`
+- Setup guide: `thoughts/guides/hubspot-manual-setup.md`
+- Existing E2E patterns: `e2e/features/leads-crud.spec.ts`, `e2e/utils/auth-helper.ts`
+- HubSpot Properties API: https://developers.hubspot.com/docs/reference/api/crm/properties
+- `@hubspot/api-client` v13.5.0: `node_modules/@hubspot/api-client/lib/codegen/crm/properties/`


### PR DESCRIPTION
## Context/Motivation

The pilot consultant (Creation Homes QLD) uses HubSpot as their CRM. Every lead captured in the Rekurve app must exist in HubSpot as a contact so the consultant has one unified record. Epic 1 (#85) established the HubSpot API connection and a webhook endpoint that only validated signatures. This PR wires the actual sync logic: lead create/update now flows through HubSpot first, and the webhook handler processes inbound changes from HubSpot into the local `leads` table.

Per project convention, HubSpot is the source of truth for contact data -- writes go to HubSpot first, the local DB mirrors that state, and contact changes originating in HubSpot reach the app via webhooks.

Closes #102.

## Description of Changes

### Outbound sync (`src/server/api/routers/leads.ts`, `src/server/hubspot/`)
- `leads.create` now extracts mapped fields, dedups against HubSpot by email then phone, and creates or updates the contact before inserting the local record with `hubspotContactId` populated
- `leads.update` sends only mapped fields to HubSpot (when the lead is linked), then updates the local DB -- non-mapped fields like `preferredEstates` skip HubSpot entirely
- Partial-failure path: if HubSpot succeeds but the local write fails, the tRPC error message includes the HubSpot contact ID so the client can retry the local write
- `findExistingContact` uses filter-based search (not the existing text-query `searchContacts`) for exact email/phone matches

### Property map extended (`src/server/hubspot/properties.ts`)
- 7 new mappings: `preferredContactTime`, `landWidth`, `landDepth`, `leadScore`, `leadStage`, `notes`, `leadSource` -- now 20 fields total
- `toAppField(hubspotProp)` -- reverse lookup for the webhook handler
- `coerceFromHubSpot(field, value)` -- converts HubSpot's all-string responses back to booleans (`hasLand`, `landRegistered`, `seenBroker`, `resolveFinanceOptedIn`) and integers (`leadScore`)

### Inbound webhook processing (`src/app/api/hubspot/webhook/route.ts`)
- `contact.creation`: fetches the full contact (creation events don't include properties) and upserts the local lead keyed on `hubspotContactId`
- `contact.propertyChange`: maps the changed property back to the app field, coerces the value, updates the local row -- unmapped properties are ignored
- `contact.deletion`: removes the local lead by `hubspotContactId`
- Per-event `try/catch` so a single failure doesn't block the batch, and the endpoint returns 200 even on errors to prevent HubSpot retry storms

### Property provisioning script (`scripts/hubspot/setup.ts`)
- `make hubspot_setup` runs `ensureAllProperties()` which idempotently creates the "Rekurve" property group and all 16 custom contact properties (Epic 1's 9 + this PR's 7). 409 conflicts are swallowed; non-409 errors propagate
- Boolean fields use `booleancheckbox` with `true`/`false` options (the correct HubSpot type for booleans)
- Standalone client under `scripts/hubspot/client.ts` loads env via `dotenv/config` so the CLI doesn't need to satisfy the full app env schema

### E2E tests (`e2e/features/hubspot-sync.spec.ts`, `e2e/utils/hubspot-helper.ts`)
- Outbound: verifies that creating a lead in the app populates a HubSpot contact with all Rekurve properties, and that dedup updates an existing contact instead of duplicating
- Inbound: verifies that editing a contact's phone in HubSpot and archiving a contact both propagate to the local lead via webhook processing
- Inbound suite is gated on `HUBSPOT_WEBHOOK_ACTIVE` because the webhook target URL is production-only for HubSpot private apps
- Helper is self-contained (own `Client` + Neon instances) and cleans up by the `e2e-%@test.rekurve.dev` email pattern

### Docs (`thoughts/guides/hubspot-manual-setup.md`)
- Updated setup guide: `make hubspot_setup` replaces the manual property-creation walkthrough; webhook subscription steps stay manual (not programmable for private apps)
- Notes the required `crm.schemas.contacts.write` scope

## Testing Information

- [x] Unit tests pass (`make test` -- 140 tests across 13 files, 0 failures)
- [x] Lint + typecheck pass (`make check` -- clean on 200 files)
- [ ] E2E tests pass against production (`HUBSPOT_WEBHOOK_ACTIVE` required for inbound suite)
- [ ] Manual verification against live HubSpot account completed

**Test steps:**
1. Run `make hubspot_setup` against the live HubSpot account -- verify the Rekurve property group and 16 custom properties appear, and that a second run is a no-op (409s swallowed)
2. Create a lead via `/leads/new` -- confirm a matching contact appears in HubSpot with all mapped properties populated, and that the local lead row has `hubspot_contact_id` set
3. Create a second lead with the same email -- confirm no duplicate is created in HubSpot and the existing contact is updated instead
4. Update a lead's budget/phone via the app -- confirm the HubSpot contact reflects the change
5. Edit a contact's phone directly in HubSpot -- confirm the local lead updates within ~30s (requires production deployment with webhook subscriptions active)
6. Archive a contact in HubSpot -- confirm the local lead is removed
7. Run `yarn test:e2e:features hubspot-sync` against a live environment with `HUBSPOT_ACCESS_TOKEN` set

## Screenshots/Videos

N/A -- no UI changes. All sync happens server-side.

## Relevant Links

- Closes #102
- Related to #86 (Epic 2: Lead Management + AI Qualification Scoring)
- Depends on #85 (Epic 1: HubSpot API connection -- merged)
- Depends on #96 (tRPC Leads Router -- merged)
- Implementation plans: `thoughts/plans/2026-04-08-102-hubspot-contact-sync.md`, `thoughts/plans/2026-04-09-102-hubspot-property-setup-e2e.md`
- Setup guide: `thoughts/guides/hubspot-manual-setup.md`

## Breaking Changes

None. The HubSpot integration is additive: existing leads without a `hubspotContactId` continue to work, and the update path skips HubSpot when the lead is unlinked. One operational step is required before merging to production:

- Run `make hubspot_setup` against the production HubSpot account to provision the custom properties
- Add the `crm.schemas.contacts.write` scope to the Rekurve private app (required by the setup script)
- Ensure the three webhook subscriptions (`contact.creation`, `contact.propertyChange`, `contact.deletion`) are active and pointed at the production webhook URL
