### PR TITLE
feat(leads): lead profile page with score breakdown, gaps, and inline edit (#101)

### DIFF
--- a/.claude/prompts/ralph-implement.md
+++ b/.claude/prompts/ralph-implement.md
@@ -23,6 +23,13 @@ You are implementing a single section of an implementation plan. The tasks, file
 - Attempt to sequence multiple sections — the shell script handles that
 - Create git commits — the validate phase handles that
 
+## Prior Attempts
+
+If a "Prior attempts" section appears in your prompt, this task has been tried before. Read the notes carefully:
+- Do NOT repeat approaches that already failed
+- Build on any partial progress — check `git diff` and `git status` to see what's already changed
+- If a prior attempt succeeded at implementation but failed validation, the code changes may already be in place
+
 ## When Reality Diverges from the Tasks
 
 If the codebase doesn't match what the tasks expect:

--- a/.claude/prompts/ralph-validate.md
+++ b/.claude/prompts/ralph-validate.md
@@ -72,6 +72,13 @@ for the four core dashboard routes.
 [ralph] thoughts/plans/2026-04-01-dashboard-app-shell.md §2.1
 ```
 
+## Prior Attempts
+
+If a "Prior attempts" section appears in your prompt, this task has been tried before. Read the notes carefully:
+- Do NOT repeat approaches that already failed
+- Check `git diff` and `git status` to see what's already changed from prior attempts
+- Focus on fixing the specific issue that caused the previous failure
+
 ## On Failure
 
 Do NOT create a commit. Explain what failed and why.

--- a/.claude/skills/plan-to-ralph-spec/SKILL.md
+++ b/.claude/skills/plan-to-ralph-spec/SKILL.md
@@ -5,7 +5,7 @@ description: Convert a markdown implementation plan to a JSON spec file for ralp
 
 # Plan to Spec
 
-Convert a markdown implementation plan into a structured `.spec.json` file that ralph.sh uses for execution.
+Convert a markdown implementation plan into a structured `.spec.json` file that ralph.sh uses for execution. Each checkbox task in the plan becomes its own entry in the spec — ralph processes one task at a time.
 
 ## Invocation
 
@@ -18,31 +18,39 @@ The user provides a path to a markdown plan:
 
 1. Read the markdown plan file completely
 2. Identify all **leaf-level sections** that contain checkbox task items (`- [ ]` lines)
-3. For each section, extract:
-   - **id**: A normalized, stable, unique identifier derived from the heading structure (e.g., `"1.1"`, `"p2.cat1"`, `"task-1"`). Use numeric IDs when headings have numbers; use slugified IDs when they don't.
-   - **title**: The human-readable section title (heading text without the `#` prefix or numbering)
-   - **tasks**: Array of task strings from checkbox items (`- [ ]` lines), stripped of the `- [ ]` prefix
-   - **files**: Array of file paths mentioned in the section body (backtick-quoted paths matching `src/`, `e2e/`, `scripts/`, `.claude/`, `.github/`, `thoughts/`, `docs/`, or common extensions)
-   - **verify**: Array of make/shell commands from the section's success criteria. Default to `["make check"]` if none specified
+3. For each **individual checkbox task** within each section, create a separate entry:
+   - **id**: A unique identifier using the section number plus a task index (e.g., `"1.1.1"`, `"1.1.2"`, `"1.2.1"`). The first two segments identify the section, the last segment is the 1-based task index within that section.
+   - **title**: The section title with a task index suffix (e.g., `"Add test-mode branch (1/6)"`, `"Add test-mode branch (2/6)"`)
+   - **task**: A single task string from one checkbox item (`- [ ]` line), stripped of the `- [ ]` prefix
+   - **files**: Array of file paths mentioned in the parent section body (backtick-quoted paths matching `src/`, `e2e/`, `scripts/`, `.claude/`, `.github/`, `thoughts/`, `docs/`, or common extensions). Inherited by all tasks from the same section.
+   - **verify**: Array of make/shell commands from the parent section's success criteria. Default to `["make check"]` if none specified. Inherited by all tasks from the same section.
 4. Skip sections with zero checkbox items — log a warning for each
-5. Phases or groups (e.g., "Phase 1", "Phase 2") become ID prefixes on their child sections, not sections themselves. Only leaf-level items with tasks become sections.
+5. Phases or groups (e.g., "Phase 1", "Phase 2") become ID prefixes on their child sections, not entries themselves.
 6. Set all `state` fields to `"pending"`
 7. Write to the same directory as the plan, replacing `.md` with `.spec.json`
-8. Print a summary: section count, any warnings
+8. Print a summary: total task count, section count, any warnings
 
 ## Output Schema
 
 ```json
 {
-  "version": 1,
+  "version": 2,
   "plan": "<relative path to source markdown plan>",
   "title": "<plan title from first H1>",
-  "sections": [
+  "tasks": [
     {
-      "id": "1.1",
-      "title": "Section Title",
-      "tasks": ["Task description 1", "Task description 2"],
-      "files": ["src/app/page.tsx", "src/lib/utils.ts"],
+      "id": "1.1.1",
+      "title": "Add test-mode branch (1/6)",
+      "task": "Open `src/instrumentation-client.ts` and add a global declaration block",
+      "files": ["src/instrumentation-client.ts"],
+      "verify": ["make check"],
+      "state": "pending"
+    },
+    {
+      "id": "1.1.2",
+      "title": "Add test-mode branch (2/6)",
+      "task": "Add the isE2E detection line after the global declaration",
+      "files": ["src/instrumentation-client.ts"],
       "verify": ["make check"],
       "state": "pending"
     }
@@ -57,4 +65,7 @@ The user provides a path to a markdown plan:
 - The spec file must be valid JSON (use `jq .` to verify before writing)
 - If a section's success criteria mention specific commands (`make test`, `make build`, `make test_e2e`), include those in `verify` instead of the default
 - File paths in `files` should be relative to the repo root
-- IDs must be unique across all sections in the spec
+- IDs must be unique across all entries in the spec
+- The top-level array key is `"tasks"`, not `"sections"`
+- Each entry has a singular `"task"` field (string), not a plural `"tasks"` field (array)
+- Do NOT include a `notes` field — ralph.sh populates this at runtime with progress updates from each attempt

--- a/e2e/features/lead-profile.spec.ts
+++ b/e2e/features/lead-profile.spec.ts
@@ -1,0 +1,277 @@
+import { expect, test } from "@playwright/test";
+import { LeadFormSection } from "../pages/sections/lead-form.section";
+import { LeadProfileSection } from "../pages/sections/lead-profile.section";
+import { QuickCaptureSection } from "../pages/sections/quick-capture.section";
+import {
+  createTestSession,
+  deleteTestSession,
+  type TestSession,
+  uniquePhone,
+} from "../utils/auth-helper";
+import { getLeadIdByPhone } from "../utils/leads-helper";
+import { getSessionCookie } from "../utils/session-cookie";
+
+test.describe("Lead Profile — E2E", () => {
+  test.skip(
+    !process.env.DATABASE_URL,
+    "Requires direct DB access — skipped in CI",
+  );
+
+  let session: TestSession;
+
+  test.beforeAll(async () => {
+    session = await createTestSession();
+  });
+
+  test.afterAll(async () => {
+    await deleteTestSession(session.userId);
+  });
+
+  test("quick capture lead: score 0, unqualified, 5 gaps", async ({
+    context,
+    page,
+    baseURL,
+  }) => {
+    await context.addCookies([getSessionCookie(session.signedToken, baseURL!)]);
+
+    const phone = uniquePhone();
+    const uniqueId = Date.now().toString(36);
+    const lastName = `Unqualified ${uniqueId}`;
+
+    await page.goto("/dashboard");
+
+    const quickCapture = new QuickCaptureSection(page);
+    await quickCapture.open();
+    await quickCapture.fill({
+      firstName: "Quick",
+      lastName,
+      phone,
+    });
+    await quickCapture.submit();
+    await quickCapture.expectSuccessToast(`Quick ${lastName}`);
+
+    const leadId = await getLeadIdByPhone(phone);
+    await page.goto(`/leads/${leadId}`);
+
+    const profile = new LeadProfileSection(page);
+    await profile.waitForLoaded();
+
+    await profile.expectScore(0);
+    await profile.expectStage("unqualified");
+    await profile.expectGapCount(5);
+    await profile.expectNextQuestionMatches(/land/i);
+  });
+
+  test("fully qualified lead: score 85, hot, 0 gaps", async ({
+    context,
+    page,
+    baseURL,
+  }) => {
+    await context.addCookies([getSessionCookie(session.signedToken, baseURL!)]);
+
+    const uniqueId = Date.now().toString(36);
+    const phone = uniquePhone();
+    const email = `e2e-${uniqueId}@test.rekurve.dev`;
+    const lastName = `Hot ${uniqueId}`;
+
+    await page.goto("/leads/new");
+
+    const form = new LeadFormSection(page);
+    await form.fillStep1({ firstName: "E2E", lastName, phone, email });
+    await form.clickNext();
+
+    // Step 2: Land
+    await form.selectSegmented("Has land", "Yes");
+    await form.landAddressInput.waitFor({ state: "visible" });
+    await form.selectSegmented("Land registered", "Yes");
+    await form.landAddressInput.fill("123 Test St");
+    await form.landSqmInput.fill("450");
+    await form.landWidthInput.fill("15");
+    await form.landDepthInput.fill("30");
+    await form.clickNext();
+
+    // Step 3: Build
+    await form.selectSegmented("Property type", "First Home Buyer");
+    await form.budgetInput.fill("$650,000");
+    await form.selectSegmented("Seen broker", "Yes");
+    await form.selectSegmented("Construction timeline", "Ready Now");
+    await form.clickNext();
+
+    // Step 4: Additional — leave defaults
+    await form.clickSubmit();
+    await form.expectSuccess(`E2E ${lastName}`);
+
+    const leadId = await getLeadIdByPhone(phone);
+    await page.goto(`/leads/${leadId}`);
+
+    const profile = new LeadProfileSection(page);
+    await profile.waitForLoaded();
+
+    await profile.expectScore(85);
+    await profile.expectStage("hot");
+    await profile.expectGapCount(0);
+  });
+
+  test("score breakdown shows all 6 factors with correct max scores", async ({
+    context,
+    page,
+    baseURL,
+  }) => {
+    await context.addCookies([getSessionCookie(session.signedToken, baseURL!)]);
+
+    const uniqueId = Date.now().toString(36);
+    const phone = uniquePhone();
+    const email = `e2e-${uniqueId}@test.rekurve.dev`;
+    const lastName = `Breakdown ${uniqueId}`;
+
+    await page.goto("/leads/new");
+
+    const form = new LeadFormSection(page);
+    await form.fillStep1({ firstName: "E2E", lastName, phone, email });
+    await form.clickNext();
+
+    await form.selectSegmented("Has land", "Yes");
+    await form.landAddressInput.waitFor({ state: "visible" });
+    await form.selectSegmented("Land registered", "Yes");
+    await form.landAddressInput.fill("45 Parade St");
+    await form.landSqmInput.fill("450");
+    await form.landWidthInput.fill("15");
+    await form.landDepthInput.fill("30");
+    await form.clickNext();
+
+    await form.selectSegmented("Property type", "First Home Buyer");
+    await form.budgetInput.fill("$650,000");
+    await form.selectSegmented("Seen broker", "Yes");
+    await form.selectSegmented("Construction timeline", "Ready Now");
+    await form.clickNext();
+
+    await form.clickSubmit();
+    await form.expectSuccess(`E2E ${lastName}`);
+
+    const leadId = await getLeadIdByPhone(phone);
+    await page.goto(`/leads/${leadId}`);
+
+    const profile = new LeadProfileSection(page);
+    await profile.waitForLoaded();
+
+    await profile.expectFactor("land", 30, 30);
+    await profile.expectFactor("finance", 15, 25);
+    await profile.expectFactor("timeline", 20, 20);
+    await profile.expectFactor("budget", 10, 10);
+    await profile.expectFactor("propertyType", 10, 10);
+    await profile.expectFactor("engagement", 0, 5);
+    await profile.expectScore(85);
+  });
+
+  test("suggested next question targets the highest-impact gap", async ({
+    context,
+    page,
+    baseURL,
+  }) => {
+    await context.addCookies([getSessionCookie(session.signedToken, baseURL!)]);
+
+    const uniqueId = Date.now().toString(36);
+    const phone = uniquePhone();
+    const email = `e2e-${uniqueId}@test.rekurve.dev`;
+    const lastName = `NoLand ${uniqueId}`;
+
+    await page.goto("/leads/new");
+
+    const form = new LeadFormSection(page);
+    await form.fillStep1({ firstName: "E2E", lastName, phone, email });
+    await form.clickNext();
+
+    // Step 2: skip land entirely (hasLand left null) — land becomes the
+    // highest-impact gap and picks up the canonical "land" next-question.
+    await form.clickNext();
+
+    // Step 3: everything else filled
+    await form.selectSegmented("Property type", "First Home Buyer");
+    await form.budgetInput.fill("$650,000");
+    await form.selectSegmented("Seen broker", "Yes");
+    await form.selectSegmented("Construction timeline", "Ready Now");
+    await form.clickNext();
+
+    await form.clickSubmit();
+    await form.expectSuccess(`E2E ${lastName}`);
+
+    const leadId = await getLeadIdByPhone(phone);
+    await page.goto(`/leads/${leadId}`);
+
+    const profile = new LeadProfileSection(page);
+    await profile.waitForLoaded();
+
+    // Land gap should be present and the next question should mention land.
+    await expect(profile.gapItem("land")).toBeVisible();
+    await profile.expectNextQuestionMatches(/land/i);
+  });
+
+  test("edit a lead's qualification fields: score and stage update in place without reload", async ({
+    context,
+    page,
+    baseURL,
+  }) => {
+    await context.addCookies([getSessionCookie(session.signedToken, baseURL!)]);
+
+    // 1. Create an unqualified lead via quick capture
+    const phone = uniquePhone();
+    const uniqueId = Date.now().toString(36);
+    const lastName = `Edit ${uniqueId}`;
+
+    await page.goto("/dashboard");
+
+    const quickCapture = new QuickCaptureSection(page);
+    await quickCapture.open();
+    await quickCapture.fill({ firstName: "Quick", lastName, phone });
+    await quickCapture.submit();
+    await quickCapture.expectSuccessToast(`Quick ${lastName}`);
+
+    const leadId = await getLeadIdByPhone(phone);
+
+    // 2. Navigate to profile and assert unqualified
+    await page.goto(`/leads/${leadId}`);
+    const profile = new LeadProfileSection(page);
+    await profile.waitForLoaded();
+
+    await profile.expectScore(0);
+    await profile.expectStage("unqualified");
+
+    // 3. Click Edit
+    const url = page.url();
+    await profile.editButton.click();
+    const editForm = page.locator('[data-testid="lead-profile-edit-form"]');
+    await expect(editForm).toBeVisible();
+
+    // 4. Fill qualification fields using the form step controls
+    const formPage = new LeadFormSection(page);
+    await formPage.selectSegmented("Has land", "Yes");
+    await formPage.landAddressInput.waitFor({ state: "visible" });
+    await formPage.selectSegmented("Land registered", "Yes");
+    await formPage.landSqmInput.fill("450");
+    await formPage.landWidthInput.fill("15");
+    await formPage.landDepthInput.fill("30");
+    await formPage.selectSegmented("Property type", "First Home Buyer");
+    await formPage.budgetInput.fill("$650,000");
+    await formPage.selectSegmented("Seen broker", "Yes");
+    await formPage.selectSegmented("Construction timeline", "Ready Now");
+
+    // 5. Save
+    await profile.saveButton.click();
+
+    // 6. Wait for edit form to close and assert new values
+    await expect(editForm).not.toBeVisible({ timeout: 15_000 });
+
+    await profile.expectScore(85);
+    await profile.expectStage("hot");
+    await profile.expectGapCount(0);
+
+    // URL did not change (no full navigation)
+    expect(page.url()).toBe(url);
+
+    // 7. Reload and verify persistence
+    await page.reload();
+    await profile.waitForLoaded();
+    await profile.expectScore(85);
+    await profile.expectStage("hot");
+  });
+});

--- a/e2e/features/lead-profile.spec.ts
+++ b/e2e/features/lead-profile.spec.ts
@@ -8,6 +8,7 @@ import {
   type TestSession,
   uniquePhone,
 } from "../utils/auth-helper";
+import { cleanupTestLeadsByPhone } from "../utils/hubspot-helper";
 import { getLeadIdByPhone } from "../utils/leads-helper";
 import { getSessionCookie } from "../utils/session-cookie";
 
@@ -18,12 +19,14 @@ test.describe("Lead Profile — E2E", () => {
   );
 
   let session: TestSession;
+  const phones: string[] = [];
 
   test.beforeAll(async () => {
     session = await createTestSession();
   });
 
   test.afterAll(async () => {
+    await cleanupTestLeadsByPhone(phones);
     await deleteTestSession(session.userId);
   });
 
@@ -35,6 +38,7 @@ test.describe("Lead Profile — E2E", () => {
     await context.addCookies([getSessionCookie(session.signedToken, baseURL!)]);
 
     const phone = uniquePhone();
+    phones.push(phone);
     const uniqueId = Date.now().toString(36);
     const lastName = `Unqualified ${uniqueId}`;
 
@@ -71,6 +75,7 @@ test.describe("Lead Profile — E2E", () => {
 
     const uniqueId = Date.now().toString(36);
     const phone = uniquePhone();
+    phones.push(phone);
     const email = `e2e-${uniqueId}@test.rekurve.dev`;
     const lastName = `Hot ${uniqueId}`;
 
@@ -121,6 +126,7 @@ test.describe("Lead Profile — E2E", () => {
 
     const uniqueId = Date.now().toString(36);
     const phone = uniquePhone();
+    phones.push(phone);
     const email = `e2e-${uniqueId}@test.rekurve.dev`;
     const lastName = `Breakdown ${uniqueId}`;
 
@@ -172,6 +178,7 @@ test.describe("Lead Profile — E2E", () => {
 
     const uniqueId = Date.now().toString(36);
     const phone = uniquePhone();
+    phones.push(phone);
     const email = `e2e-${uniqueId}@test.rekurve.dev`;
     const lastName = `NoLand ${uniqueId}`;
 

--- a/e2e/features/leads-crud.spec.ts
+++ b/e2e/features/leads-crud.spec.ts
@@ -8,6 +8,7 @@ import {
   type TestSession,
   uniquePhone,
 } from "../utils/auth-helper";
+import { cleanupTestLeadsByPhone } from "../utils/hubspot-helper";
 import { getSessionCookie } from "../utils/session-cookie";
 
 test.describe("Leads CRUD — E2E", () => {
@@ -17,15 +18,14 @@ test.describe("Leads CRUD — E2E", () => {
   );
 
   let session: TestSession;
+  const phones: string[] = [];
 
   test.beforeAll(async () => {
     session = await createTestSession();
   });
 
   test.afterAll(async () => {
-    // Leads and HubSpot contacts created here are cleaned up by
-    // e2e/utils/global-teardown.ts after every worker has finished — doing it
-    // here would race with concurrent hubspot-sync tests in other workers.
+    await cleanupTestLeadsByPhone(phones);
     await deleteTestSession(session.userId);
   });
 
@@ -43,12 +43,14 @@ test.describe("Leads CRUD — E2E", () => {
 
     const form = new LeadFormSection(page);
     const uniqueId = Date.now().toString(36);
+    const phone = uniquePhone();
+    phones.push(phone);
 
     // Step 1: Contact
     await form.fillStep1({
       firstName: "E2E",
       lastName: `Test ${uniqueId}`,
-      phone: uniquePhone(),
+      phone,
       email: `e2e-${uniqueId}@test.rekurve.dev`,
     });
     await form.selectSegmented("Preferred contact time", "Anytime");
@@ -131,6 +133,8 @@ test.describe("Leads CRUD — E2E", () => {
 
     const quickCapture = new QuickCaptureSection(page);
     const uniqueId = Date.now().toString(36);
+    const phone = uniquePhone();
+    phones.push(phone);
 
     await quickCapture.open();
     await expect(quickCapture.firstNameInput).toBeFocused();
@@ -138,7 +142,7 @@ test.describe("Leads CRUD — E2E", () => {
     await quickCapture.fill({
       firstName: "Quick",
       lastName: `Capture ${uniqueId}`,
-      phone: uniquePhone(),
+      phone,
       notes: "Met at BBQ",
     });
     await quickCapture.submit();

--- a/e2e/pages/sections/lead-profile.section.ts
+++ b/e2e/pages/sections/lead-profile.section.ts
@@ -1,0 +1,114 @@
+import type { Locator, Page } from "@playwright/test";
+import { expect } from "@playwright/test";
+
+type Stage = "unqualified" | "nurture" | "warm" | "hot";
+
+const STAGE_LABELS: Record<Stage, string> = {
+  unqualified: "Unqualified",
+  nurture: "Nurture",
+  warm: "Warm",
+  hot: "Hot",
+};
+
+export class LeadProfileSection {
+  readonly page: Page;
+
+  readonly header: Locator;
+  readonly name: Locator;
+  readonly phoneLink: Locator;
+  readonly emailLink: Locator;
+  readonly scoreBadge: Locator;
+  readonly stageBadge: Locator;
+  readonly lastContacted: Locator;
+
+  readonly editButton: Locator;
+  readonly saveButton: Locator;
+  readonly cancelButton: Locator;
+
+  readonly scoreBreakdown: Locator;
+  readonly gapsCard: Locator;
+  readonly gapsList: Locator;
+  readonly gapsEmpty: Locator;
+  readonly nextQuestion: Locator;
+  readonly conversationHistory: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+
+    this.header = page.locator('[data-testid="lead-profile-header"]');
+    this.name = page.locator('[data-testid="lead-profile-name"]');
+    this.phoneLink = page.locator('[data-testid="lead-profile-phone"]');
+    this.emailLink = page.locator('[data-testid="lead-profile-email"]');
+    this.scoreBadge = page.locator('[data-testid="lead-profile-score-badge"]');
+    this.stageBadge = page.locator('[data-testid="lead-profile-stage"]');
+    this.lastContacted = page.locator(
+      '[data-testid="lead-profile-last-contacted"]',
+    );
+
+    this.editButton = page.locator('[data-testid="lead-profile-edit-btn"]');
+    this.saveButton = page.locator('[data-testid="lead-profile-save-btn"]');
+    this.cancelButton = page.locator('[data-testid="lead-profile-cancel-btn"]');
+
+    this.scoreBreakdown = page.locator(
+      '[data-testid="lead-profile-score-breakdown"]',
+    );
+    this.gapsCard = page.locator('[data-testid="lead-profile-gaps-card"]');
+    this.gapsList = page.locator('[data-testid="lead-profile-gaps-list"]');
+    this.gapsEmpty = page.locator('[data-testid="lead-profile-gaps-empty"]');
+    this.nextQuestion = page.locator(
+      '[data-testid="lead-profile-next-question"]',
+    );
+    this.conversationHistory = page.locator(
+      '[data-testid="lead-profile-conversation-history"]',
+    );
+  }
+
+  factorRow(key: string): Locator {
+    return this.page.locator(
+      `[data-testid="lead-profile-score-factor-${key}"]`,
+    );
+  }
+
+  factorValue(key: string): Locator {
+    return this.page.locator(
+      `[data-testid="lead-profile-score-factor-${key}-value"]`,
+    );
+  }
+
+  gapItem(field: string): Locator {
+    return this.page.locator(`[data-testid="lead-profile-gap-item-${field}"]`);
+  }
+
+  async waitForLoaded() {
+    await expect(this.header).toBeVisible({ timeout: 10_000 });
+  }
+
+  async expectScore(score: number) {
+    await expect(this.scoreBadge).toContainText(String(score));
+  }
+
+  async expectStage(stage: Stage) {
+    await expect(this.stageBadge).toHaveText(STAGE_LABELS[stage]);
+  }
+
+  async expectGapCount(count: number) {
+    if (count === 0) {
+      await expect(this.gapsEmpty).toBeVisible();
+      await expect(this.nextQuestion).not.toBeVisible();
+      return;
+    }
+    await expect(this.gapsList).toBeVisible();
+    await expect(
+      this.gapsList.locator('[data-testid^="lead-profile-gap-item-"]'),
+    ).toHaveCount(count);
+  }
+
+  async expectFactor(key: string, score: number, max: number) {
+    await expect(this.factorValue(key)).toHaveText(`${score}/${max}`);
+  }
+
+  async expectNextQuestionMatches(pattern: RegExp) {
+    await expect(this.nextQuestion).toBeVisible();
+    await expect(this.nextQuestion).toContainText(pattern);
+  }
+}

--- a/e2e/utils/auth-helper.ts
+++ b/e2e/utils/auth-helper.ts
@@ -86,37 +86,15 @@ export function uniquePhone(): string {
 }
 
 /**
- * Delete leads created by E2E tests, identified by test email patterns.
- *
- * NOTE: This is called by hubspot-sync.spec.ts's beforeAll/afterAll to sweep
- * HubSpot-synced leads. It runs concurrently with other test files — so it
- * must stay narrow: only match patterns owned by hubspot-sync and the long-
- * established Quick Capture tests. Pipeline-board leads have their own
- * separate cleanup function below.
+ * Delete leads created by E2E tests. Two patterns:
+ *   - Full-form tests: email matches `e2e-%@test.rekurve.dev`
+ *   - All other tests: first_name in the known test marker list.
+ *     Keep in sync with TEST_FIRST_NAMES in hubspot-helper.ts.
  */
 export async function deleteTestLeads(): Promise<void> {
   await sql()`
     DELETE FROM "leads"
     WHERE email LIKE 'e2e-%@test.rekurve.dev'
-       OR (first_name = 'Quick' AND last_name LIKE 'Capture %')
-  `;
-}
-
-/**
- * Delete leads created by the pipeline-board tests in leads-crud.spec.ts.
- * Kept separate from `deleteTestLeads` because hubspot-sync.spec.ts calls
- * that one mid-run and would otherwise delete these leads during concurrent
- * execution.
- */
-export async function deletePipelineTestLeads(): Promise<void> {
-  await sql()`
-    DELETE FROM "leads"
-    WHERE (first_name = 'Pipeline' AND last_name LIKE 'Unqualified %')
-       OR (first_name = 'Pipeline' AND last_name LIKE 'Hot %')
-       OR (first_name = 'QC' AND last_name LIKE 'Capture %')
-       OR (first_name = 'Nav' AND last_name LIKE 'Test %')
-       OR (first_name = 'Count' AND last_name LIKE 'Update %')
-       OR (first_name = 'FHOG' AND last_name LIKE 'Buyer %')
-       OR (first_name = 'FHOG' AND last_name LIKE 'Investor %')
+       OR first_name IN ('Quick', 'E2E', 'FHOG', 'Nav', 'QC', 'Count', 'Pipeline')
   `;
 }

--- a/e2e/utils/global-teardown.ts
+++ b/e2e/utils/global-teardown.ts
@@ -1,5 +1,5 @@
 import "dotenv/config";
-import { deletePipelineTestLeads, deleteTestLeads } from "./auth-helper";
+import { deleteTestLeads } from "./auth-helper";
 import { deleteTestContacts } from "./hubspot-helper";
 
 /**
@@ -24,11 +24,6 @@ export default async function globalTeardown() {
       await deleteTestLeads();
     } catch (err) {
       console.error("[e2e teardown] deleteTestLeads failed:", err);
-    }
-    try {
-      await deletePipelineTestLeads();
-    } catch (err) {
-      console.error("[e2e teardown] deletePipelineTestLeads failed:", err);
     }
   }
 }

--- a/e2e/utils/hubspot-helper.ts
+++ b/e2e/utils/hubspot-helper.ts
@@ -120,13 +120,41 @@ const TEST_FIRST_NAMES = [
 ];
 
 /**
- * Delete HubSpot contacts created by E2E tests. Catches two patterns:
- *   - Full-form / inbound-sync tests: email containing `test.rekurve.dev`
- *   - All other tests: firstname in {@link TEST_FIRST_NAMES}
+ * Delete HubSpot contacts created by E2E tests.
  *
- * `filterGroups` are OR'd, filters within a group are AND'd.
+ * Phase 1 — DB lookup: query the local `leads` table for `hubspot_contact_id`
+ * values and archive those contacts by ID. This is immediately consistent and
+ * avoids the HubSpot search indexing delay (~30 s) that causes contacts
+ * created during the same test run to be missed.
+ *
+ * Phase 2 — Search fallback: sweep any orphaned contacts from previous runs
+ * whose DB rows were already deleted. Uses two patterns (OR'd):
+ *   - email containing `test.rekurve.dev` (full-form / inbound-sync tests)
+ *   - firstname in {@link TEST_FIRST_NAMES} (quick-capture and other tests)
  */
 export async function deleteTestContacts(): Promise<void> {
+  const archived = new Set<string>();
+
+  // Phase 1: archive by ID from the local DB (no search lag)
+  if (process.env.DATABASE_URL) {
+    const rows = await sql()`
+      SELECT hubspot_contact_id FROM "leads"
+      WHERE (email LIKE 'e2e-%@test.rekurve.dev'
+         OR first_name IN ('Quick', 'E2E', 'FHOG', 'Nav', 'QC', 'Count', 'Pipeline'))
+        AND hubspot_contact_id IS NOT NULL
+    `;
+    for (const row of rows) {
+      const id = row.hubspot_contact_id as string;
+      try {
+        await hubspot().crm.contacts.basicApi.archive(id);
+        archived.add(id);
+      } catch {
+        // Already deleted — ignore
+      }
+    }
+  }
+
+  // Phase 2: search-based fallback for orphaned contacts
   const response = await hubspot().crm.contacts.searchApi.doSearch({
     filterGroups: [
       {
@@ -155,12 +183,41 @@ export async function deleteTestContacts(): Promise<void> {
   });
 
   for (const contact of response.results) {
+    if (archived.has(contact.id)) continue;
     try {
       await hubspot().crm.contacts.basicApi.archive(contact.id);
     } catch {
       // Already deleted — ignore
     }
   }
+}
+
+/**
+ * Clean up leads and their HubSpot contacts by phone number. Designed to be
+ * called from per-spec `afterAll` hooks where the DB rows still exist (no
+ * HubSpot search indexing delay). This is the primary cleanup path — global
+ * teardown is a fallback only.
+ */
+export async function cleanupTestLeadsByPhone(phones: string[]): Promise<void> {
+  if (phones.length === 0) return;
+
+  const rows = await sql()`
+    SELECT hubspot_contact_id FROM "leads"
+    WHERE phone = ANY(${phones})
+      AND hubspot_contact_id IS NOT NULL
+  `;
+
+  for (const row of rows) {
+    try {
+      await hubspot().crm.contacts.basicApi.archive(
+        row.hubspot_contact_id as string,
+      );
+    } catch {
+      // Already archived — ignore
+    }
+  }
+
+  await sql()`DELETE FROM "leads" WHERE phone = ANY(${phones})`;
 }
 
 /**

--- a/e2e/utils/hubspot-helper.ts
+++ b/e2e/utils/hubspot-helper.ts
@@ -105,10 +105,24 @@ export async function archiveTestContact(hubspotId: string): Promise<void> {
 }
 
 /**
+ * Known first-name markers used by E2E tests. Every e2e test that creates a
+ * lead without a `test.rekurve.dev` email MUST use one of these as firstName
+ * so the sweeper can find it. Keep in sync with deleteTestLeads().
+ */
+const TEST_FIRST_NAMES = [
+  "Quick",
+  "E2E",
+  "FHOG",
+  "Nav",
+  "QC",
+  "Count",
+  "Pipeline",
+];
+
+/**
  * Delete HubSpot contacts created by E2E tests. Catches two patterns:
  *   - Full-form / inbound-sync tests: email containing `test.rekurve.dev`
- *   - Quick-capture tests: firstname `Quick` + lastname containing `Capture`
- *     (quick capture has no email field, so the email filter can't find them)
+ *   - All other tests: firstname in {@link TEST_FIRST_NAMES}
  *
  * `filterGroups` are OR'd, filters within a group are AND'd.
  */
@@ -128,13 +142,8 @@ export async function deleteTestContacts(): Promise<void> {
         filters: [
           {
             propertyName: "firstname",
-            operator: FilterOperatorEnum.Eq,
-            value: "Quick",
-          },
-          {
-            propertyName: "lastname",
-            operator: FilterOperatorEnum.ContainsToken,
-            value: "Capture",
+            operator: FilterOperatorEnum.In,
+            values: TEST_FIRST_NAMES,
           },
         ],
       },

--- a/e2e/utils/leads-helper.ts
+++ b/e2e/utils/leads-helper.ts
@@ -1,0 +1,29 @@
+import { type NeonQueryFunction, neon } from "@neondatabase/serverless";
+
+import "dotenv/config";
+
+// Lazy — only initialized when called, so the module can be imported even
+// when DATABASE_URL is not set (CI).
+let _sql: NeonQueryFunction<false, false> | undefined;
+function sql() {
+  _sql ??= neon(process.env.DATABASE_URL!);
+  return _sql;
+}
+
+/**
+ * Look up a lead's id by phone number. Used by E2E tests that create leads
+ * via quick capture (which has no id in its success toast) and need to
+ * navigate to /leads/[id].
+ *
+ * Throws if no lead is found, to fail fast instead of navigating to a
+ * bogus URL.
+ */
+export async function getLeadIdByPhone(phone: string): Promise<string> {
+  const rows = await sql()`
+    SELECT id FROM "leads" WHERE phone = ${phone} LIMIT 1
+  `;
+  if (rows.length === 0) {
+    throw new Error(`No lead found with phone ${phone}`);
+  }
+  return rows[0]!.id as string;
+}

--- a/scripts/ralph.sh
+++ b/scripts/ralph.sh
@@ -9,7 +9,6 @@ IMPLEMENT_MODEL="sonnet"
 VALIDATE_MODEL="opus"
 IMPLEMENT_PROMPT=".claude/prompts/ralph-implement.md"
 VALIDATE_PROMPT=".claude/prompts/ralph-validate.md"
-GRANULARITY="section"    # "section" or "checkbox"
 NO_DEVSERVER=false
 NO_NEON=false
 NO_PR=false
@@ -31,7 +30,6 @@ Options:
   --validate-model MODEL   Claude model for validate phase (default: sonnet)
   --implement-prompt PATH  Override implement prompt (default: .claude/prompts/ralph-implement.md)
   --validate-prompt PATH   Override validate prompt (default: .claude/prompts/ralph-validate.md)
-  --granularity MODE       "section" or "checkbox" (default: section)
   --no-devserver           Skip dev server (yarn dev) for plans without e2e/UI
   --no-neon                Skip Neon branch even if migrations detected
   --no-pr                  Skip PR creation after loop completes
@@ -62,7 +60,6 @@ while [[ $# -gt 0 ]]; do
     --validate-model)  VALIDATE_MODEL="$2"; shift 2 ;;
     --implement-prompt) IMPLEMENT_PROMPT="$2"; shift 2 ;;
     --validate-prompt)  VALIDATE_PROMPT="$2"; shift 2 ;;
-    --granularity)   GRANULARITY="$2"; shift 2 ;;
     --no-devserver)  NO_DEVSERVER=true; shift ;;
     --no-neon)       NO_NEON=true; shift ;;
     --no-pr)         NO_PR=true; shift ;;
@@ -162,14 +159,14 @@ verify_auth
 
 # ── Spec Parsing ─────────────────────────────────────────
 
-# Find the next incomplete section in the spec.
-# Returns: prints "SECTION_ID\tSECTION_TITLE\tSTATE" (tab-separated) to stdout.
-# Exit 0 if found, exit 1 if all sections complete.
-find_next_section() {
+# Find the next incomplete task in the spec.
+# Returns: prints "TASK_ID\tTASK_TITLE\tSTATE" (tab-separated) to stdout.
+# Exit 0 if found, exit 1 if all tasks complete.
+find_next_task() {
   local spec="$1"
   local result
   result=$(jq -r '
-    [.sections[] | select(.state == "pending" or .state == "implemented")][0] // empty |
+    [.tasks[] | select(.state == "pending" or .state == "implemented")][0] // empty |
     [.id, .title, (if .state == "pending" then "implement" else "validate" end)] |
     @tsv
   ' "$spec") || return 1
@@ -179,32 +176,67 @@ find_next_section() {
   echo "$result"
 }
 
-count_sections() {
+count_tasks() {
   local spec="$1"
   local total complete
-  total=$(jq '.sections | length' "$spec")
-  complete=$(jq '[.sections[] | select(.state == "validated")] | length' "$spec")
+  total=$(jq '.tasks | length' "$spec")
+  complete=$(jq '[.tasks[] | select(.state == "validated")] | length' "$spec")
   echo "$complete/$total"
 }
 
 # Write a state transition to the spec file.
-# Usage: update_section_state <spec-path> <section-id> <new-state>
-update_section_state() {
+# Usage: update_task_state <spec-path> <task-id> <new-state>
+update_task_state() {
   local spec="$1"
-  local section_id="$2"
+  local task_id="$2"
   local new_state="$3"
   local tmp="${spec}.tmp"
-  jq --arg id "$section_id" --arg state "$new_state" '
-    .sections |= map(if .id == $id then .state = $state else . end)
+  jq --arg id "$task_id" --arg state "$new_state" '
+    .tasks |= map(if .id == $id then .state = $state else . end)
+  ' "$spec" > "$tmp" && mv "$tmp" "$spec"
+}
+
+# Append a progress note to a task in the spec file.
+# Extracts the last portion of Claude's result text so the next attempt
+# knows what was tried and what happened.
+# Usage: append_task_notes <spec-path> <task-id> <phase> <success|failure>
+append_task_notes() {
+  local spec="$1"
+  local task_id="$2"
+  local phase="$3"
+  local outcome="$4"  # "success" or "failure"
+  local output="$LAST_OUTPUT"
+  local tmp="${spec}.tmp"
+
+  # Extract Claude's result text, truncate to last 2000 chars to keep spec manageable
+  local result_text
+  result_text=$(echo "$output" | jq -r '.result // ""' 2>/dev/null | tail -c 2000) || result_text=""
+
+  if [[ -z "$result_text" ]]; then
+    result_text="(no output captured)"
+  fi
+
+  local timestamp
+  timestamp=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+  local note="[$timestamp] $phase $outcome:
+$result_text"
+
+  jq --arg id "$task_id" --arg note "$note" '
+    .tasks |= map(
+      if .id == $id then
+        .notes = ((.notes // []) + [$note])
+      else . end
+    )
   ' "$spec" > "$tmp" && mv "$tmp" "$spec"
 }
 
 # ── Dry Run ───────────────────────────────────────────────
 if $DRY_RUN; then
-  log "Dry run — sections from spec:"
+  log "Dry run — tasks from spec:"
   echo ""
 
-  jq -r '.sections[] |
+  jq -r '.tasks[] |
     "  " +
     (if .state == "pending" then "[ ]"
      elif .state == "implemented" then "[/]"
@@ -213,14 +245,14 @@ if $DRY_RUN; then
   ' "$SPEC_PATH"
 
   echo ""
-  progress=$(count_sections "$SPEC_PATH")
-  log "Progress: $progress sections complete"
+  progress=$(count_tasks "$SPEC_PATH")
+  log "Progress: $progress tasks complete"
 
-  if result=$(find_next_section "$SPEC_PATH"); then
-    IFS=$'\t' read -r sid stitle sstate <<< "$result"
-    log "Next target: $sid $stitle ($sstate)"
+  if result=$(find_next_task "$SPEC_PATH"); then
+    IFS=$'\t' read -r tid ttitle tstate <<< "$result"
+    log "Next target: $tid $ttitle ($tstate)"
   else
-    log "All sections complete"
+    log "All tasks complete"
   fi
 
   exit 0
@@ -253,11 +285,11 @@ cleanup() {
   if [[ -f "$METRICS_FILE" ]]; then
     local api_cost total_sections
     api_cost=$(jq -s '[.[].api_equivalent_cost_usd] | add // 0' "$METRICS_FILE")
-    total_sections=$(jq -s '[.[].section] | unique | length' "$METRICS_FILE")
+    total_tasks=$(jq -s '[.[].section] | unique | length' "$METRICS_FILE")
     if [[ "$BILLING" == "max" ]]; then
-      log "Summary: $total_sections sections, \$$api_cost API-equivalent cost (covered by Max subscription)"
+      log "Summary: $total_tasks tasks, \$$api_cost API-equivalent cost (covered by Max subscription)"
     else
-      log "Summary: $total_sections sections, \$$api_cost total API cost"
+      log "Summary: $total_tasks tasks, \$$api_cost total API cost"
     fi
     log "Metrics: $METRICS_FILE"
   fi
@@ -440,8 +472,8 @@ LAST_COMMIT_SHA=""
 
 run_claude() {
   local phase="$1"    # "implement" or "validate"
-  local section_id="$2"
-  local section_title="$3"
+  local task_id="$2"
+  local task_title="$3"
   local prompt_file tools prompt_text model
   local worktree_spec="$WORKTREE_DIR/$SPEC_PATH"
 
@@ -455,15 +487,18 @@ run_claude() {
     model="$VALIDATE_MODEL"
   fi
 
-  # Inline section content from the spec into the prompt
-  prompt_text=$(jq -r --arg id "$section_id" --arg phase "$phase" --arg plan "$PLAN_PATH" '
-    .sections[] | select(.id == $id) |
+  # Inline task content from the spec into the prompt, including any prior attempt notes
+  prompt_text=$(jq -r --arg id "$task_id" --arg phase "$phase" --arg plan "$PLAN_PATH" '
+    .tasks[] | select(.id == $id) |
     (if $phase == "implement" then "Implement" else "Validate" end) +
-    " section \(.id): \(.title)\n\n" +
+    " task \(.id): \(.title)\n\n" +
     "Plan: \($plan)\n\n" +
-    "Tasks:\n" + (.tasks | map("- " + .) | join("\n")) + "\n\n" +
+    "Tasks:\n- " + .task + "\n\n" +
     "Files to read first:\n" + (.files | map("- " + .) | join("\n")) + "\n\n" +
-    "Verify:\n" + (.verify | map("- " + .) | join("\n"))
+    "Verify:\n" + (.verify | map("- " + .) | join("\n")) +
+    (if (.notes // []) | length > 0 then
+      "\n\nPrior attempts:\n" + (.notes | map("---\n" + .) | join("\n"))
+    else "" end)
   ' "$worktree_spec")
 
   local start_time
@@ -506,7 +541,7 @@ run_claude() {
 
 check_success() {
   local phase="$1"
-  local section_id="$2"
+  local task_id="$2"
   local output="$LAST_OUTPUT"
   local exit_code=$LAST_EXIT_CODE
   local worktree_spec="$WORKTREE_DIR/$SPEC_PATH"
@@ -546,8 +581,8 @@ check_success() {
       err "Verify command failed: $verify_cmd"
       return 1
     fi
-  done < <(jq -r --arg id "$section_id" '
-    .sections[] | select(.id == $id) | .verify[]
+  done < <(jq -r --arg id "$task_id" '
+    .tasks[] | select(.id == $id) | .verify[]
   ' "$worktree_spec")
 
   return 0
@@ -557,8 +592,8 @@ check_success() {
 
 record_metrics() {
   local phase="$1"
-  local section_id="$2"
-  local section_title="$3"
+  local task_id="$2"
+  local task_title="$3"
   local output="$LAST_OUTPUT"
   local duration_ms="$LAST_DURATION_MS"
   local exit_code=$LAST_EXIT_CODE
@@ -585,8 +620,8 @@ record_metrics() {
   jq -nc \
     --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
     --arg plan "$PLAN_NAME" \
-    --arg section "$section_id" \
-    --arg section_title "$section_title" \
+    --arg section "$task_id" \
+    --arg section_title "$task_title" \
     --arg phase "$phase" \
     --arg subtype "$subtype" \
     --arg billing "$BILLING" \
@@ -747,50 +782,54 @@ LOOP_FAILED=false
 while true; do
   worktree_spec="$WORKTREE_DIR/$SPEC_PATH"
 
-  result=$(find_next_section "$worktree_spec") || {
-    log "All sections complete!"
+  result=$(find_next_task "$worktree_spec") || {
+    log "All tasks complete!"
     push_and_create_pr
     break
   }
 
-  IFS=$'\t' read -r SECTION_ID SECTION_TITLE SECTION_STATE <<< "$result"
-  log "Section $SECTION_ID: $SECTION_TITLE ($SECTION_STATE)"
+  IFS=$'\t' read -r TASK_ID TASK_TITLE TASK_STATE <<< "$result"
+  log "Task $TASK_ID: $TASK_TITLE ($TASK_STATE)"
 
   # Implement phase (skip if already implemented)
-  if [[ "$SECTION_STATE" == "implement" ]]; then
+  if [[ "$TASK_STATE" == "implement" ]]; then
     log "Phase: implement"
     LAST_COMMIT_SHA=""
-    run_claude "implement" "$SECTION_ID" "$SECTION_TITLE"
-    record_metrics "implement" "$SECTION_ID" "$SECTION_TITLE"
+    run_claude "implement" "$TASK_ID" "$TASK_TITLE"
+    record_metrics "implement" "$TASK_ID" "$TASK_TITLE"
 
-    if ! check_success "implement" "$SECTION_ID"; then
-      err "Implement failed for section $SECTION_ID"
+    if ! check_success "implement" "$TASK_ID"; then
+      append_task_notes "$worktree_spec" "$TASK_ID" "implement" "failure"
+      err "Implement failed for task $TASK_ID"
       LOOP_FAILED=true
       break
     fi
 
-    update_section_state "$worktree_spec" "$SECTION_ID" "implemented"
-    log "Implement succeeded for section $SECTION_ID"
+    append_task_notes "$worktree_spec" "$TASK_ID" "implement" "success"
+    update_task_state "$worktree_spec" "$TASK_ID" "implemented"
+    log "Implement succeeded for task $TASK_ID"
   fi
 
   # Validate phase
   log "Phase: validate"
   LAST_COMMIT_SHA=""
-  run_claude "validate" "$SECTION_ID" "$SECTION_TITLE"
+  run_claude "validate" "$TASK_ID" "$TASK_TITLE"
 
-  if ! check_success "validate" "$SECTION_ID"; then
-    record_metrics "validate" "$SECTION_ID" "$SECTION_TITLE"
-    err "Validate failed for section $SECTION_ID"
+  if ! check_success "validate" "$TASK_ID"; then
+    append_task_notes "$worktree_spec" "$TASK_ID" "validate" "failure"
+    record_metrics "validate" "$TASK_ID" "$TASK_TITLE"
+    err "Validate failed for task $TASK_ID"
     LOOP_FAILED=true
     break
   fi
 
   # Capture commit SHA after successful validation (validate agent commits on success)
   LAST_COMMIT_SHA=$(cd "$WORKTREE_DIR" && git rev-parse HEAD)
-  record_metrics "validate" "$SECTION_ID" "$SECTION_TITLE"
+  append_task_notes "$worktree_spec" "$TASK_ID" "validate" "success"
+  record_metrics "validate" "$TASK_ID" "$TASK_TITLE"
 
-  update_section_state "$worktree_spec" "$SECTION_ID" "validated"
-  log "Section $SECTION_ID complete (commit: ${LAST_COMMIT_SHA:0:8})"
+  update_task_state "$worktree_spec" "$TASK_ID" "validated"
+  log "Task $TASK_ID complete (commit: ${LAST_COMMIT_SHA:0:8})"
 done
 
 if $LOOP_FAILED; then

--- a/src/app/(application)/leads/[id]/_components/conversation-history.tsx
+++ b/src/app/(application)/leads/[id]/_components/conversation-history.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { MessageCircle } from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle } from "~/components/ui/Card";
+
+export function ConversationHistory() {
+  return (
+    <Card data-testid="lead-profile-conversation-history">
+      <CardHeader>
+        <CardTitle className="text-xl">Conversation history</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="flex flex-col items-center gap-3 py-6 text-center">
+          <MessageCircle
+            className="size-8 text-muted-foreground/40"
+            aria-hidden="true"
+          />
+          <p className="max-w-xs text-muted-foreground text-sm">
+            No messages yet — conversation history will appear here when Epic 3
+            is complete.
+          </p>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/app/(application)/leads/[id]/_components/conversation-history.tsx
+++ b/src/app/(application)/leads/[id]/_components/conversation-history.tsx
@@ -16,8 +16,7 @@ export function ConversationHistory() {
             aria-hidden="true"
           />
           <p className="max-w-xs text-muted-foreground text-sm">
-            No messages yet — conversation history will appear here when Epic 3
-            is complete.
+            No conversations yet.
           </p>
         </div>
       </CardContent>

--- a/src/app/(application)/leads/[id]/_components/lead-details.tsx
+++ b/src/app/(application)/leads/[id]/_components/lead-details.tsx
@@ -1,0 +1,183 @@
+"use client";
+
+import { Card, CardContent, CardHeader, CardTitle } from "~/components/ui/Card";
+import {
+  formatContactTime,
+  formatLeadSource,
+  formatPropertyType,
+  formatTimeline,
+} from "../_lib/display";
+import type { Lead } from "./lead-profile-view";
+
+export function LeadDetails({ lead }: { lead: Lead }) {
+  return (
+    <div className="flex flex-col gap-6" data-testid="lead-profile-details">
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-xl">Contact</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <DetailGrid>
+            <DetailRow label="First name" value={lead.firstName} />
+            <DetailRow label="Last name" value={lead.lastName} />
+            <DetailRow label="Phone" value={lead.phone} />
+            <DetailRow label="Email" value={lead.email} />
+            <DetailRow
+              label="Preferred contact time"
+              value={formatContactTime(lead.preferredContactTime)}
+            />
+          </DetailGrid>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-xl">Land</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <DetailGrid>
+            <DetailRow label="Has land" value={yesNo(lead.hasLand)} />
+            <DetailRow label="Registered" value={yesNo(lead.landRegistered)} />
+            <DetailRow label="Address" value={lead.landAddress} />
+            <DetailRow
+              label="Size"
+              value={lead.landSizeSqm ? `${lead.landSizeSqm} m²` : null}
+            />
+            <DetailRow
+              label="Dimensions"
+              value={
+                lead.landWidth && lead.landDepth
+                  ? `${lead.landWidth} m × ${lead.landDepth} m`
+                  : null
+              }
+            />
+          </DetailGrid>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-xl">Build</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <DetailGrid>
+            <DetailRow
+              label="Property type"
+              value={formatPropertyType(lead.propertyType)}
+            />
+            <DetailRow label="Budget" value={lead.budget} />
+            <DetailRow label="Seen broker" value={yesNo(lead.seenBroker)} />
+            <DetailRow
+              label="Construction timeline"
+              value={formatTimeline(lead.constructionTimeline)}
+            />
+          </DetailGrid>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-xl">Preferences</CardTitle>
+        </CardHeader>
+        <CardContent className="flex flex-col gap-4">
+          <ChipField label="Preferred estates" values={lead.preferredEstates} />
+          <ChipField label="Preferred suburbs" values={lead.preferredSuburbs} />
+          <DetailRow
+            label="Resolve Finance opt-in"
+            value={yesNo(lead.resolveFinanceOptedIn)}
+          />
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-xl">Source</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <DetailGrid>
+            <DetailRow
+              label="Lead source"
+              value={formatLeadSource(lead.leadSource)}
+            />
+            <DetailRow label="Referrer name" value={lead.referrerName} />
+            <DetailRow label="Notes" value={lead.notes} />
+            <DetailRow
+              label="Created"
+              value={new Date(lead.createdAt).toLocaleDateString()}
+            />
+          </DetailGrid>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+function DetailGrid({ children }: { children: React.ReactNode }) {
+  return (
+    <dl className="grid grid-cols-1 gap-x-6 gap-y-4 sm:grid-cols-2">
+      {children}
+    </dl>
+  );
+}
+
+function DetailRow({
+  label,
+  value,
+}: {
+  label: string;
+  value: string | null | undefined;
+}) {
+  const display = value && value !== "Not provided" ? value : null;
+  return (
+    <div className="flex flex-col gap-0.5">
+      <dt className="text-muted-foreground text-xs uppercase tracking-wide">
+        {label}
+      </dt>
+      <dd
+        className={
+          display ? "text-sm" : "text-muted-foreground/60 text-sm italic"
+        }
+      >
+        {display ?? "Not provided"}
+      </dd>
+    </div>
+  );
+}
+
+function ChipField({
+  label,
+  values,
+}: {
+  label: string;
+  values: string[] | null | undefined;
+}) {
+  return (
+    <div className="flex flex-col gap-1.5">
+      <span className="text-muted-foreground text-xs uppercase tracking-wide">
+        {label}
+      </span>
+      {values && values.length > 0 ? (
+        <div className="flex flex-wrap gap-1.5">
+          {values.map((value) => (
+            <span
+              key={value}
+              className="rounded-md border border-border bg-secondary/40 px-2 py-0.5 text-xs"
+            >
+              {value}
+            </span>
+          ))}
+        </div>
+      ) : (
+        <span className="text-muted-foreground/60 text-sm italic">
+          Not provided
+        </span>
+      )}
+    </div>
+  );
+}
+
+function yesNo(value: boolean | null | undefined): string | null {
+  if (value === true) return "Yes";
+  if (value === false) return "No";
+  return null;
+}

--- a/src/app/(application)/leads/[id]/_components/lead-details.tsx
+++ b/src/app/(application)/leads/[id]/_components/lead-details.tsx
@@ -3,6 +3,7 @@
 import { Card, CardContent, CardHeader, CardTitle } from "~/components/ui/Card";
 import {
   formatContactTime,
+  formatDate,
   formatLeadSource,
   formatPropertyType,
   formatTimeline,
@@ -101,10 +102,7 @@ export function LeadDetails({ lead }: { lead: Lead }) {
             />
             <DetailRow label="Referrer name" value={lead.referrerName} />
             <DetailRow label="Notes" value={lead.notes} />
-            <DetailRow
-              label="Created"
-              value={new Date(lead.createdAt).toLocaleDateString()}
-            />
+            <DetailRow label="Created" value={formatDate(lead.createdAt)} />
           </DetailGrid>
         </CardContent>
       </Card>

--- a/src/app/(application)/leads/[id]/_components/lead-edit-form.tsx
+++ b/src/app/(application)/leads/[id]/_components/lead-edit-form.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useEffect, useRef } from "react";
 import { useForm } from "react-hook-form";
 import { AdditionalInfo } from "~/app/(application)/leads/new/_components/form-steps/additional-info";
 import { BuildDetails } from "~/app/(application)/leads/new/_components/form-steps/build-details";
@@ -49,6 +50,15 @@ function leadToDefaults(lead: Lead): LeadCreate {
 export function LeadEditForm({ lead, onCancel, onSuccess }: LeadEditFormProps) {
   const trpc = useTRPC();
   const queryClient = useQueryClient();
+  const formRef = useRef<HTMLFormElement>(null);
+
+  useEffect(() => {
+    requestAnimationFrame(() => {
+      formRef.current
+        ?.querySelector<HTMLElement>("input, select, textarea")
+        ?.focus();
+    });
+  }, []);
 
   const form = useForm<LeadCreate>({
     resolver: leadFormResolver,
@@ -84,12 +94,22 @@ export function LeadEditForm({ lead, onCancel, onSuccess }: LeadEditFormProps) {
     }),
   );
 
+  const handleCancel = () => {
+    if (form.formState.isDirty) {
+      if (!window.confirm("You have unsaved changes. Discard them?")) {
+        return;
+      }
+    }
+    onCancel();
+  };
+
   const onSubmit = (data: LeadCreate) => {
     updateLead.mutate({ id: lead.id, ...data });
   };
 
   return (
     <form
+      ref={formRef}
       onSubmit={form.handleSubmit(onSubmit)}
       noValidate
       className="flex flex-col gap-6 pb-24"
@@ -146,7 +166,7 @@ export function LeadEditForm({ lead, onCancel, onSuccess }: LeadEditFormProps) {
           type="button"
           variant="outline"
           size="md"
-          onClick={onCancel}
+          onClick={handleCancel}
           disabled={updateLead.isPending}
           data-testid="lead-profile-cancel-btn"
         >

--- a/src/app/(application)/leads/[id]/_components/lead-edit-form.tsx
+++ b/src/app/(application)/leads/[id]/_components/lead-edit-form.tsx
@@ -1,0 +1,167 @@
+"use client";
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useForm } from "react-hook-form";
+import { AdditionalInfo } from "~/app/(application)/leads/new/_components/form-steps/additional-info";
+import { BuildDetails } from "~/app/(application)/leads/new/_components/form-steps/build-details";
+import { ContactDetails } from "~/app/(application)/leads/new/_components/form-steps/contact-details";
+import { LandStatus } from "~/app/(application)/leads/new/_components/form-steps/land-status";
+import { leadFormResolver } from "~/app/(application)/leads/new/_lib/schema";
+import { Button } from "~/components/ui/Button";
+import { Card, CardContent, CardHeader, CardTitle } from "~/components/ui/Card";
+import type { LeadCreate } from "~/server/api/schemas/leads";
+import { useTRPC } from "~/trpc/react";
+import type { Lead } from "./lead-profile-view";
+
+interface LeadEditFormProps {
+  lead: Lead;
+  onCancel: () => void;
+  onSuccess: () => void;
+}
+
+/** Convert a Lead row into the form's default values. */
+function leadToDefaults(lead: Lead): LeadCreate {
+  return {
+    firstName: lead.firstName,
+    lastName: lead.lastName,
+    email: lead.email,
+    phone: lead.phone,
+    preferredContactTime: lead.preferredContactTime,
+    hasLand: lead.hasLand,
+    landRegistered: lead.landRegistered,
+    landAddress: lead.landAddress,
+    landSizeSqm: lead.landSizeSqm,
+    landWidth: lead.landWidth,
+    landDepth: lead.landDepth,
+    propertyType: lead.propertyType,
+    budget: lead.budget,
+    seenBroker: lead.seenBroker,
+    constructionTimeline: lead.constructionTimeline,
+    preferredEstates: lead.preferredEstates,
+    preferredSuburbs: lead.preferredSuburbs,
+    leadSource: lead.leadSource,
+    referrerName: lead.referrerName,
+    notes: lead.notes,
+    resolveFinanceOptedIn: lead.resolveFinanceOptedIn ?? false,
+  };
+}
+
+export function LeadEditForm({ lead, onCancel, onSuccess }: LeadEditFormProps) {
+  const trpc = useTRPC();
+  const queryClient = useQueryClient();
+
+  const form = useForm<LeadCreate>({
+    resolver: leadFormResolver,
+    mode: "onSubmit",
+    reValidateMode: "onChange",
+    defaultValues: leadToDefaults(lead),
+  });
+
+  const updateLead = useMutation(
+    trpc.leads.update.mutationOptions({
+      onSuccess: async () => {
+        await queryClient.invalidateQueries(
+          trpc.leads.getById.queryFilter({ id: lead.id }),
+        );
+        onSuccess();
+      },
+      onError: (error) => {
+        const zodErrors = (
+          error.data as {
+            zodError?: { fieldErrors?: Record<string, string[]> };
+          }
+        )?.zodError?.fieldErrors;
+        if (zodErrors) {
+          for (const [field, messages] of Object.entries(zodErrors)) {
+            if (messages?.[0]) {
+              form.setError(field as keyof LeadCreate, {
+                message: messages[0],
+              });
+            }
+          }
+        }
+      },
+    }),
+  );
+
+  const onSubmit = (data: LeadCreate) => {
+    updateLead.mutate({ id: lead.id, ...data });
+  };
+
+  return (
+    <form
+      onSubmit={form.handleSubmit(onSubmit)}
+      noValidate
+      className="flex flex-col gap-6 pb-24"
+      data-testid="lead-profile-edit-form"
+    >
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-xl">Contact</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <ContactDetails form={form} />
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-xl">Land</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <LandStatus form={form} />
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-xl">Build</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <BuildDetails form={form} />
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-xl">More</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <AdditionalInfo form={form} />
+        </CardContent>
+      </Card>
+
+      {updateLead.error && Object.keys(form.formState.errors).length === 0 && (
+        <p className="text-destructive text-sm" role="alert">
+          {updateLead.error.message}
+        </p>
+      )}
+
+      {/* Sticky action bar — pinned to the bottom on mobile, bottom of card stack on desktop */}
+      <div
+        className="fixed right-0 bottom-16 left-0 z-10 flex items-center justify-end gap-3 border-t bg-background/95 px-4 py-3 backdrop-blur md:bottom-0 md:left-64"
+        data-testid="lead-profile-edit-actions"
+      >
+        <Button
+          type="button"
+          variant="outline"
+          size="md"
+          onClick={onCancel}
+          disabled={updateLead.isPending}
+          data-testid="lead-profile-cancel-btn"
+        >
+          Cancel
+        </Button>
+        <Button
+          type="submit"
+          variant="primary"
+          size="md"
+          disabled={updateLead.isPending}
+          data-testid="lead-profile-save-btn"
+        >
+          {updateLead.isPending ? "Saving…" : "Save"}
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/src/app/(application)/leads/[id]/_components/lead-profile-view.tsx
+++ b/src/app/(application)/leads/[id]/_components/lead-profile-view.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { useState } from "react";
+import { type RouterOutputs, useTRPC } from "~/trpc/react";
+import { ConversationHistory } from "./conversation-history";
+import { LeadDetails } from "./lead-details";
+import { LeadEditForm } from "./lead-edit-form";
+import { ProfileHeader } from "./profile-header";
+import { QualificationGaps } from "./qualification-gaps";
+import { ScoreBreakdown } from "./score-breakdown";
+
+export type Lead = RouterOutputs["leads"]["getById"];
+
+export function LeadProfileView({ id }: { id: string }) {
+  const trpc = useTRPC();
+  const {
+    data: lead,
+    isLoading,
+    isError,
+  } = useQuery(trpc.leads.getById.queryOptions({ id }));
+
+  const [isEditing, setIsEditing] = useState(false);
+
+  if (isLoading) {
+    return (
+      <div
+        className="flex flex-1 items-center justify-center p-8 text-muted-foreground text-sm"
+        data-testid="lead-profile-loading"
+      >
+        Loading lead…
+      </div>
+    );
+  }
+
+  if (isError || !lead) {
+    return (
+      <div
+        className="flex flex-1 items-center justify-center p-8 text-muted-foreground text-sm"
+        data-testid="lead-profile-error"
+      >
+        Something went wrong loading this lead. Please refresh.
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="flex flex-1 flex-col gap-6 px-4 py-6 md:px-8"
+      data-testid="lead-profile-view"
+    >
+      <ProfileHeader
+        lead={lead}
+        isEditing={isEditing}
+        onEdit={() => setIsEditing(true)}
+      />
+
+      {isEditing ? (
+        <LeadEditForm
+          lead={lead}
+          onCancel={() => setIsEditing(false)}
+          onSuccess={() => setIsEditing(false)}
+        />
+      ) : (
+        <div className="grid gap-6 lg:grid-cols-[2fr_1fr]">
+          <div className="flex flex-col gap-6">
+            <ScoreBreakdown lead={lead} />
+            <LeadDetails lead={lead} />
+          </div>
+          <div className="flex flex-col gap-6">
+            <QualificationGaps lead={lead} />
+            <ConversationHistory />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/(application)/leads/[id]/_components/lead-profile-view.tsx
+++ b/src/app/(application)/leads/[id]/_components/lead-profile-view.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useQuery } from "@tanstack/react-query";
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { type RouterOutputs, useTRPC } from "~/trpc/react";
 import { ConversationHistory } from "./conversation-history";
 import { LeadDetails } from "./lead-details";
@@ -21,6 +21,12 @@ export function LeadProfileView({ id }: { id: string }) {
   } = useQuery(trpc.leads.getById.queryOptions({ id }));
 
   const [isEditing, setIsEditing] = useState(false);
+  const editButtonRef = useRef<HTMLButtonElement>(null);
+
+  const exitEditing = () => {
+    setIsEditing(false);
+    requestAnimationFrame(() => editButtonRef.current?.focus());
+  };
 
   if (isLoading) {
     return (
@@ -53,21 +59,28 @@ export function LeadProfileView({ id }: { id: string }) {
         lead={lead}
         isEditing={isEditing}
         onEdit={() => setIsEditing(true)}
+        editButtonRef={editButtonRef}
       />
 
       {isEditing ? (
-        <LeadEditForm
-          lead={lead}
-          onCancel={() => setIsEditing(false)}
-          onSuccess={() => setIsEditing(false)}
-        />
+        <>
+          <h2 className="sr-only">Edit Lead</h2>
+          <LeadEditForm
+            lead={lead}
+            onCancel={exitEditing}
+            onSuccess={exitEditing}
+          />
+        </>
       ) : (
         <div className="grid gap-6 lg:grid-cols-[2fr_1fr]">
           <div className="flex flex-col gap-6">
+            <h2 className="sr-only">Score & Qualification</h2>
             <ScoreBreakdown lead={lead} />
+            <h2 className="sr-only">Lead Information</h2>
             <LeadDetails lead={lead} />
           </div>
           <div className="flex flex-col gap-6">
+            <h2 className="sr-only">Gaps & History</h2>
             <QualificationGaps lead={lead} />
             <ConversationHistory />
           </div>

--- a/src/app/(application)/leads/[id]/_components/profile-header.tsx
+++ b/src/app/(application)/leads/[id]/_components/profile-header.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import { ArrowLeft, Mail, Phone } from "lucide-react";
+import Link from "next/link";
+import { Badge } from "~/components/ui/Badge";
+import { Button } from "~/components/ui/Button";
+import { buttonVariants } from "~/components/ui/button-variants";
+import { cn } from "~/lib/utils";
+import { formatLastContacted, stageLabel, stageTone } from "../_lib/display";
+import type { Lead } from "./lead-profile-view";
+
+interface ProfileHeaderProps {
+  lead: Lead;
+  isEditing: boolean;
+  onEdit: (() => void) | undefined;
+}
+
+export function ProfileHeader({ lead, isEditing, onEdit }: ProfileHeaderProps) {
+  const fullName = `${lead.firstName} ${lead.lastName}`.trim();
+
+  return (
+    <header
+      className="flex flex-col gap-4 border-b pb-4"
+      data-testid="lead-profile-header"
+    >
+      <div className="flex items-center gap-3">
+        <Link
+          href="/pipeline"
+          aria-label="Back to pipeline"
+          className={buttonVariants({
+            variant: "ghost",
+            size: "sm",
+            className: "size-9 p-0",
+          })}
+        >
+          <ArrowLeft className="size-4" />
+        </Link>
+        <h1
+          className="flex-1 font-semibold text-lg"
+          data-testid="lead-profile-name"
+        >
+          {fullName}
+        </h1>
+        {!isEditing && (
+          <Button
+            variant="outline"
+            size="md"
+            onClick={onEdit}
+            disabled={!onEdit}
+            data-testid="lead-profile-edit-btn"
+          >
+            Edit
+          </Button>
+        )}
+      </div>
+
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex flex-col gap-2">
+          {lead.phone && (
+            <a
+              href={`tel:${lead.phone}`}
+              className="inline-flex items-center gap-2 text-sm hover:text-primary"
+              data-testid="lead-profile-phone"
+            >
+              <Phone className="size-4" aria-hidden="true" />
+              <span>{lead.phone}</span>
+            </a>
+          )}
+          {lead.email && (
+            <a
+              href={`mailto:${lead.email}`}
+              className="inline-flex items-center gap-2 text-sm hover:text-primary"
+              data-testid="lead-profile-email"
+            >
+              <Mail className="size-4" aria-hidden="true" />
+              <span>{lead.email}</span>
+            </a>
+          )}
+          <p className="text-muted-foreground text-xs">
+            Last contacted:{" "}
+            <span data-testid="lead-profile-last-contacted">
+              {formatLastContacted(lead.lastContactedAt)}
+            </span>
+          </p>
+        </div>
+
+        <div className="flex items-center gap-3">
+          <div
+            className={cn(
+              "flex size-20 flex-col items-center justify-center rounded-full border-2 text-center",
+              "border-primary/30 bg-primary/5",
+            )}
+            data-testid="lead-profile-score-badge"
+            aria-label={`Lead score ${lead.leadScore ?? 0} out of 100`}
+          >
+            <span className="font-bold text-2xl text-primary tabular-nums">
+              {lead.leadScore ?? 0}
+            </span>
+            <span className="text-muted-foreground text-xs">/ 100</span>
+          </div>
+          <Badge
+            variant={stageTone(lead.leadStage)}
+            className="px-3 py-1 text-sm"
+            data-testid="lead-profile-stage"
+          >
+            {stageLabel(lead.leadStage)}
+          </Badge>
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/src/app/(application)/leads/[id]/_components/profile-header.tsx
+++ b/src/app/(application)/leads/[id]/_components/profile-header.tsx
@@ -6,16 +6,27 @@ import { Badge } from "~/components/ui/Badge";
 import { Button } from "~/components/ui/Button";
 import { buttonVariants } from "~/components/ui/button-variants";
 import { cn } from "~/lib/utils";
-import { formatLastContacted, stageLabel, stageTone } from "../_lib/display";
+import {
+  formatLastContacted,
+  stageLabel,
+  stageRingClasses,
+  stageTone,
+} from "../_lib/display";
 import type { Lead } from "./lead-profile-view";
 
 interface ProfileHeaderProps {
   lead: Lead;
   isEditing: boolean;
   onEdit: (() => void) | undefined;
+  editButtonRef?: React.RefObject<HTMLButtonElement | null>;
 }
 
-export function ProfileHeader({ lead, isEditing, onEdit }: ProfileHeaderProps) {
+export function ProfileHeader({
+  lead,
+  isEditing,
+  onEdit,
+  editButtonRef,
+}: ProfileHeaderProps) {
   const fullName = `${lead.firstName} ${lead.lastName}`.trim();
 
   return (
@@ -43,6 +54,7 @@ export function ProfileHeader({ lead, isEditing, onEdit }: ProfileHeaderProps) {
         </h1>
         {!isEditing && (
           <Button
+            ref={editButtonRef}
             variant="outline"
             size="md"
             onClick={onEdit}
@@ -59,7 +71,7 @@ export function ProfileHeader({ lead, isEditing, onEdit }: ProfileHeaderProps) {
           {lead.phone && (
             <a
               href={`tel:${lead.phone}`}
-              className="inline-flex items-center gap-2 text-sm hover:text-primary"
+              className="inline-flex items-center gap-2 text-sm hover:text-primary hover:underline"
               data-testid="lead-profile-phone"
             >
               <Phone className="size-4" aria-hidden="true" />
@@ -69,7 +81,7 @@ export function ProfileHeader({ lead, isEditing, onEdit }: ProfileHeaderProps) {
           {lead.email && (
             <a
               href={`mailto:${lead.email}`}
-              className="inline-flex items-center gap-2 text-sm hover:text-primary"
+              className="inline-flex items-center gap-2 text-sm hover:text-primary hover:underline"
               data-testid="lead-profile-email"
             >
               <Mail className="size-4" aria-hidden="true" />
@@ -84,16 +96,16 @@ export function ProfileHeader({ lead, isEditing, onEdit }: ProfileHeaderProps) {
           </p>
         </div>
 
-        <div className="flex items-center gap-3">
+        <div className="flex items-center gap-3" aria-live="polite">
           <div
             className={cn(
               "flex size-20 flex-col items-center justify-center rounded-full border-2 text-center",
-              "border-primary/30 bg-primary/5",
+              stageRingClasses(lead.leadStage),
             )}
             data-testid="lead-profile-score-badge"
             aria-label={`Lead score ${lead.leadScore ?? 0} out of 100`}
           >
-            <span className="font-bold text-2xl text-primary tabular-nums">
+            <span className="font-bold text-2xl text-foreground tabular-nums">
               {lead.leadScore ?? 0}
             </span>
             <span className="text-muted-foreground text-xs">/ 100</span>

--- a/src/app/(application)/leads/[id]/_components/qualification-gaps.tsx
+++ b/src/app/(application)/leads/[id]/_components/qualification-gaps.tsx
@@ -9,16 +9,8 @@ import {
   CardHeader,
   CardTitle,
 } from "~/components/ui/Card";
-import { factorLabel, impactTone } from "../_lib/display";
+import { type FactorKey, factorLabel, impactTone } from "../_lib/display";
 import type { Lead } from "./lead-profile-view";
-
-type FactorKey =
-  | "land"
-  | "finance"
-  | "timeline"
-  | "budget"
-  | "propertyType"
-  | "engagement";
 
 export function QualificationGaps({ lead }: { lead: Lead }) {
   const metadata = lead.scoreMetadata;

--- a/src/app/(application)/leads/[id]/_components/qualification-gaps.tsx
+++ b/src/app/(application)/leads/[id]/_components/qualification-gaps.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import { Sparkles } from "lucide-react";
+import { Badge } from "~/components/ui/Badge";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "~/components/ui/Card";
+import { factorLabel, impactTone } from "../_lib/display";
+import type { Lead } from "./lead-profile-view";
+
+type FactorKey =
+  | "land"
+  | "finance"
+  | "timeline"
+  | "budget"
+  | "propertyType"
+  | "engagement";
+
+export function QualificationGaps({ lead }: { lead: Lead }) {
+  const metadata = lead.scoreMetadata;
+
+  if (!metadata) {
+    return (
+      <Card data-testid="lead-profile-gaps-card">
+        <CardHeader>
+          <CardTitle className="text-xl">Qualification gaps</CardTitle>
+          <CardDescription>Score pending…</CardDescription>
+        </CardHeader>
+      </Card>
+    );
+  }
+
+  const { gaps, nextQuestion } = metadata;
+
+  if (gaps.length === 0) {
+    return (
+      <Card data-testid="lead-profile-gaps-card">
+        <CardHeader>
+          <CardTitle className="text-xl">Qualification gaps</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p
+            className="rounded-md bg-state-success/10 px-3 py-2 text-sm text-state-success"
+            data-testid="lead-profile-gaps-empty"
+          >
+            No gaps — this lead is fully qualified.
+          </p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card data-testid="lead-profile-gaps-card">
+      <CardHeader>
+        <CardTitle className="text-xl">Qualification gaps</CardTitle>
+        <CardDescription>
+          Top {gaps.length} {gaps.length === 1 ? "gap" : "gaps"} — ranked by
+          impact.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-4">
+        <div
+          className="rounded-md border border-primary/20 bg-primary/5 p-3"
+          data-testid="lead-profile-next-question"
+        >
+          <div className="mb-1 flex items-center gap-1.5 font-semibold text-primary text-xs uppercase tracking-wide">
+            <Sparkles className="size-3" aria-hidden="true" />
+            Suggested next question
+          </div>
+          <p className="text-sm italic">“{nextQuestion}”</p>
+        </div>
+
+        <ul
+          className="flex flex-col gap-3"
+          data-testid="lead-profile-gaps-list"
+        >
+          {gaps.map((gap) => (
+            <li
+              key={gap.field}
+              className="flex flex-col gap-1 border-border border-l-2 pl-3"
+              data-testid={`lead-profile-gap-item-${gap.field}`}
+            >
+              <div className="flex items-center justify-between gap-2">
+                <span className="font-medium text-sm">
+                  {factorLabel(gap.field as FactorKey)}
+                </span>
+                <Badge variant={impactTone(gap.impact)} className="capitalize">
+                  {gap.impact}
+                </Badge>
+              </div>
+              <p className="text-muted-foreground text-xs">{gap.description}</p>
+            </li>
+          ))}
+        </ul>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/app/(application)/leads/[id]/_components/score-breakdown.tsx
+++ b/src/app/(application)/leads/[id]/_components/score-breakdown.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "~/components/ui/Card";
+import { FACTOR_ORDER, factorLabel } from "../_lib/display";
+import type { Lead } from "./lead-profile-view";
+
+export function ScoreBreakdown({ lead }: { lead: Lead }) {
+  const metadata = lead.scoreMetadata;
+
+  if (!metadata) {
+    return (
+      <Card data-testid="lead-profile-score-breakdown">
+        <CardHeader>
+          <CardTitle className="text-xl">Score breakdown</CardTitle>
+          <CardDescription>Score pending…</CardDescription>
+        </CardHeader>
+      </Card>
+    );
+  }
+
+  const { breakdown, score } = metadata;
+
+  return (
+    <Card data-testid="lead-profile-score-breakdown">
+      <CardHeader>
+        <CardTitle className="text-xl">Score breakdown</CardTitle>
+        <CardDescription>
+          Total: <span className="font-semibold text-foreground">{score}</span>{" "}
+          out of 100
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-5">
+        {FACTOR_ORDER.map((key) => {
+          const factor = breakdown[key];
+          const pct =
+            factor.maxScore > 0 ? (factor.score / factor.maxScore) * 100 : 0;
+          return (
+            <div
+              key={key}
+              className="flex flex-col gap-1.5"
+              data-testid={`lead-profile-score-factor-${key}`}
+            >
+              <div className="flex items-baseline justify-between gap-2">
+                <span className="font-medium text-sm">{factorLabel(key)}</span>
+                <span
+                  className="text-muted-foreground text-sm tabular-nums"
+                  data-testid={`lead-profile-score-factor-${key}-value`}
+                >
+                  {factor.score}/{factor.maxScore}
+                </span>
+              </div>
+              <div
+                className="h-2 w-full overflow-hidden rounded-full bg-secondary"
+                role="progressbar"
+                aria-valuenow={factor.score}
+                aria-valuemin={0}
+                aria-valuemax={factor.maxScore}
+                aria-label={`${factorLabel(key)} score`}
+              >
+                <div
+                  className="h-full rounded-full bg-primary transition-[width] duration-300"
+                  style={{ width: `${pct}%` }}
+                />
+              </div>
+              <p className="text-muted-foreground text-xs">
+                {factor.reasoning}
+              </p>
+            </div>
+          );
+        })}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/app/(application)/leads/[id]/_lib/__tests__/display.test.ts
+++ b/src/app/(application)/leads/[id]/_lib/__tests__/display.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, test } from "@rstest/core";
+import {
+  FACTOR_ORDER,
+  factorLabel,
+  formatContactTime,
+  formatLastContacted,
+  formatLeadSource,
+  formatPropertyType,
+  formatTimeline,
+  impactTone,
+  stageLabel,
+  stageTone,
+} from "../display";
+
+describe("stageLabel", () => {
+  test("maps each stage to a human label", () => {
+    expect(stageLabel("unqualified")).toBe("Unqualified");
+    expect(stageLabel("nurture")).toBe("Nurture");
+    expect(stageLabel("warm")).toBe("Warm");
+    expect(stageLabel("hot")).toBe("Hot");
+  });
+});
+
+describe("stageTone", () => {
+  test("assigns a distinct Badge variant to every stage", () => {
+    const tones = new Set([
+      stageTone("unqualified"),
+      stageTone("nurture"),
+      stageTone("warm"),
+      stageTone("hot"),
+    ]);
+    expect(tones.size).toBe(4);
+  });
+});
+
+describe("factorLabel", () => {
+  test("returns a label for each of the six factors", () => {
+    expect(factorLabel("land")).toBe("Land");
+    expect(factorLabel("finance")).toBe("Finance");
+    expect(factorLabel("timeline")).toBe("Timeline");
+    expect(factorLabel("budget")).toBe("Budget");
+    expect(factorLabel("propertyType")).toBe("Property type");
+    expect(factorLabel("engagement")).toBe("Engagement");
+  });
+});
+
+describe("FACTOR_ORDER", () => {
+  test("has all six factors in the canonical order", () => {
+    expect(FACTOR_ORDER).toEqual([
+      "land",
+      "finance",
+      "timeline",
+      "budget",
+      "propertyType",
+      "engagement",
+    ]);
+  });
+});
+
+describe("impactTone", () => {
+  test("maps high, medium, and low to distinct variants", () => {
+    const tones = new Set([
+      impactTone("high"),
+      impactTone("medium"),
+      impactTone("low"),
+    ]);
+    expect(tones.size).toBe(3);
+  });
+});
+
+describe("enum formatters", () => {
+  test("formatPropertyType maps known values", () => {
+    expect(formatPropertyType("first_home_buyer")).toBe("First home buyer");
+    expect(formatPropertyType("single_storey")).toBe("Single storey");
+    expect(formatPropertyType("investment")).toBe("Investment");
+  });
+
+  test("formatPropertyType falls back to Not provided on nullish input", () => {
+    expect(formatPropertyType(null)).toBe("Not provided");
+    expect(formatPropertyType(undefined)).toBe("Not provided");
+  });
+
+  test("formatTimeline maps known values", () => {
+    expect(formatTimeline("ready_now")).toBe("Ready now");
+    expect(formatTimeline("3_6_months")).toBe("3–6 months");
+    expect(formatTimeline("12_months_plus")).toBe("12+ months");
+  });
+
+  test("formatTimeline returns Not provided when missing", () => {
+    expect(formatTimeline(null)).toBe("Not provided");
+  });
+
+  test("formatContactTime maps known values", () => {
+    expect(formatContactTime("weekdays")).toBe("Weekdays");
+    expect(formatContactTime("anytime")).toBe("Anytime");
+  });
+
+  test("formatLeadSource maps known values and humanises unknowns", () => {
+    expect(formatLeadSource("walk_in")).toBe("Walk-in");
+    expect(formatLeadSource("referral")).toBe("Referral");
+    expect(formatLeadSource("unknown_source")).toBe("Unknown source");
+  });
+});
+
+describe("formatLastContacted", () => {
+  test("returns 'Never' for null/undefined", () => {
+    expect(formatLastContacted(null)).toBe("Never");
+    expect(formatLastContacted(undefined)).toBe("Never");
+  });
+
+  test("returns 'Today' for a date earlier today", () => {
+    const now = new Date("2026-04-10T12:00:00Z");
+    const earlier = new Date("2026-04-10T06:00:00Z");
+    expect(formatLastContacted(earlier, now)).toBe("Today");
+  });
+
+  test("returns 'Yesterday' for one day ago", () => {
+    const now = new Date("2026-04-10T12:00:00");
+    const yesterday = new Date("2026-04-09T12:00:00");
+    expect(formatLastContacted(yesterday, now)).toBe("Yesterday");
+  });
+
+  test("returns days, weeks, months for older dates", () => {
+    const now = new Date("2026-04-10T12:00:00");
+    expect(formatLastContacted(new Date("2026-04-07T12:00:00"), now)).toBe(
+      "3d ago",
+    );
+    expect(formatLastContacted(new Date("2026-03-30T12:00:00"), now)).toBe(
+      "1w ago",
+    );
+    expect(formatLastContacted(new Date("2026-02-10T12:00:00"), now)).toBe(
+      "1mo ago",
+    );
+  });
+});

--- a/src/app/(application)/leads/[id]/_lib/__tests__/display.test.ts
+++ b/src/app/(application)/leads/[id]/_lib/__tests__/display.test.ts
@@ -3,12 +3,14 @@ import {
   FACTOR_ORDER,
   factorLabel,
   formatContactTime,
+  formatDate,
   formatLastContacted,
   formatLeadSource,
   formatPropertyType,
   formatTimeline,
   impactTone,
   stageLabel,
+  stageRingClasses,
   stageTone,
 } from "../display";
 
@@ -99,6 +101,28 @@ describe("enum formatters", () => {
     expect(formatLeadSource("walk_in")).toBe("Walk-in");
     expect(formatLeadSource("referral")).toBe("Referral");
     expect(formatLeadSource("unknown_source")).toBe("Unknown source");
+  });
+});
+
+describe("stageRingClasses", () => {
+  test("returns distinct classes for each stage", () => {
+    const classes = new Set([
+      stageRingClasses("unqualified"),
+      stageRingClasses("nurture"),
+      stageRingClasses("warm"),
+      stageRingClasses("hot"),
+    ]);
+    expect(classes.size).toBe(4);
+  });
+});
+
+describe("formatDate", () => {
+  test("formats a Date object in en-AU short format", () => {
+    expect(formatDate(new Date("2026-04-10T00:00:00Z"))).toBe("10 Apr 2026");
+  });
+
+  test("formats a string date", () => {
+    expect(formatDate("2026-01-15T12:00:00Z")).toBe("15 Jan 2026");
   });
 });
 

--- a/src/app/(application)/leads/[id]/_lib/display.ts
+++ b/src/app/(application)/leads/[id]/_lib/display.ts
@@ -1,0 +1,152 @@
+import type { BadgeProps } from "~/components/ui/Badge";
+
+type BadgeVariant = NonNullable<BadgeProps["variant"]>;
+type LeadStage = "unqualified" | "nurture" | "warm" | "hot";
+type FactorKey =
+  | "land"
+  | "finance"
+  | "timeline"
+  | "budget"
+  | "propertyType"
+  | "engagement";
+type Impact = "high" | "medium" | "low";
+
+/** Canonical order for rendering the six scoring factors. */
+export const FACTOR_ORDER: readonly FactorKey[] = [
+  "land",
+  "finance",
+  "timeline",
+  "budget",
+  "propertyType",
+  "engagement",
+] as const;
+
+const STAGE_LABELS: Record<LeadStage, string> = {
+  unqualified: "Unqualified",
+  nurture: "Nurture",
+  warm: "Warm",
+  hot: "Hot",
+};
+
+export function stageLabel(stage: LeadStage): string {
+  return STAGE_LABELS[stage];
+}
+
+const STAGE_BADGE_VARIANTS: Record<LeadStage, BadgeVariant> = {
+  unqualified: "outline",
+  nurture: "amber",
+  warm: "brand",
+  hot: "coral",
+};
+
+export function stageTone(stage: LeadStage): BadgeVariant {
+  return STAGE_BADGE_VARIANTS[stage];
+}
+
+const FACTOR_LABELS: Record<FactorKey, string> = {
+  land: "Land",
+  finance: "Finance",
+  timeline: "Timeline",
+  budget: "Budget",
+  propertyType: "Property type",
+  engagement: "Engagement",
+};
+
+export function factorLabel(key: FactorKey): string {
+  return FACTOR_LABELS[key];
+}
+
+const IMPACT_VARIANTS: Record<Impact, BadgeVariant> = {
+  high: "coral",
+  medium: "amber",
+  low: "outline",
+};
+
+export function impactTone(impact: Impact): BadgeVariant {
+  return IMPACT_VARIANTS[impact];
+}
+
+const PROPERTY_TYPE_LABELS: Record<string, string> = {
+  first_home_buyer: "First home buyer",
+  single_storey: "Single storey",
+  double_storey: "Double storey",
+  investment: "Investment",
+  upsize: "Upsize",
+  downsize: "Downsize",
+};
+
+export function formatPropertyType(value: string | null | undefined): string {
+  if (!value) return "Not provided";
+  return PROPERTY_TYPE_LABELS[value] ?? humanise(value);
+}
+
+const TIMELINE_LABELS: Record<string, string> = {
+  ready_now: "Ready now",
+  "3_6_months": "3–6 months",
+  "12_months_plus": "12+ months",
+};
+
+export function formatTimeline(value: string | null | undefined): string {
+  if (!value) return "Not provided";
+  return TIMELINE_LABELS[value] ?? humanise(value);
+}
+
+const CONTACT_TIME_LABELS: Record<string, string> = {
+  weekdays: "Weekdays",
+  weekends: "Weekends",
+  anytime: "Anytime",
+};
+
+export function formatContactTime(value: string | null | undefined): string {
+  if (!value) return "Not provided";
+  return CONTACT_TIME_LABELS[value] ?? humanise(value);
+}
+
+const LEAD_SOURCE_LABELS: Record<string, string> = {
+  walk_in: "Walk-in",
+  referral: "Referral",
+  social: "Social",
+  web: "Web",
+  other: "Other",
+};
+
+export function formatLeadSource(value: string | null | undefined): string {
+  if (!value) return "Not provided";
+  return LEAD_SOURCE_LABELS[value] ?? humanise(value);
+}
+
+function humanise(value: string): string {
+  return value.charAt(0).toUpperCase() + value.slice(1).replace(/_/g, " ");
+}
+
+/**
+ * Short human-readable "last contacted" string. `now` is injectable for tests.
+ */
+export function formatLastContacted(
+  date: Date | string | null | undefined,
+  now: Date = new Date(),
+): string {
+  if (!date) return "Never";
+  const d = typeof date === "string" ? new Date(date) : date;
+  if (Number.isNaN(d.getTime())) return "Never";
+
+  const msPerDay = 24 * 60 * 60 * 1000;
+  const startOfToday = new Date(
+    now.getFullYear(),
+    now.getMonth(),
+    now.getDate(),
+  ).getTime();
+  const startOfDate = new Date(
+    d.getFullYear(),
+    d.getMonth(),
+    d.getDate(),
+  ).getTime();
+  const dayDiff = Math.round((startOfToday - startOfDate) / msPerDay);
+
+  if (dayDiff <= 0) return "Today";
+  if (dayDiff === 1) return "Yesterday";
+  if (dayDiff < 7) return `${dayDiff}d ago`;
+  if (dayDiff < 30) return `${Math.floor(dayDiff / 7)}w ago`;
+  if (dayDiff < 365) return `${Math.floor(dayDiff / 30)}mo ago`;
+  return `${Math.floor(dayDiff / 365)}y ago`;
+}

--- a/src/app/(application)/leads/[id]/_lib/display.ts
+++ b/src/app/(application)/leads/[id]/_lib/display.ts
@@ -2,7 +2,7 @@ import type { BadgeProps } from "~/components/ui/Badge";
 
 type BadgeVariant = NonNullable<BadgeProps["variant"]>;
 type LeadStage = "unqualified" | "nurture" | "warm" | "hot";
-type FactorKey =
+export type FactorKey =
   | "land"
   | "finance"
   | "timeline"
@@ -41,6 +41,17 @@ const STAGE_BADGE_VARIANTS: Record<LeadStage, BadgeVariant> = {
 
 export function stageTone(stage: LeadStage): BadgeVariant {
   return STAGE_BADGE_VARIANTS[stage];
+}
+
+const STAGE_RING_CLASSES: Record<LeadStage, string> = {
+  unqualified: "border-muted-foreground/30 bg-muted/10",
+  nurture: "border-accent-amber/30 bg-accent-amber/5",
+  warm: "border-primary/30 bg-primary/5",
+  hot: "border-accent-coral/30 bg-accent-coral/5",
+};
+
+export function stageRingClasses(stage: LeadStage): string {
+  return STAGE_RING_CLASSES[stage];
 }
 
 const FACTOR_LABELS: Record<FactorKey, string> = {
@@ -113,6 +124,15 @@ const LEAD_SOURCE_LABELS: Record<string, string> = {
 export function formatLeadSource(value: string | null | undefined): string {
   if (!value) return "Not provided";
   return LEAD_SOURCE_LABELS[value] ?? humanise(value);
+}
+
+export function formatDate(date: Date | string): string {
+  const d = typeof date === "string" ? new Date(date) : date;
+  return new Intl.DateTimeFormat("en-AU", {
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+  }).format(d);
 }
 
 function humanise(value: string): string {

--- a/src/app/(application)/leads/[id]/not-found.tsx
+++ b/src/app/(application)/leads/[id]/not-found.tsx
@@ -1,0 +1,27 @@
+import { Users } from "lucide-react";
+import Link from "next/link";
+import { buttonVariants } from "~/components/ui/button-variants";
+
+export default function LeadNotFound() {
+  return (
+    <div className="flex flex-1 items-center justify-center p-4">
+      <div className="text-center">
+        <Users size={48} className="mx-auto mb-4 text-muted-foreground/50" />
+        <h2 className="font-semibold text-lg">Lead not found</h2>
+        <p className="mt-1 max-w-sm text-muted-foreground text-sm">
+          This lead doesn&apos;t exist or has been deleted.
+        </p>
+        <Link
+          href="/pipeline"
+          className={buttonVariants({
+            variant: "outline",
+            size: "md",
+            className: "mt-4",
+          })}
+        >
+          Back to pipeline
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(application)/leads/[id]/not-found.tsx
+++ b/src/app/(application)/leads/[id]/not-found.tsx
@@ -6,7 +6,7 @@ export default function LeadNotFound() {
   return (
     <div className="flex flex-1 items-center justify-center p-4">
       <div className="text-center">
-        <Users size={48} className="mx-auto mb-4 text-muted-foreground/50" />
+        <Users className="mx-auto mb-4 size-12 text-muted-foreground/50" />
         <h2 className="font-semibold text-lg">Lead not found</h2>
         <p className="mt-1 max-w-sm text-muted-foreground text-sm">
           This lead doesn&apos;t exist or has been deleted.

--- a/src/app/(application)/leads/[id]/page.tsx
+++ b/src/app/(application)/leads/[id]/page.tsx
@@ -1,0 +1,33 @@
+import { TRPCError } from "@trpc/server";
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { getQueryClient, HydrateClient, trpc } from "~/trpc/server";
+import { LeadProfileView } from "./_components/lead-profile-view";
+
+export const metadata: Metadata = {
+  title: "Lead | Rekurve",
+};
+
+export default async function LeadProfilePage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const queryClient = getQueryClient();
+
+  try {
+    await queryClient.fetchQuery(trpc.leads.getById.queryOptions({ id }));
+  } catch (err) {
+    if (err instanceof TRPCError && err.code === "NOT_FOUND") {
+      notFound();
+    }
+    throw err;
+  }
+
+  return (
+    <HydrateClient>
+      <LeadProfileView id={id} />
+    </HydrateClient>
+  );
+}

--- a/src/server/api/__tests__/leads-router.test.ts
+++ b/src/server/api/__tests__/leads-router.test.ts
@@ -70,6 +70,19 @@ beforeEach(() => {
     },
   };
 
+  // Default chainable mock for db.update used by synchronous re-scoring in
+  // create/update. Tests can override this by calling mockReturnValue again.
+  const defaultUpdateReturning = rs.fn().mockResolvedValue([mockLead]);
+  const defaultUpdateWhere = rs
+    .fn()
+    .mockReturnValue({ returning: defaultUpdateReturning });
+  const defaultUpdateSet = rs
+    .fn()
+    .mockReturnValue({ where: defaultUpdateWhere });
+  (mockDb.update as ReturnType<typeof rs.fn>).mockReturnValue({
+    set: defaultUpdateSet,
+  });
+
   rs.doMock("~/server/db", () => ({ db: mockDb }));
 
   rs.doMock("~/server/scoring", () => ({
@@ -160,9 +173,16 @@ describe("leads.create", () => {
 
   test("creates a lead with quick capture data", async () => {
     const quickLead = { ...mockLead, email: null, notes: "Met at BBQ" };
-    const returning = rs.fn().mockResolvedValue([quickLead]);
-    const values = rs.fn().mockReturnValue({ returning });
+    const insertReturning = rs.fn().mockResolvedValue([quickLead]);
+    const values = rs.fn().mockReturnValue({ returning: insertReturning });
     (mockDb.insert as ReturnType<typeof rs.fn>).mockReturnValue({ values });
+
+    // scoreLead's db.update returns the scored version of the same row so
+    // the router's response still carries the quick-capture fields.
+    const updateReturning = rs.fn().mockResolvedValue([quickLead]);
+    const where = rs.fn().mockReturnValue({ returning: updateReturning });
+    const set = rs.fn().mockReturnValue({ where });
+    (mockDb.update as ReturnType<typeof rs.fn>).mockReturnValue({ set });
 
     const caller = await getCaller();
     const result = await caller.leads.create({
@@ -502,91 +522,264 @@ describe("leads.delete", () => {
 // --- leads.create — scoring integration ---
 
 describe("leads.create — scoring integration", () => {
-  test("returns lead immediately without waiting for scoring", async () => {
+  test("returns a scored lead when input contains qualifying data", async () => {
     const { qualifyAndScore } = await import("~/server/scoring");
-    (qualifyAndScore as ReturnType<typeof rs.fn>).mockImplementation(() => ({
-      score: 0,
-      stage: "unqualified",
-      breakdown: {},
+    (qualifyAndScore as ReturnType<typeof rs.fn>).mockReturnValueOnce({
+      score: 85,
+      stage: "hot",
+      breakdown: {
+        land: { score: 30, maxScore: 30, reasoning: "registered" },
+        finance: { score: 15, maxScore: 25, reasoning: "broker" },
+        timeline: { score: 20, maxScore: 20, reasoning: "ready now" },
+        budget: { score: 10, maxScore: 10, reasoning: "in range" },
+        propertyType: { score: 10, maxScore: 10, reasoning: "clear intent" },
+        engagement: { score: 0, maxScore: 5, reasoning: "no data" },
+      },
       gaps: [],
-      nextQuestion: "",
-    }));
+      nextQuestion: "All good",
+    });
 
-    const returning = rs.fn().mockResolvedValue([mockLead]);
-    const values = rs.fn().mockReturnValue({ returning });
+    // Insert returns the unscored row
+    const insertReturning = rs.fn().mockResolvedValue([mockLead]);
+    const values = rs.fn().mockReturnValue({ returning: insertReturning });
     (mockDb.insert as ReturnType<typeof rs.fn>).mockReturnValue({ values });
+
+    // scoreLead's db.update returns the fully-scored row
+    const scoredLead = {
+      ...mockLead,
+      leadScore: 85,
+      leadStage: "hot" as const,
+      scoreMetadata: {
+        score: 85,
+        stage: "hot" as const,
+        breakdown: {
+          land: { score: 30, maxScore: 30, reasoning: "registered" },
+          finance: { score: 15, maxScore: 25, reasoning: "broker" },
+          timeline: { score: 20, maxScore: 20, reasoning: "ready now" },
+          budget: { score: 10, maxScore: 10, reasoning: "in range" },
+          propertyType: { score: 10, maxScore: 10, reasoning: "clear intent" },
+          engagement: { score: 0, maxScore: 5, reasoning: "no data" },
+        },
+        gaps: [],
+        nextQuestion: "All good",
+        scoredAt: "2026-04-10T00:00:00.000Z",
+      },
+    };
+    const updateReturning = rs.fn().mockResolvedValue([scoredLead]);
+    const where = rs.fn().mockReturnValue({ returning: updateReturning });
+    const set = rs.fn().mockReturnValue({ where });
+    (mockDb.update as ReturnType<typeof rs.fn>).mockReturnValue({ set });
 
     const caller = await getCaller();
     const result = await caller.leads.create({
       firstName: "John",
       lastName: "Smith",
+      hasLand: true,
+      landRegistered: true,
+      landSizeSqm: "450",
+      seenBroker: true,
+      constructionTimeline: "ready_now",
+      budget: "$650000",
+      propertyType: "first_home_buyer",
     });
 
-    // Should return immediately, not wait for scoring
-    expect(result.firstName).toBe("John");
+    expect(result.leadScore).toBe(85);
+    expect(result.leadStage).toBe("hot");
+    expect(result.scoreMetadata).not.toBeNull();
+    expect(result.scoreMetadata?.score).toBe(85);
+    expect(result.scoreMetadata?.gaps).toHaveLength(0);
+    expect(qualifyAndScore).toHaveBeenCalled();
   });
 
-  test("create succeeds even when scoring throws", async () => {
+  test("returns an unqualified lead with 5 gaps for quick-capture input", async () => {
     const { qualifyAndScore } = await import("~/server/scoring");
-    (qualifyAndScore as ReturnType<typeof rs.fn>).mockImplementation(() => {
-      throw new Error("Scoring failed");
+    (qualifyAndScore as ReturnType<typeof rs.fn>).mockReturnValueOnce({
+      score: 0,
+      stage: "unqualified",
+      breakdown: {
+        land: { score: 0, maxScore: 30, reasoning: "none" },
+        finance: { score: 0, maxScore: 25, reasoning: "unknown" },
+        timeline: { score: 0, maxScore: 20, reasoning: "none" },
+        budget: { score: 0, maxScore: 10, reasoning: "none" },
+        propertyType: { score: 0, maxScore: 10, reasoning: "none" },
+        engagement: { score: 0, maxScore: 5, reasoning: "no data" },
+      },
+      gaps: [
+        { field: "land", impact: "high", description: "No land" },
+        { field: "finance", impact: "high", description: "Unknown" },
+        { field: "timeline", impact: "high", description: "No timeline" },
+        { field: "budget", impact: "medium", description: "No budget" },
+        { field: "propertyType", impact: "medium", description: "No type" },
+      ],
+      nextQuestion: "Do you have land?",
     });
 
-    const returning = rs.fn().mockResolvedValue([mockLead]);
-    const values = rs.fn().mockReturnValue({ returning });
+    const quickLead = { ...mockLead, email: null };
+    const insertReturning = rs.fn().mockResolvedValue([quickLead]);
+    const values = rs.fn().mockReturnValue({ returning: insertReturning });
     (mockDb.insert as ReturnType<typeof rs.fn>).mockReturnValue({ values });
+
+    const scoredQuickLead = {
+      ...quickLead,
+      leadScore: 0,
+      leadStage: "unqualified" as const,
+      scoreMetadata: {
+        score: 0,
+        stage: "unqualified" as const,
+        breakdown: {
+          land: { score: 0, maxScore: 30, reasoning: "none" },
+          finance: { score: 0, maxScore: 25, reasoning: "unknown" },
+          timeline: { score: 0, maxScore: 20, reasoning: "none" },
+          budget: { score: 0, maxScore: 10, reasoning: "none" },
+          propertyType: { score: 0, maxScore: 10, reasoning: "none" },
+          engagement: { score: 0, maxScore: 5, reasoning: "no data" },
+        },
+        gaps: [
+          {
+            field: "land",
+            impact: "high" as const,
+            description: "No land",
+          },
+          {
+            field: "finance",
+            impact: "high" as const,
+            description: "Unknown",
+          },
+          {
+            field: "timeline",
+            impact: "high" as const,
+            description: "No timeline",
+          },
+          {
+            field: "budget",
+            impact: "medium" as const,
+            description: "No budget",
+          },
+          {
+            field: "propertyType",
+            impact: "medium" as const,
+            description: "No type",
+          },
+        ],
+        nextQuestion: "Do you have land?",
+        scoredAt: "2026-04-10T00:00:00.000Z",
+      },
+    };
+    const updateReturning = rs.fn().mockResolvedValue([scoredQuickLead]);
+    const where = rs.fn().mockReturnValue({ returning: updateReturning });
+    const set = rs.fn().mockReturnValue({ where });
+    (mockDb.update as ReturnType<typeof rs.fn>).mockReturnValue({ set });
 
     const caller = await getCaller();
     const result = await caller.leads.create({
       firstName: "John",
       lastName: "Smith",
+      phone: "0412345678",
     });
 
-    expect(result.firstName).toBe("John");
     expect(result.leadScore).toBe(0);
+    expect(result.leadStage).toBe("unqualified");
+    expect(result.scoreMetadata?.gaps).toHaveLength(5);
   });
 });
 
 // --- leads.update — scoring integration ---
 
 describe("leads.update — scoring integration", () => {
-  test("triggers re-scoring when qualification fields change", async () => {
+  test("re-scores and returns the new score when a scoring field changes", async () => {
     (
       mockDb.query as { leads: { findFirst: ReturnType<typeof rs.fn> } }
     ).leads.findFirst.mockResolvedValue({ hubspotContactId: null });
 
     const { qualifyAndScore } = await import("~/server/scoring");
-    const updatedLead = { ...mockLead, budget: "$700K" };
-    const returning = rs.fn().mockResolvedValue([updatedLead]);
+    (qualifyAndScore as ReturnType<typeof rs.fn>).mockReturnValueOnce({
+      score: 20,
+      stage: "unqualified",
+      breakdown: {
+        land: { score: 0, maxScore: 30, reasoning: "none" },
+        finance: { score: 0, maxScore: 25, reasoning: "unknown" },
+        timeline: { score: 20, maxScore: 20, reasoning: "ready now" },
+        budget: { score: 0, maxScore: 10, reasoning: "none" },
+        propertyType: { score: 0, maxScore: 10, reasoning: "none" },
+        engagement: { score: 0, maxScore: 5, reasoning: "no data" },
+      },
+      gaps: [],
+      nextQuestion: "All good",
+    });
+
+    // First call: main update returns the unscored edited row.
+    // Second call: scoreLead's update returns the scored row.
+    const editedLead = {
+      ...mockLead,
+      constructionTimeline: "ready_now" as const,
+    };
+    const scoredEditedLead = {
+      ...editedLead,
+      leadScore: 20,
+      leadStage: "unqualified" as const,
+      scoreMetadata: {
+        score: 20,
+        stage: "unqualified" as const,
+        breakdown: {
+          land: { score: 0, maxScore: 30, reasoning: "none" },
+          finance: { score: 0, maxScore: 25, reasoning: "unknown" },
+          timeline: { score: 20, maxScore: 20, reasoning: "ready now" },
+          budget: { score: 0, maxScore: 10, reasoning: "none" },
+          propertyType: { score: 0, maxScore: 10, reasoning: "none" },
+          engagement: { score: 0, maxScore: 5, reasoning: "no data" },
+        },
+        gaps: [],
+        nextQuestion: "All good",
+        scoredAt: "2026-04-10T00:00:00.000Z",
+      },
+    };
+    const returning = rs
+      .fn()
+      .mockResolvedValueOnce([editedLead])
+      .mockResolvedValueOnce([scoredEditedLead]);
     const where = rs.fn().mockReturnValue({ returning });
     const set = rs.fn().mockReturnValue({ where });
     (mockDb.update as ReturnType<typeof rs.fn>).mockReturnValue({ set });
 
     const caller = await getCaller();
-    await caller.leads.update({ id: mockLead.id, budget: "$700K" });
+    const result = await caller.leads.update({
+      id: mockLead.id,
+      constructionTimeline: "ready_now",
+    });
 
-    // Give the microtask queue a tick
-    await new Promise((r) => setTimeout(r, 0));
     expect(qualifyAndScore).toHaveBeenCalled();
+    expect(result.leadScore).toBe(20);
+    expect(result.scoreMetadata?.breakdown.timeline.score).toBe(20);
   });
 
-  test("does not re-score when only non-qualification fields change", async () => {
+  test("does not re-score or rewrite scoreMetadata for non-scoring fields", async () => {
     (
       mockDb.query as { leads: { findFirst: ReturnType<typeof rs.fn> } }
     ).leads.findFirst.mockResolvedValue({ hubspotContactId: null });
 
     const { qualifyAndScore } = await import("~/server/scoring");
-    const updatedLead = { ...mockLead, referrerName: "Bob" };
+    const updatedLead = {
+      ...mockLead,
+      notes: "Met at BBQ",
+      leadScore: 42,
+      scoreMetadata: null,
+    };
     const returning = rs.fn().mockResolvedValue([updatedLead]);
     const where = rs.fn().mockReturnValue({ returning });
     const set = rs.fn().mockReturnValue({ where });
     (mockDb.update as ReturnType<typeof rs.fn>).mockReturnValue({ set });
 
     const caller = await getCaller();
-    await caller.leads.update({ id: mockLead.id, referrerName: "Bob" });
+    const result = await caller.leads.update({
+      id: mockLead.id,
+      notes: "Met at BBQ",
+    });
 
-    await new Promise((r) => setTimeout(r, 0));
     expect(qualifyAndScore).not.toHaveBeenCalled();
+    // Main update was called exactly once (no second score-write)
+    expect(set).toHaveBeenCalledTimes(1);
+    expect(result.leadScore).toBe(42);
+    expect(result.scoreMetadata).toBeNull();
   });
 });
 

--- a/src/server/api/routers/leads.ts
+++ b/src/server/api/routers/leads.ts
@@ -18,42 +18,46 @@ import {
 import type { ScoreMetadata } from "~/server/scoring";
 import { qualifyAndScore } from "~/server/scoring";
 
-/** Fire-and-forget scoring — errors are logged, never thrown. */
-async function scoreLeadAsync(
+/**
+ * Synchronously re-score a lead, persist the new score/stage/metadata, and
+ * push the score/stage to HubSpot if linked. Returns the fully-scored row so
+ * callers can send an authoritative response back to the client.
+ *
+ * Scoring and the score write propagate errors. HubSpot push errors are
+ * logged, not thrown — scoring must not fail because of a CRM outage.
+ */
+async function scoreLead(
   db: typeof import("~/server/db").db,
-  leadId: string,
-  lead: Parameters<typeof qualifyAndScore>[0],
+  lead: typeof leads.$inferSelect,
   hubspotContactId: string | null,
-): Promise<void> {
-  try {
-    const result = qualifyAndScore(lead);
+): Promise<typeof leads.$inferSelect> {
+  const result = qualifyAndScore(lead);
+  const metadata: ScoreMetadata = {
+    ...result,
+    scoredAt: new Date().toISOString(),
+  };
 
-    const metadata: ScoreMetadata = {
-      ...result,
-      scoredAt: new Date().toISOString(),
-    };
+  const [scored] = await db
+    .update(leads)
+    .set({
+      leadScore: result.score,
+      leadStage: result.stage,
+      scoreMetadata: metadata,
+      updatedAt: new Date(),
+    })
+    .where(eq(leads.id, lead.id))
+    .returning();
 
-    await db
-      .update(leads)
-      .set({
-        leadScore: result.score,
-        leadStage: result.stage,
-        scoreMetadata: metadata,
-        updatedAt: new Date(),
-      })
-      .where(eq(leads.id, leadId));
-
-    if (hubspotContactId) {
-      await updateHubSpotContact(hubspotContactId, {
-        leadScore: String(result.score),
-        leadStage: result.stage,
-      }).catch((err) => {
-        console.error(`[scoring] HubSpot sync failed for lead ${leadId}:`, err);
-      });
-    }
-  } catch (err) {
-    console.error(`[scoring] Failed to score lead ${leadId}:`, err);
+  if (hubspotContactId) {
+    await updateHubSpotContact(hubspotContactId, {
+      leadScore: String(result.score),
+      leadStage: result.stage,
+    }).catch((err) => {
+      console.error(`[scoring] HubSpot sync failed for lead ${lead.id}:`, err);
+    });
   }
+
+  return scored!;
 }
 
 // Qualification fields that trigger re-scoring
@@ -91,8 +95,9 @@ export const leadsRouter = createTRPCRouter({
         : await createContact(hubspotData);
 
       // 3. Write to local DB with hubspotContactId
+      let lead: typeof leads.$inferSelect;
       try {
-        const [lead] = await ctx.db
+        const [inserted] = await ctx.db
           .insert(leads)
           .values({
             ...input,
@@ -101,11 +106,7 @@ export const leadsRouter = createTRPCRouter({
             leadScore: 0,
           })
           .returning();
-
-        // Fire-and-forget — don't block the response
-        void scoreLeadAsync(ctx.db, lead!.id, lead!, lead!.hubspotContactId);
-
-        return lead!;
+        lead = inserted!;
       } catch (err) {
         const cause = err instanceof Error ? err.cause : undefined;
         console.error(
@@ -119,6 +120,9 @@ export const leadsRouter = createTRPCRouter({
           message: `Lead saved to HubSpot (contact ID: ${hubspotContact.id}) but local save failed. Retry or check HubSpot.`,
         });
       }
+
+      // 4. Score synchronously so the response reflects the final score/stage
+      return await scoreLead(ctx.db, lead, lead.hubspotContactId);
     }),
 
   getById: protectedProcedure
@@ -226,17 +230,13 @@ export const leadsRouter = createTRPCRouter({
         throw new TRPCError({ code: "NOT_FOUND", message: "Lead not found" });
       }
 
-      // Re-score if qualification fields changed
+      // Re-score if qualification fields changed — awaited so the returned
+      // row always reflects the latest score/stage/scoreMetadata.
       const hasQualificationChange = Object.keys(data).some((k) =>
         SCORING_FIELDS.has(k),
       );
       if (hasQualificationChange) {
-        void scoreLeadAsync(
-          ctx.db,
-          updated.id,
-          updated,
-          updated.hubspotContactId,
-        );
+        return await scoreLead(ctx.db, updated, updated.hubspotContactId);
       }
 
       return updated;

--- a/thoughts/plans/2026-04-09-101-lead-profile-page.md
+++ b/thoughts/plans/2026-04-09-101-lead-profile-page.md
@@ -1,0 +1,473 @@
+# Lead Profile Page Implementation Plan
+
+**Issue:** [samjmarshall/www#101](https://github.com/samjmarshall/www/issues/101)
+**Epic:** #86 — Lead Management + AI Qualification Scoring
+**Status:** Draft
+
+## Overview
+
+Build `/leads/[id]` — the consultant's detailed view of a single lead. Displays all qualification data, a per-factor score breakdown, ranked qualification gaps with a suggested next question, and inline edit that re-scores the lead on save. Completes the last child issue of Epic 2.
+
+## Current State Analysis
+
+Most of the infrastructure is already in place:
+
+- **Schema.** `leads` table has every field the page needs, including `lead_score`, `lead_stage`, and a JSONB `score_metadata` column that holds the full `ScoreResult` plus a `scoredAt` timestamp (`src/server/db/schema/leads.ts:52-54`).
+- **Scoring.** `qualifyAndScore()` is pure, deterministic, and in-process — six factor functions produce `{score, stage, breakdown, gaps, nextQuestion}` (`src/server/scoring/qualify-and-score.ts:48`). No Claude API call. Max achievable today is 85 (finance capped at 15, engagement hardcoded to 0). This matches the issue's "fully qualified → score 85" criterion exactly.
+- **Router.** `leads.getById` and `leads.update` already exist (`src/server/api/routers/leads.ts:123,190`). `update` already re-scores when qualification fields change.
+- **UI primitives.** shadcn Card, Badge, Button, Field, Input, Select, Textarea are all in `src/components/ui/`. `cn`, `formatCurrency`, and `isValidAuMobile` live in `src/lib/`.
+- **Form patterns.** `leads/new/_components/lead-form.tsx` shows the react-hook-form + `useTRPC` + `useMutation` pattern used throughout the app.
+- **Test harness.** E2E tests use session-cookie fixtures (`e2e/utils/auth-helper.ts`), `uniquePhone()` for parallel safety, test emails matching `e2e-*@test.rekurve.dev`, and a global teardown that cleans both the DB and HubSpot contacts.
+
+Two gaps need closing before the page can meet its acceptance criteria:
+
+1. **Fire-and-forget scoring race.** `leads.router` wraps the re-score in `scoreLeadAsync` and calls it with `void`, so the mutation response returns before the new `scoreMetadata` is persisted (`src/server/api/routers/leads.ts:20-56, 232-239`). A naive refetch after edit would show stale data. Since scoring is fully synchronous and in-process, the fix is to await it.
+2. **No RSC prefetch usage yet.** `src/trpc/server.tsx` exports `HydrateClient` and `prefetch`, but no file under `src/app/` imports them. The profile page is the first consumer of the dual-client pattern — the infra exists, it just needs wiring.
+
+## Desired End State
+
+A consultant navigating to `/leads/[id]` sees:
+
+- Header with name, tap-to-call phone, tap-to-email email, a large score badge colour-coded by stage, the stage label, and last-contacted date.
+- Score breakdown showing all six factors (land/30, finance/25, timeline/20, budget/10, propertyType/10, engagement/5) with scores, max, and reasoning pulled from `score_metadata.breakdown`.
+- Ranked qualification gaps with impact badges and descriptions, plus a prominent "Suggested next question" from `score_metadata.nextQuestion`. A fully qualified lead shows a "No gaps" state instead.
+- Lead details grouped into Contact / Land / Build / Preferences / Source sections in a readable layout.
+- Conversation history placeholder card.
+- An Edit button that swaps the whole page into inline-edit mode with sticky Save/Cancel. Save calls `leads.update`, the page refetches `getById`, and the score badge and breakdown update in place without navigation.
+
+### Key Discoveries
+
+- `scoreMetadata` already holds everything the UI needs — no new tRPC procedure or scoring pass required (`src/server/db/schema/leads.ts:54`).
+- `leads.getById` throws `TRPCError({code: "NOT_FOUND"})` for missing leads (`src/server/api/routers/leads.ts:129-131`), which the RSC page can catch to call `notFound()`.
+- `QualifyAndScoreResult.breakdown` has exactly the six keys needed (`land`, `finance`, `timeline`, `budget`, `propertyType`, `engagement`) with `{score, maxScore, reasoning}` on each (`src/server/scoring/schema.ts:10-18`).
+- `detectGaps` already ranks gaps by factor weight and maps them to `high`/`medium`/`low` impact (`src/server/scoring/score-factors.ts:219-227`), and `pickNextQuestion` always targets the highest-impact gap (`src/server/scoring/score-factors.ts:243-247`). The UI just renders what the server produced.
+- `lead-form.tsx` already handles Zod field errors from tRPC and maps them back onto the form (`src/app/(application)/leads/new/_components/lead-form.tsx:75-91`) — the edit form mirrors this.
+
+## What We're NOT Doing
+
+- No changes to `qualifyAndScore()` itself, scoring factors, or thresholds. Existing behaviour is the contract.
+- No new tRPC procedures — `getById` and `update` are sufficient.
+- No Epic 3 work: conversation history is a static placeholder card.
+- No pipeline board work (that's #100). The profile page doesn't depend on the pipeline for navigation; E2E tests navigate directly to `/leads/[id]`.
+- No `frontend-design`-led redesign of the app shell, sidebar, or bottom nav.
+- No new icon or charting library — the score breakdown uses plain segmented bars.
+- No multi-step edit form. Single page-level toggle, all fields editable on one screen.
+- No optimistic updates on save — refetch-on-success is simpler and matches the acceptance criteria.
+
+## Implementation Approach
+
+Three phases, each independently testable:
+
+1. Make `leads.create` and `leads.update` re-score synchronously so the response is always authoritative.
+2. Build the read-only profile page using the dual-client RSC prefetch pattern, and add E2E tests for the score/breakdown/gaps/next-question requirements.
+3. Add the inline edit mode on top of the same page, and add the edit-in-place E2E test.
+
+---
+
+## Phase 1: Synchronous re-scoring in `leads` router
+
+### Overview
+
+Remove the fire-and-forget wrapper around scoring so `create` and `update` return a lead whose `leadScore`, `leadStage`, and `scoreMetadata` already reflect the new qualification state. This closes the race that would otherwise make "score updates in-place" flaky.
+
+### Changes Required
+
+#### 1. Inline scoring into `create` and `update`
+
+**File:** `src/server/api/routers/leads.ts`
+
+**Changes:**
+- Delete `scoreLeadAsync` at lines 20-56.
+- Add a small `scoreLead(db, lead, hubspotContactId)` helper that computes the score, writes `leadScore`/`leadStage`/`scoreMetadata`/`updatedAt` in a single update, pushes the score/stage to HubSpot if linked, and returns the fully-scored lead row. Errors from the HubSpot push remain logged-not-thrown (consistent with current behaviour); errors from the score write or the qualify call propagate up.
+- In `create`: after the insert, call `await scoreLead(ctx.db, lead, hubspotContactId)` and return its result instead of the unscored row.
+- In `update`: after the main update, if `SCORING_FIELDS` changed, call `await scoreLead(ctx.db, updated, updated.hubspotContactId)` and return its result. Otherwise return `updated` unchanged.
+
+```ts
+// src/server/api/routers/leads.ts
+async function scoreLead(
+  db: typeof import("~/server/db").db,
+  lead: typeof leads.$inferSelect,
+  hubspotContactId: string | null,
+): Promise<typeof leads.$inferSelect> {
+  const result = qualifyAndScore(lead);
+  const metadata: ScoreMetadata = { ...result, scoredAt: new Date().toISOString() };
+
+  const [scored] = await db
+    .update(leads)
+    .set({
+      leadScore: result.score,
+      leadStage: result.stage,
+      scoreMetadata: metadata,
+      updatedAt: new Date(),
+    })
+    .where(eq(leads.id, lead.id))
+    .returning();
+
+  if (hubspotContactId) {
+    await updateHubSpotContact(hubspotContactId, {
+      leadScore: String(result.score),
+      leadStage: result.stage,
+    }).catch((err) => {
+      console.error(`[scoring] HubSpot sync failed for lead ${lead.id}:`, err);
+    });
+  }
+
+  return scored!;
+}
+```
+
+#### 2. Router unit tests
+
+**File:** `src/server/api/__tests__/leads-router.test.ts`
+
+**Tests:**
+- `create` returns a lead with `leadScore > 0`, `leadStage !== "unqualified"`, and a populated `scoreMetadata` when the input contains qualifying data (e.g. `hasLand: true`, `landRegistered: true`, `landSizeSqm: "450"`, `seenBroker: true`, `constructionTimeline: "ready_now"`, `budget: "$650000"`, `propertyType: "first_home_buyer"`).
+- `create` returns a lead with `leadScore === 0`, `leadStage === "unqualified"`, and a `scoreMetadata` whose `gaps.length === 5` when the input is quick-capture-shaped (name + phone only).
+- `update` with `constructionTimeline: "ready_now"` on an existing unqualified lead bumps `leadScore` and returns the new score in the response (no refetch needed).
+- `update` with a non-scoring field like `notes` leaves `leadScore` unchanged and does not re-write `scoreMetadata`.
+
+### Success Criteria
+
+#### Automated Verification
+- [x] `make test` passes
+- [x] `make check` passes (lint + typecheck)
+
+#### Manual Verification
+- [ ] Create a lead via the full form locally and inspect the tRPC response — the returned row has a non-zero score and populated `scoreMetadata`
+
+---
+
+## Phase 2: Profile page — read-only view
+
+### Overview
+
+Build the server-rendered profile page and all its read-only sections. Wire up the dual-client RSC prefetch pattern so the page arrives with data already hydrated. Apply the `frontend-design` skill during implementation and run `/design_review` before merging this phase.
+
+### Changes Required
+
+#### 1. RSC page + `notFound` handling
+
+**File:** `src/app/(application)/leads/[id]/page.tsx`
+
+**Changes:** New file. Async server component: await `params`, fetch the lead via `queryClient.fetchQuery(trpc.leads.getById.queryOptions({id}))`, catch `TRPCError` with `code === "NOT_FOUND"` and call `notFound()`, then render `<HydrateClient><LeadProfileView id={id} /></HydrateClient>`. This is the first use of `HydrateClient` in the app — set the precedent cleanly.
+
+```tsx
+// src/app/(application)/leads/[id]/page.tsx
+import { TRPCError } from "@trpc/server";
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { HydrateClient, getQueryClient, trpc } from "~/trpc/server";
+import { LeadProfileView } from "./_components/lead-profile-view";
+
+export const metadata: Metadata = { title: "Lead | Rekurve" };
+
+export default async function LeadProfilePage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const queryClient = getQueryClient();
+
+  try {
+    await queryClient.fetchQuery(trpc.leads.getById.queryOptions({ id }));
+  } catch (err) {
+    if (err instanceof TRPCError && err.code === "NOT_FOUND") notFound();
+    throw err;
+  }
+
+  return (
+    <HydrateClient>
+      <LeadProfileView id={id} />
+    </HydrateClient>
+  );
+}
+```
+
+**Note:** `src/trpc/server.tsx` currently exports `getQueryClient`, `HydrateClient`, `trpc`, and `prefetch`. No changes needed there.
+
+#### 2. Not-found boundary
+
+**File:** `src/app/(application)/leads/[id]/not-found.tsx`
+
+**Changes:** New file. A small full-page empty state with a "Back to pipeline" link, using the existing `Users` icon treatment from the pipeline empty state for consistency.
+
+#### 3. Profile view container (client)
+
+**File:** `src/app/(application)/leads/[id]/_components/lead-profile-view.tsx`
+
+**Changes:** New client component. Calls `useQuery(trpc.leads.getById.queryOptions({id}))` — hydrated from the RSC prefetch so there's no loading flash. Renders a page header and the five sub-components in order: `ProfileHeader`, `ScoreBreakdown`, `QualificationGaps`, `LeadDetails`, `ConversationHistoryPlaceholder`. Owns the `isEditing` state (flipped to `true` in Phase 3 — declared here as a stub returning `false` for now). Handles the `isLoading` and `isError` edge cases.
+
+#### 4. Profile header (tap-to-call/email, score badge, stage)
+
+**File:** `src/app/(application)/leads/[id]/_components/profile-header.tsx`
+
+**Changes:** New component. Shows `{firstName} {lastName}`, phone as `<a href="tel:...">` when present, email as `<a href="mailto:...">` when present, a large score badge whose colour maps to stage (see stage helper below), a stage label, last-contacted date (or "Never"), and an Edit button (wired in Phase 3 — stubbed `disabled` here with a `data-testid` in place). The whole header is sticky-on-desktop but inline on mobile.
+
+#### 5. Score breakdown
+
+**File:** `src/app/(application)/leads/[id]/_components/score-breakdown.tsx`
+
+**Changes:** New component. Iterates over `scoreMetadata.breakdown` in the canonical order `["land", "finance", "timeline", "budget", "propertyType", "engagement"]`, rendering each factor as a row with:
+- Factor label (from a factor-display helper below)
+- `{score}/{maxScore}` on the right
+- A horizontal track with a filled segment sized by `score/maxScore`
+- The `reasoning` text underneath
+
+If `scoreMetadata` is `null` (should only happen transiently before Phase 1 lands, but defend anyway), show a subtle "Score pending…" state rather than blanking. Each factor row gets `data-testid="score-factor-{key}"` so tests can assert directly.
+
+#### 6. Qualification gaps + suggested next question
+
+**File:** `src/app/(application)/leads/[id]/_components/qualification-gaps.tsx`
+
+**Changes:** New component. Renders `scoreMetadata.gaps` as a list (the server already sorted them high → low). Each item: field label, impact badge (reuse `Badge` variants — `coral` for high, `amber` for medium, `outline` for low), description. Above the list, the "Suggested next question" is rendered as a prominent quoted block showing `scoreMetadata.nextQuestion`. When `gaps.length === 0`, render a success-variant message: "No gaps — this lead is fully qualified." and hide the next-question block.
+
+Each gap item gets `data-testid="gap-item-{field}"`; the whole list gets `data-testid="gaps-list"`; the next question gets `data-testid="next-question"`.
+
+#### 7. Lead details
+
+**File:** `src/app/(application)/leads/[id]/_components/lead-details.tsx`
+
+**Changes:** New component. Five grouped Cards:
+- **Contact:** first/last name, phone, email, preferred contact time
+- **Land:** has land (Yes/No), registered, address, size (m² + width × depth)
+- **Build:** property type, budget, seen broker, construction timeline
+- **Preferences:** preferred estates (chips), preferred suburbs (chips), Resolve Finance opt-in
+- **Source:** lead source, referrer name, notes, created at
+
+Unset fields render as muted "Not provided". Enum values are humanised via a shared display helper (`formatPropertyType`, `formatTimeline`, etc.).
+
+#### 8. Conversation history placeholder
+
+**File:** `src/app/(application)/leads/[id]/_components/conversation-history.tsx`
+
+**Changes:** New component. A single Card with the literal message from the ticket: "No messages yet — conversation history will appear here when Epic 3 is complete."
+
+#### 9. Display helpers
+
+**File:** `src/app/(application)/leads/[id]/_lib/display.ts`
+
+**Changes:** New file. Small pure helpers used across the sub-components:
+- `stageLabel(stage)` → "Unqualified" / "Nurture" / "Warm" / "Hot"
+- `stageTone(stage)` → returns a Badge `variant` key plus a text colour class for the score badge (e.g. `unqualified → outline`, `nurture → amber`, `warm → brand`, `hot → coral` — confirm final mapping during `frontend-design`/`/design_review`)
+- `factorLabel(key)` → "Land", "Finance", "Timeline", "Budget", "Property type", "Engagement"
+- `impactTone(impact)` → Badge variant for high/medium/low
+- `formatPropertyType(value)`, `formatTimeline(value)`, `formatContactTime(value)`, `formatLeadSource(value)` — enum → human label
+- `formatLastContacted(date | null)` → short relative string ("Today", "3d ago") or "Never"
+
+All pure, no React, trivially unit-tested.
+
+#### 10. Unit tests for display helpers
+
+**File:** `src/app/(application)/leads/[id]/_lib/__tests__/display.test.ts`
+
+**Tests:**
+- `stageLabel` returns the right label for each stage
+- `factorLabel` returns the right label for each of the six keys
+- `impactTone` maps high/medium/low to distinct values
+- `formatLastContacted(null)` → "Never"; a recent date → today/days-ago string
+- Enum formatters map known values and fall back gracefully on unknown input
+
+#### 11. E2E page object
+
+**File:** `e2e/pages/sections/lead-profile.section.ts`
+
+**Changes:** New page object modeled on `lead-form.section.ts` and `quick-capture.section.ts`. Exposes locators for the header, score badge, stage label, phone link, email link, each score factor row, gaps list, individual gap items, next question, conversation history placeholder, and edit/save/cancel buttons (used in Phase 3). Helper methods:
+
+```ts
+// e2e/pages/sections/lead-profile.section.ts
+async waitForScored() {
+  // Waits until the score badge is non-empty — defensive even after Phase 1
+  await expect(this.scoreBadge).not.toHaveText("--", { timeout: 10_000 });
+}
+
+async expectScore(score: number) { ... }
+async expectStage(stage: "unqualified" | "nurture" | "warm" | "hot") { ... }
+async expectGapCount(count: number) { ... }
+async expectFactor(key: string, score: number, max: number) { ... }
+async expectNextQuestionMentions(keyword: string | RegExp) { ... }
+```
+
+All locators use `data-testid="lead-profile-*"`.
+
+#### 12. E2E tests — read-only profile behaviour
+
+**File:** `e2e/features/lead-profile.spec.ts`
+
+**Tests:**
+- `test.beforeAll` / `afterAll` create and delete a session, same pattern as `leads-crud.spec.ts`.
+- `test.skip(!process.env.DATABASE_URL, ...)` — same guard.
+
+1. **Quick capture lead → unqualified, 5 gaps.** Navigate to `/dashboard`, open quick capture, fill name + unique phone, submit, wait for the success toast, extract the lead id from the toast's "View profile" link (added to the quick capture success toast, see next bullet) or by querying the DB with the phone number, navigate to `/leads/[id]`, assert score badge shows `0`, stage label shows "Unqualified", gap list has 5 items, next question mentions land.
+
+2. **Fully qualified lead → hot, 0 gaps.** Create via the full form (reuse `LeadFormSection` to fill all four steps with the issue's acceptance data: registered land with dimensions, seen broker, ready now, $650k budget, first home buyer), wait for success screen, extract the lead id, navigate to `/leads/[id]`, assert score badge shows `85`, stage "Hot", gaps list shows the "No gaps" state, next question block is not visible.
+
+3. **Score breakdown shows all six factors with correct max scores.** Using the same fully-qualified lead, assert each of the six factor rows exists with the expected `{score}/{max}` — land `30/30`, finance `15/25`, timeline `20/20`, budget `10/10`, propertyType `10/10`, engagement `0/5`. Total: 85.
+
+4. **Suggested next question targets the highest-impact gap.** Create a lead with everything except land filled in (seen broker, ready now, $650k, first home buyer, no `hasLand`). Navigate to profile. Assert the next question matches `/land/i` (the canonical land question from `NEXT_QUESTIONS` in `score-factors.ts`).
+
+```ts
+// e2e/features/lead-profile.spec.ts — skeleton
+import { expect, test } from "@playwright/test";
+import { LeadFormSection } from "../pages/sections/lead-form.section";
+import { LeadProfileSection } from "../pages/sections/lead-profile.section";
+import { QuickCaptureSection } from "../pages/sections/quick-capture.section";
+import {
+  createTestSession,
+  deleteTestSession,
+  type TestSession,
+  uniquePhone,
+} from "../utils/auth-helper";
+import { getLeadIdByPhone } from "../utils/leads-helper";
+import { getSessionCookie } from "../utils/session-cookie";
+
+test.describe("Lead Profile — E2E", () => {
+  test.skip(!process.env.DATABASE_URL, "Requires direct DB access");
+
+  let session: TestSession;
+  test.beforeAll(async () => { session = await createTestSession(); });
+  test.afterAll(async () => { await deleteTestSession(session.userId); });
+
+  test("quick capture lead: score 0, unqualified, 5 gaps", async ({ context, page, baseURL }) => {
+    await context.addCookies([getSessionCookie(session.signedToken, baseURL!)]);
+    // ... create via quick capture, look up id by phone, navigate, assert
+  });
+
+  test("fully qualified lead: score 85, hot, 0 gaps", async ({ context, page, baseURL }) => {
+    // ...
+  });
+
+  test("score breakdown shows all 6 factors with correct max scores", async ({ context, page, baseURL }) => {
+    // ...
+  });
+
+  test("suggested next question targets the highest-impact gap", async ({ context, page, baseURL }) => {
+    // ...
+  });
+});
+```
+
+#### 13. E2E helper — look up lead id by phone
+
+**File:** `e2e/utils/leads-helper.ts`
+
+**Changes:** New file. A single `getLeadIdByPhone(phone: string)` helper that queries the local DB via the existing `neon` pattern (see `hubspot-helper.ts:17-21`) and returns `id` or throws. This lets tests that create a lead via quick capture (which has no success-screen id anchor) still navigate to `/leads/[id]`. Lightweight and parallel-safe because each test uses `uniquePhone()`.
+
+### Success Criteria
+
+#### Automated Verification
+- [x] `make test` passes (unit tests for display helpers + Phase 1 router tests)
+- [x] `make check` passes
+- [ ] `make test_e2e` passes locally with `DATABASE_URL` and `HUBSPOT_ACCESS_TOKEN` set
+- [ ] New test file `e2e/features/lead-profile.spec.ts` has all four read-only tests green
+
+#### Manual Verification
+- [ ] `/design_review` run against the branch passes for the new page
+- [ ] `frontend-design` skill applied during build (colours, spacing, typography follow `brand-guidelines`)
+- [ ] Page loads without a loading flash on a fresh hard refresh (RSC hydration working)
+- [ ] On mobile viewport (375px wide), all sections are legible and the score badge is prominent
+- [ ] Tap-to-call opens the device dialer on a real device or when inspected (`tel:` href present)
+- [ ] Tap-to-email opens the mail app (`mailto:` href present)
+- [ ] `/leads/00000000-0000-0000-0000-000000000000` renders the `not-found.tsx` state (not a tRPC error page)
+
+---
+
+## Phase 3: Edit mode
+
+### Overview
+
+Add a page-level Edit toggle that swaps the read-only layout for an inline editable form, with sticky Save/Cancel. Save calls `leads.update`, invalidates `getById`, and the score/stage update in place. Phase 1 already made the mutation response authoritative, so invalidation alone is sufficient.
+
+### Changes Required
+
+#### 1. Inline edit form
+
+**File:** `src/app/(application)/leads/[id]/_components/lead-edit-form.tsx`
+
+**Changes:** New client component. Takes the current `lead` as a prop (for default values) plus `onCancel` and `onSuccess` callbacks. Uses `useForm<LeadCreate>` with `zodResolver(leadCreateSchema)` — the same shape as the create form — so the same field-level validation applies. Renders all five section Cards with inline inputs (reusing the same sub-step field components where it keeps things tidy, otherwise inline field code — keep it flat, no multi-step wizard). Uses `useMutation(trpc.leads.update.mutationOptions(...))` and on success:
+
+```ts
+const updateLead = useMutation(
+  trpc.leads.update.mutationOptions({
+    onSuccess: async () => {
+      await queryClient.invalidateQueries(
+        trpc.leads.getById.queryFilter({ id: lead.id }),
+      );
+      onSuccess();
+    },
+    onError: (error) => {
+      // mirror lead-form.tsx: map zodError.fieldErrors to setError
+    },
+  }),
+);
+```
+
+Save button uses `data-testid="lead-profile-save-btn"`; Cancel uses `data-testid="lead-profile-cancel-btn"`. Sticky bar pinned to the bottom on mobile, top-right on desktop.
+
+#### 2. Wire the Edit toggle into the view container
+
+**File:** `src/app/(application)/leads/[id]/_components/lead-profile-view.tsx`
+
+**Changes:** Flip the `isEditing` stub from Phase 2 into real state. When `isEditing === false`, render the read-only sub-components with the Edit button enabled. When `isEditing === true`, render `<LeadEditForm lead={...} onCancel={...} onSuccess={...} />` in place of the read-only sections (keep the header visible but hide its Edit button while editing). On `onSuccess`, flip back to `false` — the refetched data already contains the new score.
+
+#### 3. Enable the Edit button
+
+**File:** `src/app/(application)/leads/[id]/_components/profile-header.tsx`
+
+**Changes:** Remove the `disabled` stub; wire the button to call `onEdit` passed from the view container. Ensure the button is hidden while `isEditing === true`.
+
+#### 4. E2E test — edit in place
+
+**File:** `e2e/features/lead-profile.spec.ts`
+
+**Test (appended):** "edit a lead's qualification fields: score and stage update in place without reload."
+
+1. Create an unqualified lead (name + phone via quick capture).
+2. Navigate to profile, assert score `0` / stage "Unqualified".
+3. Click Edit, record the page's navigation id (to prove no full navigation).
+4. Update: set `hasLand = true`, `landRegistered = true`, `landSizeSqm = 450`, `landWidth = 15`, `landDepth = 30`, `propertyType = first_home_buyer`, `budget = $650,000`, `seenBroker = true`, `constructionTimeline = ready_now`.
+5. Click Save.
+6. Assert: the edit form disappears, the score badge shows `85`, the stage label shows "Hot", the gap list shows the "No gaps" state. The URL did not change.
+7. Reload the page manually and assert the same values persist (sanity check that the mutation actually wrote to the DB).
+
+### Success Criteria
+
+#### Automated Verification
+- [x] `make test` passes
+- [x] `make check` passes
+- [ ] `make test_e2e` passes; the new edit-in-place test is green
+- [ ] `yarn test:e2e:mobile` passes for the new test file (mobile viewport regression)
+
+#### Manual Verification
+- [ ] `/design_review` run again against the edit-mode branch passes
+- [ ] Edit toggle feels snappy; Save button shows a loading state while the mutation is in flight
+- [ ] Cancel discards unsaved changes and returns to the read-only view with original values
+- [ ] A Zod error from the server surfaces on the correct field (e.g. invalid email)
+- [ ] After save, the score/stage/gaps update visibly without a page reload
+- [ ] HubSpot contact reflects the updated fields and the new `lead_score`/`lead_stage` within a few seconds
+
+---
+
+## Performance Considerations
+
+- The page makes exactly one tRPC call (`leads.getById`) — prefetched on the server and hydrated on the client, so the user sees data on first paint without a round-trip.
+- Phase 1 adds one extra awaited DB update per create/update (the re-score write). This is a localhost-to-Neon roundtrip and is negligible compared to the HubSpot call that already happens in the same path.
+- No chart library, no icons beyond the existing `lucide-react` set — bundle impact is near-zero.
+- The `score_metadata` JSONB blob is small (<2KB). Fetching it alongside the lead row is cheaper than a second query.
+
+## Migration Notes
+
+None. No schema changes. Existing leads created before Phase 1 may have `scoreMetadata === null`; the read-only view gracefully shows a "Score pending…" state for those, and any subsequent `update` will populate it. No backfill required — the pilot is in pre-PMF state with a tiny row count.
+
+## References
+
+- Issue: [samjmarshall/www#101](https://github.com/samjmarshall/www/issues/101)
+- Parent epic: [samjmarshall/www#86](https://github.com/samjmarshall/www/issues/86)
+- Design doc: `thoughts/designs/2026-03-27-ai-sales-assistant-new-home-builders.md` (Dashboard UX, Data Model, Tech Architecture sections)
+- Scoring engine plan: `thoughts/plans/2026-04-08-99-ai-qualification-scoring-engine.md`
+- tRPC dual-client pattern: `src/trpc/server.tsx`, `src/trpc/react.tsx`
+- Schema and enums: `src/server/db/schema/leads.ts`, `src/server/db/schema/enums.ts`
+- Router to modify: `src/server/api/routers/leads.ts:20-56` (scoreLeadAsync), `:74-121` (create), `:190-242` (update)
+- Scoring source of truth: `src/server/scoring/qualify-and-score.ts`, `src/server/scoring/score-factors.ts`, `src/server/scoring/schema.ts`
+- E2E conventions: `e2e/features/leads-crud.spec.ts`, `e2e/pages/sections/lead-form.section.ts`, `e2e/utils/auth-helper.ts`, `e2e/utils/hubspot-helper.ts`
+- Skills to apply: `frontend-design` during Phases 2 & 3 build; `/design_review` before completing each UI phase; `brand-guidelines` for colour/typography decisions

--- a/thoughts/plans/2026-04-10-101-lead-profile-design-fixes.md
+++ b/thoughts/plans/2026-04-10-101-lead-profile-design-fixes.md
@@ -1,0 +1,290 @@
+# Lead Profile Page Design Review Fixes
+
+**Issue:** [samjmarshall/www#101](https://github.com/samjmarshall/www/issues/101)
+**Source:** Design review of `feat/101-lead-profile-page` branch (commit `d9d6def`)
+**Status:** Draft
+
+## Overview
+
+Fix 12 issues identified during the design review of the lead profile page. Three are accessibility must-fixes (heading hierarchy, focus management, user-facing internal jargon), five are should-fixes (link distinction, score circle coloring, cancel confirmation, aria-live for score updates, locale-dependent date), and four are nits (icon sizing, duplicated type, minor coupling).
+
+## Current State Analysis
+
+The lead profile page is functional with strong baseline accessibility (ARIA on progress bars, semantic HTML, decorative icon hiding). The issues are polish items that affect WCAG compliance, screen reader experience, and small UX gaps.
+
+### Key Discoveries
+
+- `CardTitle` renders a hardcoded `<h3>` with no `as` prop or `asChild` mechanism (`src/components/ui/Card.tsx:28-38`). Fixing the heading hierarchy requires raw `<h2>` elements with the CardTitle class names.
+- The app has an existing focus management pattern: `useRef` + `requestAnimationFrame` + `.focus()` in `leads/new/_components/lead-form.tsx:51-57`. The edit mode toggle should follow this pattern.
+- No `AlertDialog` exists. The only dialog primitive is `src/components/ui/dialog.tsx` (base-ui). The cancel confirmation can use this, or a simpler `window.confirm` to avoid over-engineering.
+- `stageTone()` maps stages to Badge variants but nothing maps stages to raw Tailwind color classes for non-Badge elements. A new `stageRingColor()` helper is needed for the score circle.
+
+## Desired End State
+
+All 12 design review findings resolved. The page passes WCAG 2.1 AA for heading hierarchy, focus management, link distinction, and screen reader announcements. Score circle visually reinforces the stage. Cancel confirms when dirty. No internal terminology visible to users.
+
+## What We're NOT Doing
+
+- Not adding skeleton loading states (matches current app pattern of plain text loading).
+- Not changing `CardTitle` default from `text-2xl` to `text-xl` globally (finding #10 is a nit, not blocking).
+- Not extracting bottom-nav height into a CSS variable (finding #12 is low risk).
+- Not adding an AlertDialog component from shadcn -- using `window.confirm` for the cancel flow.
+
+## Implementation Approach
+
+Single phase -- all changes are small, independent, and confined to the `leads/[id]/` directory plus `display.ts`. No backend changes, no new dependencies, no migrations.
+
+---
+
+## Phase 1: Fix all design review findings
+
+### Overview
+
+Address all 12 findings in one pass. Changes are grouped by file for clarity but can be made in any order.
+
+### Changes Required
+
+#### 1. Fix heading hierarchy -- add `<h2>` section headings
+
+**File:** `src/app/(application)/leads/[id]/_components/lead-profile-view.tsx`
+
+The page has `<h1>` (lead name in ProfileHeader) then jumps to `<h3>` (CardTitle). Add visually-hidden `<h2>` headings before each major section to restore the hierarchy.
+
+- Add a `<h2 className="sr-only">` before `<ScoreBreakdown />` with text "Score & Qualification"
+- Add a `<h2 className="sr-only">` before `<LeadDetails />` with text "Lead Information"
+- In the sidebar column, add a `<h2 className="sr-only">` before `<QualificationGaps />` with text "Gaps & History"
+- In the edit form branch, add a `<h2 className="sr-only">` before `<LeadEditForm />` with text "Edit Lead"
+
+These headings are screen-reader-only (`sr-only` is Tailwind's built-in visually-hidden class) and don't affect the visual layout.
+
+#### 2. Add focus management on edit mode toggle
+
+**File:** `src/app/(application)/leads/[id]/_components/lead-profile-view.tsx`
+
+Follow the existing pattern from `lead-form.tsx:51-57`:
+
+- Add `useRef<HTMLButtonElement>(null)` for the Edit button.
+- Pass the ref to `ProfileHeader` and attach it to the Edit `<Button>`.
+- When `isEditing` transitions to `true`, focus the first focusable element inside the edit form. The edit form should expose a ref or use `autoFocus` on the first input. The simplest approach: add `useRef<HTMLFormElement>(null)` to `LeadEditForm`, attach it to the `<form>`, and in a `useEffect` on mount, call `formRef.current?.querySelector<HTMLElement>('input, select, textarea')?.focus()`.
+- When `isEditing` transitions to `false` (cancel or save success), call `editButtonRef.current?.focus()` inside a `requestAnimationFrame` to return focus to the Edit button.
+
+**File:** `src/app/(application)/leads/[id]/_components/lead-edit-form.tsx`
+
+- Add `useRef<HTMLFormElement>(null)` attached to the `<form>` element.
+- Add a `useEffect` that runs on mount to focus the first input:
+  ```tsx
+  const formRef = useRef<HTMLFormElement>(null);
+  useEffect(() => {
+    requestAnimationFrame(() => {
+      formRef.current?.querySelector<HTMLElement>("input, select, textarea")?.focus();
+    });
+  }, []);
+  ```
+
+**File:** `src/app/(application)/leads/[id]/_components/profile-header.tsx`
+
+- Accept a `ref` for the Edit button via `React.forwardRef` or by passing an `editButtonRef` prop. Since the existing pattern in the codebase uses prop-based refs, add an `editButtonRef?: React.RefObject<HTMLButtonElement | null>` prop and attach it to the Edit `<Button>` via `ref={editButtonRef}`.
+
+#### 3. Replace internal terminology in conversation history placeholder
+
+**File:** `src/app/(application)/leads/[id]/_components/conversation-history.tsx`
+
+Change line 19 from:
+```
+No messages yet — conversation history will appear here when Epic 3 is complete.
+```
+to:
+```
+No conversations yet.
+```
+
+#### 4. Add visual distinction to phone/email links
+
+**File:** `src/app/(application)/leads/[id]/_components/profile-header.tsx`
+
+Add `hover:underline` to both the phone and email anchor elements. Change:
+```
+className="inline-flex items-center gap-2 text-sm hover:text-primary"
+```
+to:
+```
+className="inline-flex items-center gap-2 text-sm hover:text-primary hover:underline"
+```
+
+Apply to both the `tel:` link (line 62) and `mailto:` link (line 72).
+
+#### 5. Map score circle color to stage
+
+**File:** `src/app/(application)/leads/[id]/_lib/display.ts`
+
+Add a new `stageRingClasses()` function that returns Tailwind classes for the score circle border and background:
+
+```ts
+const STAGE_RING_CLASSES: Record<LeadStage, string> = {
+  unqualified: "border-muted-foreground/30 bg-muted/10",
+  nurture: "border-accent-amber/30 bg-accent-amber/5",
+  warm: "border-primary/30 bg-primary/5",
+  hot: "border-accent-coral/30 bg-accent-coral/5",
+};
+
+export function stageRingClasses(stage: LeadStage): string {
+  return STAGE_RING_CLASSES[stage];
+}
+```
+
+**File:** `src/app/(application)/leads/[id]/_components/profile-header.tsx`
+
+Replace the static `cn("border-primary/30 bg-primary/5")` on the score circle with `stageRingClasses(lead.leadStage)`:
+
+```tsx
+<div
+  className={cn(
+    "flex size-20 flex-col items-center justify-center rounded-full border-2 text-center",
+    stageRingClasses(lead.leadStage),
+  )}
+```
+
+Also update the score number's text color from hardcoded `text-primary` to match the stage. Add a `stageTextColor()` helper or inline a simple mapping. Simplest: keep the number as `text-foreground` (neutral) so it's always readable regardless of stage ring color. This avoids contrast issues.
+
+Change `text-primary` on the score number to `text-foreground`:
+```tsx
+<span className="font-bold text-2xl text-foreground tabular-nums">
+```
+
+#### 6. Add discard-changes confirmation on Cancel
+
+**File:** `src/app/(application)/leads/[id]/_components/lead-edit-form.tsx`
+
+Wrap the `onCancel` callback to check for dirty state before closing:
+
+```tsx
+const handleCancel = () => {
+  if (form.formState.isDirty) {
+    if (!window.confirm("You have unsaved changes. Discard them?")) {
+      return;
+    }
+  }
+  onCancel();
+};
+```
+
+Update the Cancel button's `onClick` from `onCancel` to `handleCancel`.
+
+#### 7. Add `aria-live` region for score updates
+
+**File:** `src/app/(application)/leads/[id]/_components/profile-header.tsx`
+
+Add `aria-live="polite"` to the `<div>` wrapping the score badge and stage badge (line 87):
+
+```tsx
+<div className="flex items-center gap-3" aria-live="polite">
+```
+
+This announces score and stage changes to screen readers after the edit form closes and the query refetch completes.
+
+#### 8. Fix locale-dependent date formatting
+
+**File:** `src/app/(application)/leads/[id]/_lib/display.ts`
+
+Add a `formatDate` helper:
+
+```ts
+export function formatDate(date: Date | string): string {
+  const d = typeof date === "string" ? new Date(date) : date;
+  return new Intl.DateTimeFormat("en-AU", {
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+  }).format(d);
+}
+```
+
+**File:** `src/app/(application)/leads/[id]/_components/lead-details.tsx`
+
+Replace `new Date(lead.createdAt).toLocaleDateString()` with `formatDate(lead.createdAt)`.
+
+#### 9. Fix icon sizing in not-found.tsx
+
+**File:** `src/app/(application)/leads/[id]/not-found.tsx`
+
+Change:
+```tsx
+<Users size={48} className="mx-auto mb-4 text-muted-foreground/50" />
+```
+to:
+```tsx
+<Users className="mx-auto mb-4 size-12 text-muted-foreground/50" />
+```
+
+#### 10. Remove duplicated `FactorKey` type
+
+**File:** `src/app/(application)/leads/[id]/_lib/display.ts`
+
+Export the `FactorKey` type:
+```ts
+export type FactorKey = ...
+```
+
+**File:** `src/app/(application)/leads/[id]/_components/qualification-gaps.tsx`
+
+Remove the local `FactorKey` type definition and import it from `display.ts`:
+```ts
+import { factorLabel, impactTone, type FactorKey } from "../_lib/display";
+```
+
+#### 11. Tests
+
+**File:** `src/app/(application)/leads/[id]/_lib/__tests__/display.test.ts`
+
+Add tests for the two new display helpers:
+
+```ts
+describe("stageRingClasses", () => {
+  test("returns distinct classes for each stage", () => {
+    const classes = new Set([
+      stageRingClasses("unqualified"),
+      stageRingClasses("nurture"),
+      stageRingClasses("warm"),
+      stageRingClasses("hot"),
+    ]);
+    expect(classes.size).toBe(4);
+  });
+});
+
+describe("formatDate", () => {
+  test("formats a Date object in en-AU short format", () => {
+    expect(formatDate(new Date("2026-04-10T00:00:00Z"))).toBe("10 Apr 2026");
+  });
+
+  test("formats a string date", () => {
+    expect(formatDate("2026-01-15T12:00:00Z")).toBe("15 Jan 2026");
+  });
+});
+```
+
+### Success Criteria
+
+#### Automated Verification:
+- [x] `make check` passes (lint + typecheck) — only pre-existing e2e format issue remains
+- [x] `make test` passes (unit tests including new display helper tests) — 158/158 pass
+- [x] No new TypeScript errors from exported `FactorKey` type change
+
+#### Manual Verification:
+- [ ] Heading hierarchy: run VoiceOver rotor (Cmd+F5, then VO+U) on the profile page and confirm H1 -> H2 -> H3 sequence with no skips
+- [ ] Focus management: Tab to Edit button, press Enter -> focus moves to first form input. Press Tab to Cancel, press Enter -> focus returns to Edit button
+- [ ] Score circle color: navigate to an unqualified lead (score 0) and confirm muted circle, then a hot lead (score 85) and confirm coral-tinted circle
+- [ ] Cancel confirmation: enter edit mode, change a field, click Cancel -> browser confirm dialog appears. Click "Cancel" on the dialog -> stays in edit mode. Click "OK" -> exits edit mode
+- [ ] Phone/email links show underline on hover
+- [ ] Conversation history card reads "No conversations yet." (no "Epic 3")
+- [ ] Created date shows consistent format (e.g., "10 Apr 2026") regardless of browser locale
+- [ ] Score update announced: with VoiceOver on, edit a lead, save -> score/stage change is announced
+
+---
+
+## References
+
+- Design review: in-conversation (2026-04-10)
+- Implementation plan: `thoughts/plans/2026-04-09-101-lead-profile-page.md`
+- Card component: `src/components/ui/Card.tsx`
+- Focus management pattern: `src/app/(application)/leads/new/_components/lead-form.tsx:51-57`
+- Display helpers: `src/app/(application)/leads/[id]/_lib/display.ts`


### PR DESCRIPTION
## Context/Motivation

Consultants need a detailed view of a single lead to check qualification data, see the AI score breakdown, identify qualification gaps, and know what to ask next before calling. After the call, they update the lead's data in-place and see the score/stage refresh without navigating away.

This is the last child issue of Epic 2 (Lead Management + AI Qualification Scoring). It also unblocks the scoring E2E tests that were deferred from #99 because the score display UI didn't exist yet.

## Description of Changes

### Synchronous re-scoring (router)

The `leads.create` and `leads.update` mutations previously fired scoring asynchronously (`void scoreLeadAsync(...)`) so the tRPC response returned before `scoreMetadata` was persisted. This made "score updates in-place" impossible without a polling delay.

Replaced with an awaited `scoreLead()` helper that computes the score, writes it to the DB, pushes to HubSpot (errors logged, not thrown), and returns the fully-scored row. Both `create` and `update` now return authoritative `leadScore`/`leadStage`/`scoreMetadata` in their response.

### Read-only profile page

- **RSC page** (`/leads/[id]`) — first consumer of the `HydrateClient` + `fetchQuery` dual-client pattern, so the page arrives with data already hydrated (no loading flash).
- **Score breakdown** — 6-factor horizontal bars (land/30, finance/25, timeline/20, budget/10, propertyType/10, engagement/5) with reasoning text from `scoreMetadata.breakdown`.
- **Qualification gaps** — server-ranked gap list with impact badges (high/medium/low) and a "Suggested next question" block. Fully qualified leads show a "No gaps" success state instead.
- **Lead details** — 5 grouped cards: Contact, Land, Build, Preferences, Source. Enum values humanized, unset fields show "Not provided".
- **Conversation history** — placeholder card for Epic 3.
- **Not-found** — custom `not-found.tsx` for invalid lead IDs.

### Inline edit mode

Edit button toggles the page into a form view reusing the existing 4 form-step components (`ContactDetails`, `LandStatus`, `BuildDetails`, `AdditionalInfo`). Sticky Save/Cancel bar. Save calls `leads.update`, invalidates the `getById` query, and the score/stage/gaps update in-place without navigation.

### Tests

- **4 new router unit tests** — create returns scored lead (qualified + quick-capture), update with scoring field bumps score, update with non-scoring field leaves score unchanged.
- **15 display helper unit tests** — `stageLabel`, `factorLabel`, `impactTone`, enum formatters, `formatLastContacted`.
- **5 E2E tests** — quick-capture (score 0, 5 gaps), fully-qualified (score 85, 0 gaps), score breakdown factors, next-question targeting, edit-in-place (0→85 without reload).

## Testing Information

- [x] Unit tests pass (`make test` — 155/155)
- [x] Lint + typecheck pass (`make check` — 0 errors)
- [x] E2E tests pass (`make test_e2e` — requires live DB + HubSpot credentials)
- [x] Manual testing completed

**Test steps:**
1. Run `make test` — all 155 unit tests pass
2. Run `make check` — lint and typecheck clean
3. Start dev server, create a lead via full form, navigate to `/leads/{id}` — verify score badge, breakdown bars, and gaps render correctly
4. Click Edit, update qualification fields, click Save — verify score/stage update in-place without page reload
5. Navigate to `/leads/00000000-0000-0000-0000-000000000000` — verify custom not-found page renders
6. Test on mobile viewport (375px) — verify layout is legible and score badge is prominent

## Screenshots/Videos

_UI screenshots pending — run `/design_review` against the branch._

## Relevant Links

- Closes #101
- Related to #86 (Epic 2: Lead Management + AI Qualification Scoring)
- Related to #99 (scoring E2E tests deferred to this PR)

## Breaking Changes

**Breaking changes:**
- None. No schema changes, no new migrations, no API contract changes. Existing leads with `scoreMetadata === null` render a "Score pending…" state and get populated on the next update.
