### PR TITLE
feat(messages): tRPC router with approve/edit/snooze/dismiss + Zod schemas

### DIFF
--- a/.claude/skills/ticket-writer/SKILL.md
+++ b/.claude/skills/ticket-writer/SKILL.md
@@ -241,6 +241,50 @@ Then I should receive a reset email within 2 minutes
 - Tables for structured data
 - Mermaid diagrams for technical documentation
 
+#### Parent/Child & Dependency Linking
+
+**On epic breakdowns, linking is part of creation.** Once the breakdown plan is approved, create issues and wire relationships in the same turn. Don't ask about linking separately.
+
+**Parent/child (sub-issues)** — REST API:
+
+```bash
+# Fetch the REST numeric id (not the GraphQL node_id):
+CHILD_ID=$(gh api /repos/OWNER/REPO/issues/<CHILD_NUM> --jq .id)
+
+# Link — -F for integer, not -f:
+gh api -X POST /repos/OWNER/REPO/issues/<PARENT_NUM>/sub_issues \
+  -F "sub_issue_id=$CHILD_ID"
+```
+
+Gotchas:
+- `sub_issue_id` must be an integer — `-F`, not `-f`. Strings get `422 "not of type integer"`.
+- Use the REST numeric `.id`, not the GraphQL `node_id`.
+- Shows as sub-issue progress on the parent (e.g. "3/10").
+
+**Blocked-by / blocks** — no native typed field on classic issues. Use body-text sections; they render as cross-references and surface in Projects views:
+
+```markdown
+## Blocked by
+- #<N> — <short reason>
+
+## Blocks
+- #<N> — <short reason>
+```
+
+Bake these into the body **at creation time**. Create issues **in dependency order** so each body can reference numbers above it.
+
+**Sequence** (one turn, no mid-flow prompts):
+
+1. Create the first child (no blocked-by refs).
+2. Capture its number. Remaining children will be `N+1 … N+k` barring concurrent creates.
+3. Draft remaining bodies with `#N` refs baked in.
+4. Create them sequentially.
+5. Link every child as a sub-issue of the parent.
+6. Add every child to the project, capture the item id.
+7. Set project fields via one aliased GraphQL mutation per item.
+
+Stop to confirm only if the plan changes — never for mechanics.
+
 #### GitHub Projects Integration
 
 When issues are added to a GitHub Project, set these fields:
@@ -450,8 +494,8 @@ When MCP servers are available, the ticket-writer skill can directly create, upd
 1. **Gather requirements** through questioning
 2. **Draft ticket content** collaboratively
 3. **Review with user** for completeness
-4. **If MCP available**: Offer to create ticket directly in the system
-5. **If not available**: Provide formatted markdown for manual entry
+4. **Create + link + populate in one turn**: After plan approval, create tickets, wire sub-issue relationships, add to the project, and set fields — one turn, no re-confirmation. Linking and field assignment are part of "create".
+5. **If no MCP / CLI available**: Provide formatted markdown for manual entry.
 
 ### Benefits of MCP Integration
 

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "input-otp": "1.4.2",
     "lucide-react": "0.563.0",
     "motion": "12.23.24",
-    "next": "16.2.1",
+    "next": "16.2.3",
     "next-themes": "0.4.6",
     "posthog-js": "1.298.0",
     "posthog-node": "5.14.0",

--- a/src/server/api/__tests__/messages-router.test.ts
+++ b/src/server/api/__tests__/messages-router.test.ts
@@ -1,0 +1,419 @@
+import { beforeEach, describe, expect, rs, test } from "@rstest/core";
+import { TRPCError } from "@trpc/server";
+import type { createCaller } from "../root";
+
+type Caller = ReturnType<typeof createCaller>;
+
+const MSG_ID = "550e8400-e29b-41d4-a716-446655440000";
+const LEAD_ID = "660e8400-e29b-41d4-a716-446655440001";
+
+const baseMessage = {
+  id: MSG_ID,
+  leadId: LEAD_ID,
+  channel: "sms" as const,
+  subject: null,
+  body: "Original draft body",
+  aiReasoning: null,
+  priority: 5,
+  status: "pending" as const,
+  snoozedUntil: null,
+  originalBody: null,
+  approvedAt: null,
+  sentAt: null,
+  createdAt: new Date("2026-04-10T00:00:00Z"),
+};
+
+let mockDb: Record<string, unknown>;
+
+beforeEach(() => {
+  rs.resetModules();
+
+  rs.doMock("~/env", () => ({
+    env: {
+      DATABASE_URL: "postgres://mock",
+      HUBSPOT_ACCESS_TOKEN: "mock",
+      HUBSPOT_CLIENT_SECRET: "mock",
+    },
+  }));
+
+  rs.doMock("~/lib/session", () => ({
+    getSession: rs.fn().mockResolvedValue({
+      user: { id: "test-user-id", email: "test@example.com", name: "Test" },
+      session: { id: "test-session-id" },
+    }),
+  }));
+
+  mockDb = {
+    update: rs.fn(),
+    query: {
+      messageQueue: {
+        findFirst: rs.fn(),
+        findMany: rs.fn(),
+      },
+    },
+  };
+
+  rs.doMock("~/server/db", () => ({ db: mockDb }));
+});
+
+async function getCaller(): Promise<Caller> {
+  const { createCaller } = await import("../root");
+  const { createTRPCContext } = await import("../trpc");
+  const ctx = await createTRPCContext({ headers: new Headers() });
+  return createCaller(ctx);
+}
+
+// Helper — wire up a chainable update mock that returns the given row
+function mockUpdateReturning(row: unknown) {
+  const returning = rs.fn().mockResolvedValue([row]);
+  const where = rs.fn().mockReturnValue({ returning });
+  const set = rs.fn().mockReturnValue({ where });
+  (mockDb.update as ReturnType<typeof rs.fn>).mockReturnValue({ set });
+  return { set, where, returning };
+}
+
+// --- messages.listPending ---
+
+describe("messages.listPending", () => {
+  test("returns rows from findMany", async () => {
+    (
+      mockDb.query as { messageQueue: { findMany: ReturnType<typeof rs.fn> } }
+    ).messageQueue.findMany.mockResolvedValue([baseMessage]);
+
+    const caller = await getCaller();
+    const result = await caller.messages.listPending();
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.id).toBe(MSG_ID);
+  });
+
+  test("returns empty array when no pending rows", async () => {
+    (
+      mockDb.query as { messageQueue: { findMany: ReturnType<typeof rs.fn> } }
+    ).messageQueue.findMany.mockResolvedValue([]);
+
+    const caller = await getCaller();
+    const result = await caller.messages.listPending();
+
+    expect(result).toEqual([]);
+  });
+
+  test("orders by priority desc then createdAt asc", async () => {
+    const findMany = (
+      mockDb.query as { messageQueue: { findMany: ReturnType<typeof rs.fn> } }
+    ).messageQueue.findMany;
+    findMany.mockResolvedValue([]);
+
+    const caller = await getCaller();
+    await caller.messages.listPending();
+
+    expect(findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        orderBy: expect.anything(),
+        where: expect.anything(),
+      }),
+    );
+  });
+});
+
+// --- messages.approve ---
+
+describe("messages.approve", () => {
+  test("transitions pending → approved and sets approvedAt", async () => {
+    (
+      mockDb.query as { messageQueue: { findFirst: ReturnType<typeof rs.fn> } }
+    ).messageQueue.findFirst.mockResolvedValue(baseMessage);
+
+    const approved = {
+      ...baseMessage,
+      status: "approved" as const,
+      approvedAt: new Date(),
+    };
+    const { set } = mockUpdateReturning(approved);
+
+    const caller = await getCaller();
+    const result = await caller.messages.approve({ id: MSG_ID });
+
+    expect(result.status).toBe("approved");
+    expect(result.approvedAt).not.toBeNull();
+    expect(set).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: "approved",
+        approvedAt: expect.any(Date),
+      }),
+    );
+  });
+
+  test("allows snoozed → approved", async () => {
+    const snoozed = { ...baseMessage, status: "snoozed" as const };
+    (
+      mockDb.query as { messageQueue: { findFirst: ReturnType<typeof rs.fn> } }
+    ).messageQueue.findFirst.mockResolvedValue(snoozed);
+
+    mockUpdateReturning({
+      ...snoozed,
+      status: "approved",
+      approvedAt: new Date(),
+    });
+
+    const caller = await getCaller();
+    const result = await caller.messages.approve({ id: MSG_ID });
+
+    expect(result.status).toBe("approved");
+  });
+
+  test("throws NOT_FOUND when message does not exist", async () => {
+    (
+      mockDb.query as { messageQueue: { findFirst: ReturnType<typeof rs.fn> } }
+    ).messageQueue.findFirst.mockResolvedValue(undefined);
+
+    const caller = await getCaller();
+    try {
+      await caller.messages.approve({ id: MSG_ID });
+      expect.unreachable("Should have thrown");
+    } catch (e) {
+      expect(e).toBeInstanceOf(TRPCError);
+      expect((e as TRPCError).code).toBe("NOT_FOUND");
+    }
+  });
+
+  test("rejects terminal state (dismissed)", async () => {
+    (
+      mockDb.query as { messageQueue: { findFirst: ReturnType<typeof rs.fn> } }
+    ).messageQueue.findFirst.mockResolvedValue({
+      ...baseMessage,
+      status: "dismissed",
+    });
+
+    const caller = await getCaller();
+    try {
+      await caller.messages.approve({ id: MSG_ID });
+      expect.unreachable("Should have thrown");
+    } catch (e) {
+      expect(e).toBeInstanceOf(TRPCError);
+      expect((e as TRPCError).code).toBe("BAD_REQUEST");
+      expect((e as TRPCError).message).toContain("dismissed");
+    }
+  });
+
+  test("rejects invalid uuid", async () => {
+    const caller = await getCaller();
+    try {
+      await caller.messages.approve({ id: "not-a-uuid" });
+      expect.unreachable("Should have thrown");
+    } catch (e) {
+      expect(e).toBeInstanceOf(TRPCError);
+      expect((e as TRPCError).code).toBe("BAD_REQUEST");
+    }
+  });
+});
+
+// --- messages.editAndApprove ---
+
+describe("messages.editAndApprove", () => {
+  test("copies existing body into originalBody and sets new body", async () => {
+    (
+      mockDb.query as { messageQueue: { findFirst: ReturnType<typeof rs.fn> } }
+    ).messageQueue.findFirst.mockResolvedValue(baseMessage);
+
+    const edited = {
+      ...baseMessage,
+      status: "edited_and_approved" as const,
+      body: "Rewritten message",
+      originalBody: "Original draft body",
+      approvedAt: new Date(),
+    };
+    const { set } = mockUpdateReturning(edited);
+
+    const caller = await getCaller();
+    const result = await caller.messages.editAndApprove({
+      id: MSG_ID,
+      body: "Rewritten message",
+    });
+
+    expect(result.status).toBe("edited_and_approved");
+    expect(result.body).toBe("Rewritten message");
+    expect(result.originalBody).toBe("Original draft body");
+    expect(set).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: "edited_and_approved",
+        body: "Rewritten message",
+        originalBody: "Original draft body",
+      }),
+    );
+  });
+
+  test("preserves originalBody when row was already edited once", async () => {
+    const previouslyEdited = {
+      ...baseMessage,
+      body: "First edit",
+      originalBody: "The true original",
+    };
+    (
+      mockDb.query as { messageQueue: { findFirst: ReturnType<typeof rs.fn> } }
+    ).messageQueue.findFirst.mockResolvedValue(previouslyEdited);
+
+    const { set } = mockUpdateReturning(previouslyEdited);
+
+    const caller = await getCaller();
+    await caller.messages.editAndApprove({ id: MSG_ID, body: "Second edit" });
+
+    expect(set).toHaveBeenCalledWith(
+      expect.objectContaining({ originalBody: "The true original" }),
+    );
+  });
+
+  test("rejects empty body via Zod", async () => {
+    const caller = await getCaller();
+    try {
+      await caller.messages.editAndApprove({ id: MSG_ID, body: "" });
+      expect.unreachable("Should have thrown");
+    } catch (e) {
+      expect(e).toBeInstanceOf(TRPCError);
+      expect((e as TRPCError).code).toBe("BAD_REQUEST");
+    }
+  });
+
+  test("rejects terminal state", async () => {
+    (
+      mockDb.query as { messageQueue: { findFirst: ReturnType<typeof rs.fn> } }
+    ).messageQueue.findFirst.mockResolvedValue({
+      ...baseMessage,
+      status: "approved",
+    });
+
+    const caller = await getCaller();
+    try {
+      await caller.messages.editAndApprove({ id: MSG_ID, body: "Too late" });
+      expect.unreachable("Should have thrown");
+    } catch (e) {
+      expect((e as TRPCError).code).toBe("BAD_REQUEST");
+    }
+  });
+});
+
+// --- messages.snooze ---
+
+describe("messages.snooze", () => {
+  test("sets snoozedUntil and transitions to snoozed", async () => {
+    (
+      mockDb.query as { messageQueue: { findFirst: ReturnType<typeof rs.fn> } }
+    ).messageQueue.findFirst.mockResolvedValue(baseMessage);
+
+    const future = new Date(Date.now() + 3600_000);
+    const snoozed = {
+      ...baseMessage,
+      status: "snoozed" as const,
+      snoozedUntil: future,
+    };
+    const { set } = mockUpdateReturning(snoozed);
+
+    const caller = await getCaller();
+    const result = await caller.messages.snooze({
+      id: MSG_ID,
+      snoozedUntil: future,
+    });
+
+    expect(result.status).toBe("snoozed");
+    expect(set).toHaveBeenCalledWith(
+      expect.objectContaining({ status: "snoozed", snoozedUntil: future }),
+    );
+  });
+
+  test("rejects past snoozedUntil via Zod", async () => {
+    const past = new Date(Date.now() - 1000);
+    const caller = await getCaller();
+    try {
+      await caller.messages.snooze({ id: MSG_ID, snoozedUntil: past });
+      expect.unreachable("Should have thrown");
+    } catch (e) {
+      expect((e as TRPCError).code).toBe("BAD_REQUEST");
+    }
+  });
+
+  test("rejects terminal state", async () => {
+    (
+      mockDb.query as { messageQueue: { findFirst: ReturnType<typeof rs.fn> } }
+    ).messageQueue.findFirst.mockResolvedValue({
+      ...baseMessage,
+      status: "dismissed",
+    });
+
+    const future = new Date(Date.now() + 3600_000);
+    const caller = await getCaller();
+    try {
+      await caller.messages.snooze({ id: MSG_ID, snoozedUntil: future });
+      expect.unreachable("Should have thrown");
+    } catch (e) {
+      expect((e as TRPCError).code).toBe("BAD_REQUEST");
+    }
+  });
+});
+
+// --- messages.dismiss ---
+
+describe("messages.dismiss", () => {
+  test("transitions to dismissed", async () => {
+    (
+      mockDb.query as { messageQueue: { findFirst: ReturnType<typeof rs.fn> } }
+    ).messageQueue.findFirst.mockResolvedValue(baseMessage);
+
+    const dismissed = { ...baseMessage, status: "dismissed" as const };
+    const { set } = mockUpdateReturning(dismissed);
+
+    const caller = await getCaller();
+    const result = await caller.messages.dismiss({ id: MSG_ID });
+
+    expect(result.status).toBe("dismissed");
+    expect(set).toHaveBeenCalledWith(
+      expect.objectContaining({ status: "dismissed" }),
+    );
+  });
+
+  test("allows snoozed → dismissed", async () => {
+    (
+      mockDb.query as { messageQueue: { findFirst: ReturnType<typeof rs.fn> } }
+    ).messageQueue.findFirst.mockResolvedValue({
+      ...baseMessage,
+      status: "snoozed",
+    });
+
+    mockUpdateReturning({ ...baseMessage, status: "dismissed" });
+
+    const caller = await getCaller();
+    const result = await caller.messages.dismiss({ id: MSG_ID });
+
+    expect(result.status).toBe("dismissed");
+  });
+
+  test("throws NOT_FOUND when missing", async () => {
+    (
+      mockDb.query as { messageQueue: { findFirst: ReturnType<typeof rs.fn> } }
+    ).messageQueue.findFirst.mockResolvedValue(undefined);
+
+    const caller = await getCaller();
+    try {
+      await caller.messages.dismiss({ id: MSG_ID });
+      expect.unreachable("Should have thrown");
+    } catch (e) {
+      expect((e as TRPCError).code).toBe("NOT_FOUND");
+    }
+  });
+
+  test("rejects already-dismissed row", async () => {
+    (
+      mockDb.query as { messageQueue: { findFirst: ReturnType<typeof rs.fn> } }
+    ).messageQueue.findFirst.mockResolvedValue({
+      ...baseMessage,
+      status: "dismissed",
+    });
+
+    const caller = await getCaller();
+    try {
+      await caller.messages.dismiss({ id: MSG_ID });
+      expect.unreachable("Should have thrown");
+    } catch (e) {
+      expect((e as TRPCError).code).toBe("BAD_REQUEST");
+    }
+  });
+});

--- a/src/server/api/__tests__/router.test.ts
+++ b/src/server/api/__tests__/router.test.ts
@@ -55,14 +55,9 @@ describe("tRPC — Authenticated", () => {
     }));
   });
 
-  // leads router has its own dedicated tests in leads-router.test.ts
+  // leads and messages routers have dedicated tests in *-router.test.ts
   const stubs = [
     { name: "lots.getAll", call: (c: Caller) => c.lots.getAll(), expected: [] },
-    {
-      name: "messages.getPending",
-      call: (c: Caller) => c.messages.getPending(),
-      expected: [],
-    },
     {
       name: "nurture.getActive",
       call: (c: Caller) => c.nurture.getActive(),

--- a/src/server/api/routers/messages.ts
+++ b/src/server/api/routers/messages.ts
@@ -1,7 +1,105 @@
+import { TRPCError } from "@trpc/server";
+import { and, asc, desc, eq, isNull, lte, or } from "drizzle-orm";
+import {
+  messageApproveSchema,
+  messageDismissSchema,
+  messageEditAndApproveSchema,
+  messageSnoozeSchema,
+} from "~/server/api/schemas/messages";
 import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
+import { messageQueue } from "~/server/db/schema";
+
+/**
+ * Fetch a message_queue row and assert its status permits a user action.
+ * Terminal states (approved, edited_and_approved, dismissed) are rejected.
+ * Returns the fetched row so callers like editAndApprove can reuse the body.
+ */
+async function loadActionable(
+  db: typeof import("~/server/db").db,
+  id: string,
+  action: "approve" | "edit" | "snooze" | "dismiss",
+): Promise<typeof messageQueue.$inferSelect> {
+  const row = await db.query.messageQueue.findFirst({
+    where: eq(messageQueue.id, id),
+  });
+  if (!row) {
+    throw new TRPCError({ code: "NOT_FOUND", message: "Message not found" });
+  }
+  if (row.status !== "pending" && row.status !== "snoozed") {
+    throw new TRPCError({
+      code: "BAD_REQUEST",
+      message: `Cannot ${action} message in ${row.status} state`,
+    });
+  }
+  return row;
+}
 
 export const messagesRouter = createTRPCRouter({
-  getPending: protectedProcedure.query(() => {
-    return [];
+  listPending: protectedProcedure.query(async ({ ctx }) => {
+    return await ctx.db.query.messageQueue.findMany({
+      where: and(
+        eq(messageQueue.status, "pending"),
+        or(
+          isNull(messageQueue.snoozedUntil),
+          lte(messageQueue.snoozedUntil, new Date()),
+        ),
+      ),
+      orderBy: [desc(messageQueue.priority), asc(messageQueue.createdAt)],
+    });
   }),
+
+  approve: protectedProcedure
+    .input(messageApproveSchema)
+    .mutation(async ({ ctx, input }) => {
+      await loadActionable(ctx.db, input.id, "approve");
+      const [updated] = await ctx.db
+        .update(messageQueue)
+        .set({ status: "approved", approvedAt: new Date() })
+        .where(eq(messageQueue.id, input.id))
+        .returning();
+      return updated!;
+    }),
+
+  editAndApprove: protectedProcedure
+    .input(messageEditAndApproveSchema)
+    .mutation(async ({ ctx, input }) => {
+      const existing = await loadActionable(ctx.db, input.id, "edit");
+      const [updated] = await ctx.db
+        .update(messageQueue)
+        .set({
+          status: "edited_and_approved",
+          body: input.body,
+          // Preserve the first-ever draft. If the row was already edited, keep
+          // the original; otherwise snapshot the current body.
+          originalBody: existing.originalBody ?? existing.body,
+          approvedAt: new Date(),
+        })
+        .where(eq(messageQueue.id, input.id))
+        .returning();
+      return updated!;
+    }),
+
+  snooze: protectedProcedure
+    .input(messageSnoozeSchema)
+    .mutation(async ({ ctx, input }) => {
+      await loadActionable(ctx.db, input.id, "snooze");
+      const [updated] = await ctx.db
+        .update(messageQueue)
+        .set({ status: "snoozed", snoozedUntil: input.snoozedUntil })
+        .where(eq(messageQueue.id, input.id))
+        .returning();
+      return updated!;
+    }),
+
+  dismiss: protectedProcedure
+    .input(messageDismissSchema)
+    .mutation(async ({ ctx, input }) => {
+      await loadActionable(ctx.db, input.id, "dismiss");
+      const [updated] = await ctx.db
+        .update(messageQueue)
+        .set({ status: "dismissed" })
+        .where(eq(messageQueue.id, input.id))
+        .returning();
+      return updated!;
+    }),
 });

--- a/src/server/api/schemas/__tests__/messages.test.ts
+++ b/src/server/api/schemas/__tests__/messages.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, test } from "@rstest/core";
+import {
+  messageApproveSchema,
+  messageDismissSchema,
+  messageEditAndApproveSchema,
+  messageSnoozeSchema,
+} from "../messages";
+
+const VALID_UUID = "550e8400-e29b-41d4-a716-446655440000";
+
+describe("messageApproveSchema", () => {
+  test("accepts valid uuid", () => {
+    expect(messageApproveSchema.safeParse({ id: VALID_UUID }).success).toBe(
+      true,
+    );
+  });
+
+  test("rejects non-uuid id", () => {
+    expect(messageApproveSchema.safeParse({ id: "not-a-uuid" }).success).toBe(
+      false,
+    );
+  });
+
+  test("rejects missing id", () => {
+    expect(messageApproveSchema.safeParse({}).success).toBe(false);
+  });
+});
+
+describe("messageDismissSchema", () => {
+  test("accepts valid uuid", () => {
+    expect(messageDismissSchema.safeParse({ id: VALID_UUID }).success).toBe(
+      true,
+    );
+  });
+
+  test("rejects non-uuid id", () => {
+    expect(messageDismissSchema.safeParse({ id: "x" }).success).toBe(false);
+  });
+});
+
+describe("messageEditAndApproveSchema", () => {
+  test("accepts valid body", () => {
+    const result = messageEditAndApproveSchema.safeParse({
+      id: VALID_UUID,
+      body: "Hey John, still looking at Springfield Rise?",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test("rejects empty body", () => {
+    expect(
+      messageEditAndApproveSchema.safeParse({ id: VALID_UUID, body: "" })
+        .success,
+    ).toBe(false);
+  });
+
+  test("rejects whitespace-only body after trim", () => {
+    expect(
+      messageEditAndApproveSchema.safeParse({ id: VALID_UUID, body: "   " })
+        .success,
+    ).toBe(false);
+  });
+
+  test("accepts body at exactly 1600 chars", () => {
+    expect(
+      messageEditAndApproveSchema.safeParse({
+        id: VALID_UUID,
+        body: "x".repeat(1600),
+      }).success,
+    ).toBe(true);
+  });
+
+  test("rejects body over 1600 chars", () => {
+    expect(
+      messageEditAndApproveSchema.safeParse({
+        id: VALID_UUID,
+        body: "x".repeat(1601),
+      }).success,
+    ).toBe(false);
+  });
+});
+
+describe("messageSnoozeSchema", () => {
+  test("accepts a future Date", () => {
+    const future = new Date(Date.now() + 3600_000); // +1h
+    expect(
+      messageSnoozeSchema.safeParse({ id: VALID_UUID, snoozedUntil: future })
+        .success,
+    ).toBe(true);
+  });
+
+  test("coerces an ISO string to Date", () => {
+    const future = new Date(Date.now() + 3600_000).toISOString();
+    expect(
+      messageSnoozeSchema.safeParse({ id: VALID_UUID, snoozedUntil: future })
+        .success,
+    ).toBe(true);
+  });
+
+  test("rejects a past date", () => {
+    const past = new Date(Date.now() - 1000);
+    expect(
+      messageSnoozeSchema.safeParse({ id: VALID_UUID, snoozedUntil: past })
+        .success,
+    ).toBe(false);
+  });
+
+  test("rejects unparseable input", () => {
+    expect(
+      messageSnoozeSchema.safeParse({
+        id: VALID_UUID,
+        snoozedUntil: "not-a-date",
+      }).success,
+    ).toBe(false);
+  });
+});

--- a/src/server/api/schemas/messages.ts
+++ b/src/server/api/schemas/messages.ts
@@ -1,0 +1,45 @@
+import { z } from "zod";
+
+// Enum schemas — mirror values from src/server/db/schema/enums.ts
+export const channelSchema = z.enum(["sms", "email"]);
+
+export const messageStatusSchema = z.enum([
+  "pending",
+  "approved",
+  "edited_and_approved",
+  "dismissed",
+  "snoozed",
+]);
+
+// approve / dismiss — id only
+export const messageApproveSchema = z.object({
+  id: z.string().uuid(),
+});
+
+export const messageDismissSchema = z.object({
+  id: z.string().uuid(),
+});
+
+// editAndApprove — id + new body (trimmed, non-empty, <= 1600 chars).
+// 1600 is the SMS segment ceiling; email is fine at the same bound.
+export const messageEditAndApproveSchema = z.object({
+  id: z.string().uuid(),
+  body: z
+    .string()
+    .trim()
+    .min(1, "Message body cannot be empty")
+    .max(1600, "Message body cannot exceed 1600 characters"),
+});
+
+// snooze — id + future snoozedUntil (coerced from ISO string)
+export const messageSnoozeSchema = z.object({
+  id: z.string().uuid(),
+  snoozedUntil: z.coerce.date().refine((date) => date > new Date(), {
+    message: "snoozedUntil must be a future date",
+  }),
+});
+
+export type MessageApprove = z.infer<typeof messageApproveSchema>;
+export type MessageDismiss = z.infer<typeof messageDismissSchema>;
+export type MessageEditAndApprove = z.infer<typeof messageEditAndApproveSchema>;
+export type MessageSnooze = z.infer<typeof messageSnoozeSchema>;

--- a/thoughts/plans/2026-04-09-fix-posthog-e2e-tests.md
+++ b/thoughts/plans/2026-04-09-fix-posthog-e2e-tests.md
@@ -1,0 +1,524 @@
+# Fix PostHog E2E Tests Implementation Plan
+
+## Overview
+
+Unblock 57 of 111 skipped Playwright e2e tests (51% of all skips) that verify PostHog analytics events. Today they are marked `test.fixme()` because PostHog's default `request_batching: true` queues events in memory and only flushes on page unload via `sendBeacon`, so the existing network-interception helper never sees them during a test run.
+
+The fix is a minimal, runtime-only test-mode gate on `posthog.init()` — no build-time env var, no separate production code path beyond a one-flag branch.
+
+## Current State Analysis
+
+**What already works (do not rebuild):**
+- `e2e/utils/analytics-helper.ts:85-115` — `AnalyticsHelper` already uses `page.on("request")` to intercept requests to `/rk/`, `/e`, `/capture`, `/batch`, decodes gzip-compressed PostHog payloads with `pako`, and extracts events from batch arrays. API is fluent: `expectEvent(name).withProperty(k, v).toBeFired()`.
+- `e2e/utils/analytics-helper.ts:138-153` — `waitForEvent(name, timeoutMs)` already implements an async polling pattern (every-rAF loop, 5s default timeout) that reads from the same `capturedEvents` reference. The fluent `EventAssertion` API, by contrast, is still sync. Phase 2 applies the existing polling pattern to the fluent API rather than inventing anything new.
+- `e2e/fixtures/test.ts:14-20` — `analytics` fixture instantiates the helper, calls `startCapturing()` before the test, `stopCapturing()` after. Tests import `test` from this file and destructure `analytics` from the test args.
+- All expected event names are instrumented in the app at `src/lib/posthog.ts` — `cta_clicked` (L177), `booking_form_started` (L248), `form_step_completed` (L315), `lead_identified` (L396), `booking_form_submitted` (L468), `faq_expanded` (L555), `faq_searched` (L572), `utm_captured` (L804), `login_otp_requested` (L892), `login_success` (L901).
+
+**What's broken:**
+- `src/instrumentation-client.ts:4-9` calls `posthog.init()` with the production default `request_batching: true`. Events are queued in memory; during a Playwright test the page never unloads, so the flush-on-unload path never fires and the listener never sees the POST request.
+- All 57 analytics tests are marked `test.fixme()` with top-of-file comments explaining the issue and proposing the fix that was never implemented (`e2e/features/cta-tracking.spec.ts:3-51`, `e2e/features/booking-form.spec.ts:177-203`).
+- `EventAssertion.toBeFired()` and `toBeFiredTimes()` at `e2e/utils/analytics-helper.ts:233-279` are sync. They read `this.events` (a reference, not a copy) and assert once. With batching disabled, events will arrive a few ms after the triggering action — the sync call will race and flake unless every test site adds an explicit `waitForTimeout`.
+
+**Key constraint — `safeCapture` readiness gate:**
+- `src/lib/posthog.ts:113-116` silently drops events if `posthog.__loaded === false`. This is a separate failure mode from batching. In practice tests navigate via `homePage.goto()` which waits for `load`, by which time the PostHog snippet has finished bootstrapping. But if a test sees flake after the batching fix, this gate is the second suspect.
+
+## Desired End State
+
+- `make test_e2e` reports 145 → **202 passed, 54 skipped, 0 failed** (57 previously-fixmed analytics tests now pass; other legitimately-skipped groups — mobile viewport skips, unimplemented feature stubs, viewport-exclusive dashboard tests, HubSpot inbound webhook tests — stay skipped per the prior skip audit).
+- No `test.fixme()` calls or "PostHog batches events and sends them via sendBeacon" comments remain in the 6 analytics spec files.
+- Production PostHog config is unchanged unless `window.__E2E_MODE__` is truthy. The flag can only be set via Playwright's `addInitScript` or manually by a developer with devtools — in both cases the only observable effect is reduced batching on that single browser session.
+
+### Key Discoveries:
+- `request_batching: boolean` is a valid posthog-js 1.298.0 config option (`node_modules/posthog-js/dist/module.d.ts:1399-1403`), default `true`. Setting it to `false` bypasses the in-memory queue entirely — every `posthog.capture()` fires an immediate HTTP request.
+- PostHog's `loaded: (posthog) => void` callback is public API (`node_modules/posthog-js/dist/module.d.ts:1162`). Not needed for this plan, but useful to know if we ever want browser-side event listeners instead of network interception.
+- `page.addInitScript()` is Playwright's documented API for injecting scripts before any page script runs on every navigation, so setting `window.__E2E_MODE__` before `goto()` guarantees the flag is visible when `instrumentation-client.ts` executes. This will be the first use of `addInitScript` in the e2e suite — the only existing references are commented-out proposals inside the fixme'd spec files themselves (`e2e/features/cta-tracking.spec.ts:38`, `e2e/features/booking-form.spec.ts:198`). All existing test-time mocking in this suite uses `page.route()` (see `e2e/utils/auth-mock.ts`), which is a different mechanism — it intercepts HTTP traffic, not in-page script state.
+- Tests fire `toBeFired()` assertions synchronously today, but since all 57 are `fixme`'d, there are zero live call sites — flipping the signature to `async` is a safe breaking change.
+
+## What We're NOT Doing
+
+- **Not** touching the 29 non-analytics mobile viewport skips (login.spec.ts form submission, booking-form step transitions, faq accordion animation). Those are a separate investigation per the earlier skip audit — likely stale labels referring to "WebKit" when the mobile project actually runs Chromium.
+- **Not** mocking `window.posthog` with a stub. Keeping the real SDK means we still test distinct_id propagation, session_id assignment, `$lib` property enrichment, and any middleware added to `posthog.capture`.
+- **Not** moving to a build-time env var like `NEXT_PUBLIC_E2E`. That would require a separate test build or a production fallback, and has no advantage over a runtime window flag for this use case.
+- **Not** rewriting the app-side instrumentation in `src/lib/posthog.ts`. All expected event names are already emitted.
+- **Not** adjusting `safeCapture`'s ready-check drop behavior. If we hit races we'll add a `waitForPostHogReady()` helper in Phase 4, but the baseline change doesn't touch this.
+- **Not** making `expectNoEvent` async. Its semantics (assert no event has fired within a caller-controlled window) are incompatible with polling — it must be sync and called after an explicit wait.
+
+## Implementation Approach
+
+Four sequential phases. Phase 1-2 are infrastructure with zero spec-file changes, so they can land and be verified independently. Phase 3 is the mechanical unskip. Phase 4 is the verification and triage of any individual tests that fail for reasons unrelated to batching (e.g., property schema drift between the test's expectation and `src/lib/posthog.ts`).
+
+---
+
+## Phase 1: Test-mode PostHog config and fixture flag
+
+### Overview
+Gate a `request_batching: false` override on `window.__E2E_MODE__`, and have the analytics fixture set that flag via `page.addInitScript()` before any page script runs. No test files unskipped yet — this phase only ensures the plumbing works.
+
+### Changes Required:
+
+#### 1. Add test-mode branch to PostHog init
+**File**: `src/instrumentation-client.ts`
+**Changes**: Detect `window.__E2E_MODE__` at runtime and spread an override object into the init options when true.
+
+```ts
+import posthog from "posthog-js";
+import { env } from "./env";
+
+declare global {
+  interface Window {
+    __E2E_MODE__?: boolean;
+  }
+}
+
+const isE2E =
+  typeof window !== "undefined" && window.__E2E_MODE__ === true;
+
+posthog.init(env.NEXT_PUBLIC_POSTHOG_KEY, {
+  api_host: "/rk",
+  ui_host: "https://us.posthog.com",
+  person_profiles: "identified_only",
+  defaults: "2025-05-24",
+  // Playwright E2E mode: disable batching so captures fire immediately and
+  // can be intercepted by AnalyticsHelper. Session recording is also
+  // disabled to avoid sending test traffic to the real PostHog project.
+  ...(isE2E && {
+    request_batching: false,
+    disable_session_recording: true,
+  }),
+});
+```
+
+**Tasks**:
+- [ ] Open `src/instrumentation-client.ts` and add a `declare global { interface Window { __E2E_MODE__?: boolean; } }` block after the existing imports
+- [ ] Add the line `const isE2E = typeof window !== "undefined" && window.__E2E_MODE__ === true;` after the global declaration
+- [ ] Inside the existing `posthog.init()` options object, add a conditional spread placeholder: `...(isE2E && { }),`
+- [ ] Inside the conditional spread object, add the key `request_batching: false`
+- [ ] Inside the same conditional spread object, add the key `disable_session_recording: true`
+- [ ] Add an inline comment directly above the conditional spread explaining: "Playwright E2E mode: disable batching so captures fire immediately and can be intercepted by AnalyticsHelper. Session recording is disabled to avoid test traffic leaking to the real PostHog project."
+
+#### 2. Inject the flag in the analytics fixture
+**File**: `e2e/fixtures/test.ts`
+**Changes**: Call `page.addInitScript()` at the start of the `analytics` fixture so `window.__E2E_MODE__` is set on the next navigation, before any Next.js bundle runs.
+
+```ts
+analytics: async ({ page }, use) => {
+  // Must run BEFORE any page script — the next goto() will inject this
+  // into the fresh document, and instrumentation-client.ts will pick it
+  // up in its runtime check and init PostHog with batching disabled.
+  await page.addInitScript(() => {
+    (window as Window & { __E2E_MODE__?: boolean }).__E2E_MODE__ = true;
+  });
+
+  const analytics = new AnalyticsHelper(page);
+  await analytics.startCapturing();
+  await use(analytics);
+  await analytics.stopCapturing();
+},
+```
+
+**Tasks**:
+- [ ] Open `e2e/fixtures/test.ts` and locate the `analytics` fixture body at lines 15-20
+- [ ] Before the `const analytics = new AnalyticsHelper(page)` line, add an `await page.addInitScript(() => { ... });` call
+- [ ] Inside the `addInitScript` callback, set `(window as Window & { __E2E_MODE__?: boolean }).__E2E_MODE__ = true`
+- [ ] Add a comment directly above the `addInitScript` call explaining it must run before any page script so the next `goto()` injects the flag into the fresh document where `instrumentation-client.ts` will read it
+
+#### 3. Smoke test
+**File**: `e2e/features/cta-tracking.spec.ts`
+**Tests**: Add a single new `test("[phase 1 smoke] hero primary CTA emits cta_clicked", …)` inside the `CTA Click Tracking` describe block. Do NOT modify or unskip any of the existing 6 fixme'd tests — they're unskipped in Phase 3 after the fluent API is async.
+
+Update the import at line 1 from `import { test } from "../fixtures/test"` to `import { expect, test } from "../fixtures/test"` — the current file only imports `test` (verified at `e2e/features/cta-tracking.spec.ts:1`), and the smoke test below needs `expect`.
+
+```ts
+test("[phase 1 smoke] hero primary CTA emits cta_clicked", async ({
+  homePage,
+  analytics,
+}) => {
+  await homePage.hero.clickPrimaryCta();
+
+  // Use the existing async waitForEvent helper, NOT the fluent toBeFired()
+  // API — the fluent API is still sync in Phase 1 and races the event
+  // arrival. Phase 2 will upgrade the fluent API; this smoke test will be
+  // deleted at the end of Phase 2 once the real tests are unskipped.
+  const event = await analytics.waitForEvent("cta_clicked", 5000);
+  expect(event).not.toBeNull();
+  expect(event?.properties.location).toBe("hero_primary");
+});
+```
+
+Leave the top-of-file explanatory comment in place for now — it will be removed in Phase 3. This smoke test is a temporary scaffold: it exercises the `__E2E_MODE__` → `request_batching: false` plumbing end-to-end using the already-async `waitForEvent` helper (`e2e/utils/analytics-helper.ts:138-153`), so Phase 1 can be verified independently without depending on Phase 2's async fluent API. Phase 2 deletes this smoke test once its own validation covers the same ground through the fluent API.
+
+**Tasks**:
+- [ ] At `e2e/features/cta-tracking.spec.ts:1`, change `import { test } from "../fixtures/test";` to `import { expect, test } from "../fixtures/test";`
+- [ ] Inside the `CTA Click Tracking` describe block, add a new `test("[phase 1 smoke] hero primary CTA emits cta_clicked", async ({ homePage, analytics }) => { ... });`
+- [ ] Inside the smoke test body, call `await homePage.hero.clickPrimaryCta();`
+- [ ] Inside the smoke test body, call `const event = await analytics.waitForEvent("cta_clicked", 5000);`
+- [ ] Assert `expect(event).not.toBeNull();`
+- [ ] Assert `expect(event?.properties.location).toBe("hero_primary");`
+- [ ] Add an inline comment inside the smoke test noting it is a temporary Phase 1 scaffold using `waitForEvent` (not the sync fluent API) and will be replaced in Phase 2
+- [ ] Leave the top-of-file "PostHog batches events" JSDoc comment untouched (Phase 3 removes it)
+
+### Success Criteria:
+
+#### Automated Verification:
+- [ ] `make check` passes (typecheck + lint)
+- [ ] `yarn test:e2e --project=desktop -g "\[phase 1 smoke\] hero primary CTA"` passes on 3 consecutive runs
+- [ ] The HTML report shows 1 captured `cta_clicked` event with `location: "hero_primary"`
+
+#### Manual Verification:
+- [ ] Open devtools on a production page and confirm `window.__E2E_MODE__` is `undefined` (i.e., the flag is truly test-only and not leaking)
+- [ ] In the same session, run `window.__E2E_MODE__ = true; location.reload()` and confirm PostHog still works but network traffic shows one request per event instead of batched payloads (use Network tab filter `/rk/`)
+
+---
+
+## Phase 2: Async polling in EventAssertion
+
+### Overview
+Upgrade `toBeFired()` and `toBeFiredTimes()` to async methods that poll `this.events` for up to a configurable timeout (default 5s) before failing. Keeps the existing rich error messages. `expectNoEvent` stays sync.
+
+### Changes Required:
+
+#### 1. Promote toBeFired to async with polling
+**File**: `e2e/utils/analytics-helper.ts`
+**Changes**: Rewrite `EventAssertion.toBeFired()` and `toBeFiredTimes()` to poll. The `events` array is passed by reference from the helper, so new pushes by the `page.on("request")` listener become visible on each iteration without any rework.
+
+```ts
+/** Execute the assertion — polls until the event arrives or timeout. */
+async toBeFired(timeoutMs = 5000): Promise<void> {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < timeoutMs) {
+    const matchingEvents = this.events.filter(
+      (e) => e.event === this.eventName,
+    );
+    if (matchingEvents.length > 0) {
+      if (this.propertyMatchers.length === 0) return;
+      const fullyMatching = matchingEvents.find((event) =>
+        this.propertyMatchers.every(({ key, matcher }) =>
+          matcher(event.properties[key]),
+        ),
+      );
+      if (fullyMatching) return;
+    }
+    await new Promise((r) => setTimeout(r, 50));
+  }
+  // Timeout — raise the same rich error the old sync path produced.
+  const matchingEvents = this.events.filter(
+    (e) => e.event === this.eventName,
+  );
+  expect(
+    matchingEvents.length,
+    `Expected '${this.eventName}' event to be fired within ${timeoutMs}ms, but it wasn't. ` +
+      `Captured events: [${this.events.map((e) => e.event).join(", ")}]`,
+  ).toBeGreaterThan(0);
+  const conditions = this.propertyMatchers
+    .map((m) => m.description)
+    .join(", ");
+  const actualProps = matchingEvents
+    .map((e) => JSON.stringify(e.properties))
+    .join("\n");
+  throw new Error(
+    `Expected '${this.eventName}' with [${conditions}] within ${timeoutMs}ms, but no matching event found.\n` +
+      `Actual '${this.eventName}' events:\n${actualProps}`,
+  );
+}
+
+/** Assert event was fired exactly N times — polls until count reached or timeout. */
+async toBeFiredTimes(count: number, timeoutMs = 5000): Promise<void> {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < timeoutMs) {
+    const matching = this.events.filter((e) => {
+      if (e.event !== this.eventName) return false;
+      if (this.propertyMatchers.length === 0) return true;
+      return this.propertyMatchers.every(({ key, matcher }) =>
+        matcher(e.properties[key]),
+      );
+    });
+    if (matching.length === count) return;
+    if (matching.length > count) break; // Fail fast — we've overshot
+    await new Promise((r) => setTimeout(r, 50));
+  }
+  const matching = this.events.filter((e) => {
+    if (e.event !== this.eventName) return false;
+    if (this.propertyMatchers.length === 0) return true;
+    return this.propertyMatchers.every(({ key, matcher }) =>
+      matcher(e.properties[key]),
+    );
+  });
+  expect(matching).toHaveLength(count);
+}
+```
+
+**Tasks — toBeFired (async polling)**:
+- [ ] Change the `toBeFired()` signature at `e2e/utils/analytics-helper.ts:233` from `toBeFired(): void` to `async toBeFired(timeoutMs = 5000): Promise<void>`
+- [ ] Inside `toBeFired`, record `const startedAt = Date.now();` as the first line
+- [ ] Wrap the existing match logic in a `while (Date.now() - startedAt < timeoutMs) { ... }` polling loop
+- [ ] Inside the loop, filter `this.events` into `const matchingEvents = this.events.filter((e) => e.event === this.eventName);`
+- [ ] Inside the loop, if `matchingEvents.length > 0 && this.propertyMatchers.length === 0`, `return` immediately (success path, no property matchers)
+- [ ] Inside the loop, if `matchingEvents.length > 0` and there ARE property matchers, use `matchingEvents.find((event) => this.propertyMatchers.every(({ key, matcher }) => matcher(event.properties[key])))` and `return` when a fully-matching event is found
+- [ ] At the end of each loop iteration, `await new Promise((r) => setTimeout(r, 50));` to yield control
+- [ ] After the loop (timeout branch), re-compute `matchingEvents` from the current `this.events` so the failure message reflects the final state
+- [ ] Raise the existing `expect(matchingEvents.length, ...).toBeGreaterThan(0)` assertion with a message referencing `this.eventName`, `timeoutMs`, and the captured event names
+- [ ] Build a `conditions` string by joining `this.propertyMatchers.map((m) => m.description)` with `", "`
+- [ ] Build an `actualProps` string by joining `matchingEvents.map((e) => JSON.stringify(e.properties))` with newlines
+- [ ] Throw a final `Error` with message `"Expected '${this.eventName}' with [${conditions}] within ${timeoutMs}ms, but no matching event found.\nActual '${this.eventName}' events:\n${actualProps}"`
+
+**Tasks — toBeFiredTimes (async polling)**:
+- [ ] Change the `toBeFiredTimes()` signature at `e2e/utils/analytics-helper.ts:269` from `toBeFiredTimes(count: number): void` to `async toBeFiredTimes(count: number, timeoutMs = 5000): Promise<void>`
+- [ ] Inside `toBeFiredTimes`, record `const startedAt = Date.now();` as the first line
+- [ ] Wrap the existing match logic in a `while (Date.now() - startedAt < timeoutMs) { ... }` polling loop
+- [ ] Inside the loop, compute `const matching = this.events.filter((e) => { if (e.event !== this.eventName) return false; if (this.propertyMatchers.length === 0) return true; return this.propertyMatchers.every(({ key, matcher }) => matcher(e.properties[key])); });`
+- [ ] Inside the loop, if `matching.length === count`, `return` immediately (success)
+- [ ] Inside the loop, if `matching.length > count`, `break` to fail fast on overshoot
+- [ ] At the end of each loop iteration, `await new Promise((r) => setTimeout(r, 50));`
+- [ ] After the loop (timeout or overshoot branch), re-compute `matching` from the current `this.events`
+- [ ] Raise `expect(matching).toHaveLength(count);` so Playwright surfaces its rich length-diff failure
+
+**Tasks — untouched surfaces**:
+- [ ] Verify `expectNoEvent` at `e2e/utils/analytics-helper.ts:161` remains sync — do NOT add `async` or `await` (per "What We're NOT Doing")
+- [ ] Verify `waitForEvent` at `e2e/utils/analytics-helper.ts:138-153` is NOT touched — it already polls correctly and is used as-is by the Phase 1 smoke test
+
+#### 2. Replace the Phase 1 smoke test with a fluent-API smoke test
+**File**: `e2e/features/cta-tracking.spec.ts`
+**Changes**: Delete the `[phase 1 smoke] hero primary CTA emits cta_clicked` test added in Phase 1 and add a new temporary `[phase 2 smoke] hero primary CTA fluent assertion` test in its place. The new test uses the async fluent API so we validate that the assertion chain — not just `waitForEvent` — now works end-to-end. This second smoke test is also temporary and will be deleted in Phase 3 when the real 6 fixme'd tests are unskipped and provide the same coverage.
+
+```ts
+test("[phase 2 smoke] hero primary CTA fluent assertion", async ({
+  homePage,
+  analytics,
+}) => {
+  await homePage.hero.clickPrimaryCta();
+
+  await analytics
+    .expectEvent("cta_clicked")
+    .withProperty("location", "hero_primary")
+    .toBeFired();
+});
+```
+
+**Tasks**:
+- [ ] In `e2e/features/cta-tracking.spec.ts`, delete the entire `[phase 1 smoke] hero primary CTA emits cta_clicked` test added in Phase 1
+- [ ] Add a new `test("[phase 2 smoke] hero primary CTA fluent assertion", async ({ homePage, analytics }) => { ... });` in its place, inside the `CTA Click Tracking` describe block
+- [ ] Inside the new smoke test body, call `await homePage.hero.clickPrimaryCta();`
+- [ ] Inside the new smoke test body, await the fluent chain: `await analytics.expectEvent("cta_clicked").withProperty("location", "hero_primary").toBeFired();`
+- [ ] Add an inline comment noting this smoke test will be deleted in Phase 3 once the real unskipped tests cover the same plumbing
+
+### Success Criteria:
+
+#### Automated Verification:
+- [ ] `make check` passes
+- [ ] `yarn test:e2e --project=desktop -g "\[phase 2 smoke\] hero primary CTA fluent assertion"` passes on 10 consecutive runs (stability check — polling should make this non-flaky)
+- [ ] Intentionally break the app instrumentation (temporarily rename `cta_clicked` to `cta_clicked_xxx` in `src/lib/posthog.ts:177`) and confirm the test fails with the polling timeout message within ~5s, not hanging. Revert the rename before moving on.
+
+#### Manual Verification:
+- [ ] Error message on failure lists both the expected event + conditions AND the actual captured events — useful when debugging real failures
+
+---
+
+## Phase 3: Unskip all 57 analytics tests
+
+### Overview
+Mechanical change across 6 spec files: remove every `test.fixme` marker on analytics tests, delete the top-of-file "PostHog batches events…" explanatory comments, and prefix every `.toBeFired()` / `.toBeFiredTimes()` call with `await`. Tests stay in their current describe blocks.
+
+### Changes Required:
+
+#### 1. `e2e/features/cta-tracking.spec.ts`
+**Tasks — cleanup**:
+- [ ] Delete the top-of-file JSDoc comment block at `e2e/features/cta-tracking.spec.ts:3-51` ("CTA CLICK TRACKING TESTS - ALL ANALYTICS TESTS MARKED AS FIXME…")
+- [ ] Delete the `[phase 2 smoke] hero primary CTA fluent assertion` test — the unfixme'd "hero primary CTA tracks click event" now covers the same plumbing
+
+**Tasks — unfixme per test**:
+- [ ] Change `test.fixme("hero primary CTA tracks click event", …)` at line 57 to `test("hero primary CTA tracks click event", …)`
+- [ ] Change `test.fixme("hero secondary CTA tracks click event", …)` at line 69 to `test("hero secondary CTA tracks click event", …)`
+- [ ] Change `test.fixme("navbar desktop CTA tracks click event", …)` at line 81 to `test("navbar desktop CTA tracks click event", …)`
+- [ ] Change `test.fixme("pricing tier CTAs track click events", …)` at line 93 to `test("pricing tier CTAs track click events", …)`
+- [ ] Change `test.fixme("final CTA section tracks click event", …)` at line 119 to `test("final CTA section tracks click event", …)`
+- [ ] Change `test.fixme("FAQ bottom CTA tracks click event", …)` at line 132 to `test("FAQ bottom CTA tracks click event", …)`
+
+**Tasks — await every assertion**:
+- [ ] Prefix the `.toBeFired()` call inside "hero primary CTA tracks click event" with `await`
+- [ ] Prefix the `.toBeFired()` call inside "hero secondary CTA tracks click event" with `await`
+- [ ] Prefix the `.toBeFired()` call inside "navbar desktop CTA tracks click event" with `await`
+- [ ] Prefix the first `.toBeFired()` call (pricing_foundation, before `analytics.clearEvents()`) inside "pricing tier CTAs track click events" with `await`
+- [ ] Prefix the second `.toBeFired()` call (pricing_growth, after `analytics.clearEvents()`) inside "pricing tier CTAs track click events" with `await`
+- [ ] Prefix the `.toBeFired()` call inside "final CTA section tracks click event" with `await`
+- [ ] Prefix the `.toBeFired()` call inside "FAQ bottom CTA tracks click event" with `await`
+
+#### 2. `e2e/features/booking-form.spec.ts`
+**Tasks — cleanup**:
+- [ ] Delete the mid-file JSDoc comment block at `e2e/features/booking-form.spec.ts:177-203` ("ANALYTICS TESTS - ALL MARKED AS FIXME…") — note this is mid-file, not top-of-file, because two other describe blocks precede it
+
+**Tasks — unfixme per test**:
+- [ ] Change `test.fixme("form interaction fires form_started event", …)` at line 210 to `test("form interaction fires form_started event", …)`
+- [ ] Change `test.fixme("step completion fires step_completed event", …)` at line 219 to `test("step completion fires step_completed event", …)`
+- [ ] Change `test.fixme("lead identification happens after step 1", …)` at line 235 to `test("lead identification happens after step 1", …)`
+- [ ] Change `test.fixme("successful submission fires form_submitted event", …)` at line 311 to `test("successful submission fires form_submitted event", …)`
+
+**Tasks — await every assertion**:
+- [ ] Prefix the `.toBeFired()` call inside "form interaction fires form_started event" with `await`
+- [ ] Prefix the `.toBeFired()` call inside "step completion fires step_completed event" with `await`
+- [ ] Prefix the `.toBeFired()` call inside "lead identification happens after step 1" with `await`
+- [ ] Prefix the `.toBeFired()` call inside "successful submission fires form_submitted event" with `await`
+
+#### 3. `e2e/features/login.spec.ts`
+**Tasks — cleanup**:
+- [ ] Delete the pre-describe JSDoc comment block at `e2e/features/login.spec.ts:256-263` ("POSTHOG EVENT TESTS — MARKED AS FIXME…")
+- [ ] Delete the describe-level `test.fixme(true, "PostHog events are batched…")` call at lines 265-268 that currently blocks the entire "Login Page — PostHog Events" describe
+
+**Tasks — await every assertion**:
+- [ ] Prefix the `.toBeFired()` call inside "fires login_otp_requested on email submit" (starts at line 270) with `await`
+- [ ] Prefix the `.toBeFired()` call inside "fires login_success on successful OTP verify" (starts at line 289) with `await`
+
+**Tasks — do-not-touch guardrails**:
+- [ ] Verify the `analytics.expectNoEvent("login_success")` call at line 329 remains **sync** (do NOT add `await`) — `expectNoEvent` stays sync per "What We're NOT Doing"
+- [ ] Leave all `loginPage.page.waitForTimeout(500)` calls in this file untouched — they are belt-and-braces on top of polling and genuinely needed for the sync `expectNoEvent` assertion
+
+#### 4. `e2e/features/faq-interactions.spec.ts`
+**Tasks — cleanup**:
+- [ ] Delete the inline JSDoc comment at `e2e/features/faq-interactions.spec.ts:88-90` ("ANALYTICS TEST - See booking-form.spec.ts…")
+- [ ] Delete the inline JSDoc comment at `e2e/features/faq-interactions.spec.ts:110-112` ("ANALYTICS TEST - See booking-form.spec.ts…")
+
+**Tasks — unfixme per test**:
+- [ ] Change `test.fixme("search tracks analytics event after debounce", …)` at line 91 to `test("search tracks analytics event after debounce", …)`
+- [ ] Change `test.fixme("expanding FAQ tracks analytics event", …)` at line 113 to `test("expanding FAQ tracks analytics event", …)`
+
+**Tasks — await every assertion**:
+- [ ] Prefix the `.toBeFired()` call inside "search tracks analytics event after debounce" with `await`
+- [ ] Prefix the `.toBeFired()` call inside "expanding FAQ tracks analytics event" with `await`
+
+#### 5. `e2e/journeys/form-abandonment.spec.ts`
+**Tasks — cleanup**:
+- [ ] Delete the top-of-file JSDoc comment block at `e2e/journeys/form-abandonment.spec.ts:4-10` ("ANALYTICS TESTS - ALL MARKED AS FIXME…")
+
+**Tasks — unfixme per test**:
+- [ ] Change `test.fixme("abandonment tracked when leaving after step 1", …)` at line 12 to `test("abandonment tracked when leaving after step 1", …)`
+- [ ] Change `test.fixme("partial lead data is captured at each step", …)` at line 40 to `test("partial lead data is captured at each step", …)`
+
+**Tasks — await every assertion**:
+- [ ] Prefix the `analytics.expectEvent("form_step_completed").withProperty("step", 1).toBeFired()` call inside "abandonment tracked when leaving after step 1" with `await`
+- [ ] Prefix the `analytics.expectEvent("lead_identified").toBeFired()` call inside "partial lead data is captured at each step" with `await`
+- [ ] Prefix the `analytics.expectEvent("form_step_completed").withProperty("step", 2).toBeFired()` call inside "partial lead data is captured at each step" with `await`
+
+#### 6. `e2e/journeys/lead-conversion.spec.ts`
+**Tasks — cleanup**:
+- [ ] Delete the pre-test JSDoc comment block at `e2e/journeys/lead-conversion.spec.ts:5-20` ("ANALYTICS TEST - MARKED AS FIXME…")
+- [ ] Delete the pre-test JSDoc comment block at `e2e/journeys/lead-conversion.spec.ts:116-121` ("ANALYTICS TEST - MARKED AS FIXME…")
+
+**Tasks — unfixme per test**:
+- [ ] Change `test.fixme("complete journey from landing to form submission with analytics", …)` at line 21 to `test("complete journey from landing to form submission with analytics", …)`
+- [ ] Change `test.fixme("UTM parameters are tracked", …)` at line 122 to `test("UTM parameters are tracked", …)`
+
+**Tasks — await every assertion in the complete-journey test**:
+- [ ] Prefix the `analytics.expectEvent("cta_clicked").withProperty("location", "hero_primary").toBeFired()` call with `await`
+- [ ] Prefix the `analytics.expectEvent("booking_form_started").toBeFired()` call with `await`
+- [ ] Prefix the `analytics.expectEvent("form_step_completed").withProperty("step", 1).toBeFired()` call with `await`
+- [ ] Prefix the `analytics.expectEvent("booking_form_submitted").withPropertyPresent("lead_email").toBeFired()` call with `await`
+
+**Tasks — await every assertion in the UTM test**:
+- [ ] Prefix the `analytics.expectEvent("utm_captured").withProperty("utm_source", "google").toBeFired()` call with `await`
+
+### Success Criteria:
+
+#### Automated Verification:
+- [ ] `make check` passes (typecheck — note: biome 2.4.9's `noFloatingPromises` rule is in nursery and NOT enabled in this project's `biome.json`, and TypeScript `strict` doesn't catch unawaited promises either. Static analysis will NOT catch a missed `await` on `.toBeFired()` — the checks below are the real safety net.)
+- [ ] Grep confirms zero `test.fixme` calls remain in the 6 analytics spec files: `rg "test\.fixme" e2e/features/cta-tracking.spec.ts e2e/features/booking-form.spec.ts e2e/features/login.spec.ts e2e/features/faq-interactions.spec.ts e2e/journeys/form-abandonment.spec.ts e2e/journeys/lead-conversion.spec.ts` returns nothing
+- [ ] Grep confirms every `.toBeFired(` or `.toBeFiredTimes(` call is preceded by `await`: `rg --multiline --multiline-dotall "^\s*analytics\b(?:(?!await).)*?\.toBeFired" e2e/features e2e/journeys` returns nothing. (The pattern matches statements beginning with `analytics` that chain into `.toBeFired` without an `await` on the same statement.)
+- [ ] `make test_e2e` shows ≥ 200 passed (up from 145), ≤ 55 skipped (down from 111), 0 failed on the first run. If a test silently passed due to a missed `await` on an assertion, Playwright's unhandled-rejection handler surfaces it as a failure here — rerun after fixing.
+
+#### Manual Verification:
+- [ ] Spot-check HTML report: click into 2-3 of the newly-passing tests and confirm the "events captured" count matches expectations (e.g., the `pricing tier CTAs` test should show both `pricing_foundation` and `pricing_growth` captures)
+
+---
+
+## Phase 4: Verify full suite and triage real failures
+
+### Overview
+Run the full suite, expect most tests to pass, and triage any that fail for reasons unrelated to batching. These should be rare but likely include property-name drift (the test expects a property the app doesn't set), or the `safeCapture` ready-gate race if a test fires before PostHog finishes bootstrapping.
+
+### Changes Required:
+
+#### 1. Run the full suite and collect failures
+**Command**: `make test_e2e` → capture the JSON reporter output with the same parsing approach used in the skip audit earlier in this branch.
+
+**Tasks**:
+- [ ] Confirm the working tree is clean (no unrelated diffs that could skew failures)
+- [ ] Run `make test_e2e` end-to-end against a clean worktree
+- [ ] Capture the JSON reporter output to a scratch file (e.g. `/tmp/posthog-triage.json`) for parsing
+- [ ] Parse the JSON into a list of `(test title, source file, error message)` tuples for the failures
+- [ ] Save the parsed failure list to a scratch file for use during triage
+
+#### 2. Triage bucket
+For each failure:
+- **Property mismatch** (e.g., test asserts `withProperty("step_name", "basic_info")` but the app doesn't set that key) — inspect `src/lib/posthog.ts` to see what's actually captured, fix whichever side is wrong. Prefer fixing the test if the app's shape is a deliberate schema, prefer fixing the app if it's a clear oversight.
+- **Event never fires** — check whether the user action in the test actually reaches the app instrumentation. `hero.clickPrimaryCta()` should route through whatever handler calls `trackCtaClicked("hero_primary")`. If the call site is missing, add it.
+- **Race with `safeCapture` ready-gate** — if a test fires an action immediately after `goto()` and the `[PostHog] Not ready, event queued` log appears in the page console, add a `waitForPostHogReady()` helper to the analytics fixture that does `await page.waitForFunction(() => (window as any).posthog?.__loaded === true, { timeout: 5000 })` and call it at the top of affected tests.
+
+**Tasks — classify**:
+- [ ] For each failure in the parsed list, label it `property-mismatch`, `event-never-fires`, or `safeCapture-race`
+- [ ] Note any failure that doesn't fit cleanly into one of those three buckets — surface it before continuing
+
+**Tasks — property-mismatch failures**:
+- [ ] For each property-mismatch failure, open `src/lib/posthog.ts` and locate the `trackX()` call site that emits the event
+- [ ] Compare the test's `withProperty(...)` keys/values against the app's actual capture payload and identify which side diverges
+- [ ] Decide per failure whether to fix the test or the app — prefer fixing the test when the app shape is a deliberate schema, prefer fixing the app when it's a clear oversight
+- [ ] Apply the chosen fix
+- [ ] Re-run just that single test (e.g. `yarn test:e2e -g "<test title>"`) to confirm it passes
+
+**Tasks — event-never-fires failures**:
+- [ ] For each "event never fires" failure, identify the user action in the test that should have triggered the event
+- [ ] Trace that user action back to the corresponding handler in the app source
+- [ ] Verify the handler calls the expected `trackX()` function from `src/lib/posthog.ts`
+- [ ] If the `trackX()` call site is missing, add it
+- [ ] Re-run that single test to confirm it passes
+
+**Tasks — safeCapture-race failures**:
+- [ ] For each suspected `safeCapture` race, look for `[PostHog] Not ready, event queued` in the test's page console output to confirm the diagnosis
+- [ ] If confirmed, add a `waitForPostHogReady()` helper to `e2e/fixtures/test.ts` that calls `await page.waitForFunction(() => (window as any).posthog?.__loaded === true, { timeout: 5000 })`
+- [ ] Export `waitForPostHogReady` (or expose it through the analytics fixture API) so tests can call it
+- [ ] Call `waitForPostHogReady()` at the top of each test that hit the race
+- [ ] Re-run each affected test to confirm it passes
+
+#### 3. Handle out-of-scope app gaps
+If triage uncovers a missing instrumentation site that requires non-trivial app-side work (e.g., "we never fire `utm_captured` on first load, only on re-visit"), **do not fix inline**. File a follow-up issue and mark that specific test with `test.fixme("TODO: #<issue-number> — app-side instrumentation missing")`. The current branch's goal is the batching fix; deferring correctness work to its own ticket keeps the diff reviewable.
+
+**Tasks**:
+- [ ] For each failure that requires non-trivial app-side instrumentation, draft a GitHub issue title and body describing the failing test, the missing event/property, and the proposed fix
+- [ ] File the follow-up issues via `gh issue create`, capturing the returned issue numbers
+- [ ] For each filed issue, re-apply `test.fixme("TODO: #<issue-number> — app-side instrumentation missing")` on the corresponding test (only — leave all other newly-unskipped tests untouched)
+- [ ] After re-applying the targeted fixmes, re-run `make test_e2e` and confirm 0 failures (the deferred tests now skip, the rest pass)
+- [ ] Run `make check` one more time to confirm typecheck and lint still pass with the targeted fixmes in place
+
+### Success Criteria:
+
+#### Automated Verification:
+- [ ] `make test_e2e` reports 0 failed across all 3 viewport projects
+- [ ] Passed count is ≥ 200 (allowing for 2-3 Phase 4 follow-up fixmes if genuinely blocked on app work)
+- [ ] `make check` still passes
+
+#### Manual Verification:
+- [ ] Visual inspection of the HTML report shows the formerly-skipped tests now in the "passed" column
+- [ ] Spot check one newly-passing test in each file to confirm the assertions are meaningful (not just passing because the capture array is empty and `expectNoEvent` is being used)
+- [ ] Open the PostHog project in the browser and confirm the test run did NOT create a flood of session recordings (validates that `disable_session_recording: true` kicked in)
+
+---
+
+## Performance Considerations
+
+- `request_batching: false` in E2E mode means one HTTP POST per `capture()` call instead of one batched POST per ~10s. A typical analytics test fires 1-4 events, so at most ~4 extra requests per test × ~20 unskipped tests = ~80 additional small POSTs per full run. Negligible against the 256 existing test instances. No impact on production.
+- `toBeFired()` polls every 50ms. Even a worst-case 5s timeout is bounded and only kicks in on failure. In the happy path, events arrive within ~100ms of the triggering action, so the polling overhead is ~2 iterations per assertion.
+- `disable_session_recording: true` in E2E mode means test runs do not stream rrweb snapshots to the real PostHog project. This removes a meaningful amount of cross-run noise on the production PostHog account.
+
+## Migration Notes
+
+- No database changes, no schema migrations.
+- No production config change — the PostHog dashboard, project key, and proxy path are untouched.
+- The one line added to `instrumentation-client.ts` is a runtime branch on a window flag that is `undefined` in production. Rollback is a single revert.
+
+## References
+
+- Original skip audit: see the "Category table" message earlier on branch `feat/102-hubspot-contact-sync` (showed Group 1 — PostHog events — as 51% of all skips).
+- Existing analytics helper: `e2e/utils/analytics-helper.ts`
+- Existing fixture: `e2e/fixtures/test.ts`
+- PostHog init: `src/instrumentation-client.ts`
+- PostHog instrumentation sites: `src/lib/posthog.ts:177,248,315,396,468,555,572,804,892,901`
+- `request_batching` type definition: `node_modules/posthog-js/dist/module.d.ts:1399-1403`
+- Related prior plan: `thoughts/plans/2025-11-25-posthog-analytics-integration.md`
+- Top-of-file fixme rationale (what we're replacing): `e2e/features/cta-tracking.spec.ts:3-51`, `e2e/features/booking-form.spec.ts:177-203`

--- a/thoughts/plans/2026-04-12-ENG-126-messages-router.md
+++ b/thoughts/plans/2026-04-12-ENG-126-messages-router.md
@@ -1,0 +1,822 @@
+# tRPC Messages Router + Zod Input Schemas Implementation Plan
+
+## Overview
+
+Flesh out the currently-stubbed `messagesRouter` with 5 procedures (`listPending`, `approve`, `editAndApprove`, `snooze`, `dismiss`) and introduce a dedicated Zod input-schema file. The schema, enum, and index already exist; this ticket is purely the API layer plus tests.
+
+This router unblocks three follow-on tickets (Twilio dispatch #4, HubSpot dispatch #5, action queue view). Actual message sending, queue UI, and AI draft generation are out of scope.
+
+## Current State Analysis
+
+- `src/server/api/routers/messages.ts:1-7` — stub router with a single `getPending` query that returns `[]`. No imports from `~/server/db/schema`.
+- `src/server/db/schema/message-queue.ts:13-37` — `message_queue` table with `id`, `leadId`, `channel`, `subject`, `body`, `aiReasoning`, `priority`, `status`, `snoozedUntil`, `originalBody`, `approvedAt`, `sentAt`, `createdAt`. Composite index on `(status, priority)`.
+- `src/server/db/schema/enums.ts:69-77` — `channelEnum` (`sms`, `email`) and `messageStatusEnum` (`pending`, `approved`, `edited_and_approved`, `dismissed`, `snoozed`).
+- `src/server/db/schema/index.ts:7` — re-exports `message-queue`, so `db.query.messageQueue` is available via the drizzle schema passed at `src/server/db/index.ts:10`.
+- `src/server/api/routers/leads.ts` — canonical router pattern: `protectedProcedure.input(schema).mutation/query(async ({ ctx, input }) => ...)`, `TRPCError` for NOT_FOUND, update + `.returning()` chains.
+- `src/server/api/schemas/leads.ts:1-137` — canonical schema pattern: enum schemas mirror db enums, main schemas with inline validation, type exports at bottom via `z.infer`.
+- `src/server/api/schemas/__tests__/leads.test.ts:1-125` — canonical Zod test pattern: `safeParse` + assertions on `.success`, one describe block per schema.
+- `src/server/api/__tests__/leads-router.test.ts:1-899` — canonical router test pattern: `rs.resetModules()` + `rs.doMock()` for `~/env`, `~/lib/session`, `~/server/db`, chainable mock builders for drizzle's fluent API, `getCaller()` helper.
+- `src/server/api/__tests__/router.test.ts:61-65` — the existing multi-stub test includes `messages.getPending` in its loop. This entry must be removed when the stub is replaced.
+
+### Key Discoveries
+
+- **Status transitions are enforced in the router, not the DB.** Drizzle enums are just Postgres strings; there's no runtime state machine. We need an explicit guard (terminal states: `approved`, `edited_and_approved`, `dismissed`).
+- **`listPending`'s filter is belt-and-braces.** Filtering by `status = 'pending'` alone excludes `snoozed` rows because snoozing changes the status. The additional `snoozedUntil <= now()` check is a defensive guard in case a pending row ever carries a future `snoozedUntil` (e.g. a draft scheduled for later by a follow-on ticket). Both conditions must hold.
+- **`db.query.messageQueue` works** because `src/server/db/index.ts:10` passes `* as schema` to `drizzle()`, and `message-queue.ts` exports `messageQueue` re-exported through `src/server/db/schema/index.ts:7`.
+- **`TRPCError` is wrapped automatically for Zod failures.** The error formatter at `src/server/api/trpc.ts:20-29` surfaces `ZodError` as `BAD_REQUEST` — tests use `expect((e as TRPCError).code).toBe("BAD_REQUEST")`.
+- **The `leads-router.test.ts` mocking pattern is opinionated.** Each test rebuilds chainable mocks fresh (`returning` → `where` → `set` → `update`). Follow that pattern for consistency; do not introduce a new helper.
+
+## Desired End State
+
+- `src/server/api/schemas/messages.ts` exists and exports typed Zod schemas for every mutation input, plus inferred TypeScript types.
+- `src/server/api/routers/messages.ts` exposes `listPending`, `approve`, `editAndApprove`, `snooze`, `dismiss` as `protectedProcedure`s with correct status-transition guards.
+- `src/server/api/schemas/__tests__/messages.test.ts` covers happy/unhappy paths for each schema.
+- `src/server/api/__tests__/messages-router.test.ts` covers happy/unhappy paths and transition guards for each procedure.
+- `src/server/api/__tests__/router.test.ts` no longer references `messages.getPending`.
+- `make check` and `make test` pass.
+
+### Verification
+
+```bash
+make check         # typecheck + lint
+make test          # all Rstest unit tests green, including new schema + router tests
+```
+
+## What We're NOT Doing
+
+- **Actual SMS/email dispatch.** Approving a message just flips its status; Twilio/HubSpot sends are #4/#5.
+- **AI draft generation.** Inserts into `message_queue` happen elsewhere (nurture scheduler).
+- **Un-snoozing.** A cron or the nurture scheduler will later transition expired `snoozed` rows back to `pending`. This PR does not add that job.
+- **Action queue UI.** The queue view consumes `listPending` but is its own ticket.
+- **Joined lead data in `listPending`.** Return raw `message_queue` rows; the UI can fetch lead context via separate queries.
+- **Integration tests against a real Postgres.** Follow the existing `leads-router.test.ts` pattern with mocked drizzle.
+
+## Implementation Approach
+
+Build Zod schemas first (phase 1) so the router can import and `.input()` them in phase 2. Each phase ends with all new tests green and nothing regressed.
+
+For status-transition enforcement, use a **read-then-update** flow in each mutation. This:
+
+1. Gives the exact current `status` so the error message can say what state was found.
+2. Lets `editAndApprove` read the current `body` in the same fetch (needed to populate `originalBody`).
+3. Matches how `leads.update` already reads the lead row first to get `hubspotContactId`.
+4. Keeps the mock setup in tests simple (one `findFirst` + one `update` chain).
+
+Concurrency: two simultaneous `approve` calls could both pass the status check and both write. That's acceptable for M0 — the second write is idempotent (same final status, `approvedAt` overwrite is harmless). If this matters later, move to a single conditional update with `where: and(eq(id, x), inArray(status, actionable))`.
+
+## Phase 1: Zod Input Schemas + Schema Tests
+
+### Overview
+
+Create `src/server/api/schemas/messages.ts` with validators for each mutation and a matching test file. No router changes yet — the stub router stays in place so existing tests keep passing.
+
+### Changes Required:
+
+#### 1. Zod schema file
+
+**File**: `src/server/api/schemas/messages.ts` (new)
+**Changes**: Define enum schemas mirroring db enums, per-mutation input schemas, and type exports.
+
+```typescript
+import { z } from "zod";
+
+// Enum schemas — mirror values from src/server/db/schema/enums.ts
+export const channelSchema = z.enum(["sms", "email"]);
+
+export const messageStatusSchema = z.enum([
+  "pending",
+  "approved",
+  "edited_and_approved",
+  "dismissed",
+  "snoozed",
+]);
+
+// approve / dismiss — id only
+export const messageApproveSchema = z.object({
+  id: z.string().uuid(),
+});
+
+export const messageDismissSchema = z.object({
+  id: z.string().uuid(),
+});
+
+// editAndApprove — id + new body (trimmed, non-empty, <= 1600 chars)
+// 1600 is the SMS segment ceiling; email is fine at the same bound.
+export const messageEditAndApproveSchema = z.object({
+  id: z.string().uuid(),
+  body: z
+    .string()
+    .trim()
+    .min(1, "Message body cannot be empty")
+    .max(1600, "Message body cannot exceed 1600 characters"),
+});
+
+// snooze — id + future snoozedUntil (coerced from ISO string)
+export const messageSnoozeSchema = z.object({
+  id: z.string().uuid(),
+  snoozedUntil: z.coerce.date().refine((date) => date > new Date(), {
+    message: "snoozedUntil must be a future date",
+  }),
+});
+
+export type MessageApprove = z.infer<typeof messageApproveSchema>;
+export type MessageDismiss = z.infer<typeof messageDismissSchema>;
+export type MessageEditAndApprove = z.infer<typeof messageEditAndApproveSchema>;
+export type MessageSnooze = z.infer<typeof messageSnoozeSchema>;
+```
+
+#### 2. Zod schema tests
+
+**File**: `src/server/api/schemas/__tests__/messages.test.ts` (new)
+**Tests**: Happy + unhappy paths for each schema. Follows the `leads.test.ts` style (one `describe` per schema, `safeParse` + `.success` assertions).
+
+```typescript
+import { describe, expect, test } from "@rstest/core";
+import {
+  messageApproveSchema,
+  messageDismissSchema,
+  messageEditAndApproveSchema,
+  messageSnoozeSchema,
+} from "../messages";
+
+const VALID_UUID = "550e8400-e29b-41d4-a716-446655440000";
+
+describe("messageApproveSchema", () => {
+  test("accepts valid uuid", () => {
+    expect(messageApproveSchema.safeParse({ id: VALID_UUID }).success).toBe(true);
+  });
+  test("rejects non-uuid id", () => {
+    expect(messageApproveSchema.safeParse({ id: "not-a-uuid" }).success).toBe(false);
+  });
+  test("rejects missing id", () => {
+    expect(messageApproveSchema.safeParse({}).success).toBe(false);
+  });
+});
+
+describe("messageDismissSchema", () => {
+  test("accepts valid uuid", () => {
+    expect(messageDismissSchema.safeParse({ id: VALID_UUID }).success).toBe(true);
+  });
+  test("rejects non-uuid id", () => {
+    expect(messageDismissSchema.safeParse({ id: "x" }).success).toBe(false);
+  });
+});
+
+describe("messageEditAndApproveSchema", () => {
+  test("accepts valid body", () => {
+    const result = messageEditAndApproveSchema.safeParse({
+      id: VALID_UUID,
+      body: "Hey John, still looking at Springfield Rise?",
+    });
+    expect(result.success).toBe(true);
+  });
+  test("rejects empty body", () => {
+    expect(
+      messageEditAndApproveSchema.safeParse({ id: VALID_UUID, body: "" }).success,
+    ).toBe(false);
+  });
+  test("rejects whitespace-only body after trim", () => {
+    expect(
+      messageEditAndApproveSchema.safeParse({ id: VALID_UUID, body: "   " }).success,
+    ).toBe(false);
+  });
+  test("accepts body at exactly 1600 chars", () => {
+    expect(
+      messageEditAndApproveSchema.safeParse({
+        id: VALID_UUID,
+        body: "x".repeat(1600),
+      }).success,
+    ).toBe(true);
+  });
+  test("rejects body over 1600 chars", () => {
+    expect(
+      messageEditAndApproveSchema.safeParse({
+        id: VALID_UUID,
+        body: "x".repeat(1601),
+      }).success,
+    ).toBe(false);
+  });
+});
+
+describe("messageSnoozeSchema", () => {
+  test("accepts a future Date", () => {
+    const future = new Date(Date.now() + 3600_000); // +1h
+    expect(
+      messageSnoozeSchema.safeParse({ id: VALID_UUID, snoozedUntil: future }).success,
+    ).toBe(true);
+  });
+  test("coerces an ISO string to Date", () => {
+    const future = new Date(Date.now() + 3600_000).toISOString();
+    expect(
+      messageSnoozeSchema.safeParse({ id: VALID_UUID, snoozedUntil: future }).success,
+    ).toBe(true);
+  });
+  test("rejects a past date", () => {
+    const past = new Date(Date.now() - 1000);
+    expect(
+      messageSnoozeSchema.safeParse({ id: VALID_UUID, snoozedUntil: past }).success,
+    ).toBe(false);
+  });
+  test("rejects unparseable input", () => {
+    expect(
+      messageSnoozeSchema.safeParse({ id: VALID_UUID, snoozedUntil: "not-a-date" })
+        .success,
+    ).toBe(false);
+  });
+});
+```
+
+### Success Criteria:
+
+#### Automated Verification:
+- [x] Typecheck + lint pass: `make check`
+- [x] Schema tests pass: `make test` (new file `messages.test.ts` runs and is green)
+- [x] `src/server/api/schemas/messages.ts` exports `messageApproveSchema`, `messageDismissSchema`, `messageEditAndApproveSchema`, `messageSnoozeSchema` and their inferred types
+
+#### Manual Verification:
+- [x] Eyeball the file layout against `schemas/leads.ts` — ordering (enums → schemas → types) and comment style should match
+
+---
+
+## Phase 2: Router Procedures + Router Tests
+
+### Overview
+
+Replace the stub router with the five real procedures, add a dedicated `messages-router.test.ts`, and clean up the `router.test.ts` stub list.
+
+### Changes Required:
+
+#### 1. Messages router
+
+**File**: `src/server/api/routers/messages.ts` (rewrite)
+**Changes**: Implement all five procedures. A small local helper (`loadActionable`) encapsulates the fetch + status guard used by every mutation.
+
+```typescript
+import { TRPCError } from "@trpc/server";
+import { and, asc, desc, eq, isNull, lte, or } from "drizzle-orm";
+import {
+  messageApproveSchema,
+  messageDismissSchema,
+  messageEditAndApproveSchema,
+  messageSnoozeSchema,
+} from "~/server/api/schemas/messages";
+import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
+import { messageQueue } from "~/server/db/schema";
+
+/**
+ * Fetch a message_queue row and assert its status permits a user action.
+ * Terminal states (approved, edited_and_approved, dismissed) are rejected.
+ * Returns the fetched row so callers like editAndApprove can reuse the body.
+ */
+async function loadActionable(
+  db: typeof import("~/server/db").db,
+  id: string,
+  action: "approve" | "edit" | "snooze" | "dismiss",
+): Promise<typeof messageQueue.$inferSelect> {
+  const row = await db.query.messageQueue.findFirst({
+    where: eq(messageQueue.id, id),
+  });
+  if (!row) {
+    throw new TRPCError({ code: "NOT_FOUND", message: "Message not found" });
+  }
+  if (row.status !== "pending" && row.status !== "snoozed") {
+    throw new TRPCError({
+      code: "BAD_REQUEST",
+      message: `Cannot ${action} message in ${row.status} state`,
+    });
+  }
+  return row;
+}
+
+export const messagesRouter = createTRPCRouter({
+  listPending: protectedProcedure.query(async ({ ctx }) => {
+    return await ctx.db.query.messageQueue.findMany({
+      where: and(
+        eq(messageQueue.status, "pending"),
+        or(
+          isNull(messageQueue.snoozedUntil),
+          lte(messageQueue.snoozedUntil, new Date()),
+        ),
+      ),
+      orderBy: [desc(messageQueue.priority), asc(messageQueue.createdAt)],
+    });
+  }),
+
+  approve: protectedProcedure
+    .input(messageApproveSchema)
+    .mutation(async ({ ctx, input }) => {
+      await loadActionable(ctx.db, input.id, "approve");
+      const [updated] = await ctx.db
+        .update(messageQueue)
+        .set({ status: "approved", approvedAt: new Date() })
+        .where(eq(messageQueue.id, input.id))
+        .returning();
+      return updated!;
+    }),
+
+  editAndApprove: protectedProcedure
+    .input(messageEditAndApproveSchema)
+    .mutation(async ({ ctx, input }) => {
+      const existing = await loadActionable(ctx.db, input.id, "edit");
+      const [updated] = await ctx.db
+        .update(messageQueue)
+        .set({
+          status: "edited_and_approved",
+          body: input.body,
+          // Preserve the first-ever draft. If the row was already edited, keep
+          // the original; otherwise snapshot the current body.
+          originalBody: existing.originalBody ?? existing.body,
+          approvedAt: new Date(),
+        })
+        .where(eq(messageQueue.id, input.id))
+        .returning();
+      return updated!;
+    }),
+
+  snooze: protectedProcedure
+    .input(messageSnoozeSchema)
+    .mutation(async ({ ctx, input }) => {
+      await loadActionable(ctx.db, input.id, "snooze");
+      const [updated] = await ctx.db
+        .update(messageQueue)
+        .set({ status: "snoozed", snoozedUntil: input.snoozedUntil })
+        .where(eq(messageQueue.id, input.id))
+        .returning();
+      return updated!;
+    }),
+
+  dismiss: protectedProcedure
+    .input(messageDismissSchema)
+    .mutation(async ({ ctx, input }) => {
+      await loadActionable(ctx.db, input.id, "dismiss");
+      const [updated] = await ctx.db
+        .update(messageQueue)
+        .set({ status: "dismissed" })
+        .where(eq(messageQueue.id, input.id))
+        .returning();
+      return updated!;
+    }),
+});
+```
+
+#### 2. Remove stale stub entry from shared router test
+
+**File**: `src/server/api/__tests__/router.test.ts`
+**Changes**: Drop the `messages.getPending` entry from the `stubs` array (lines 61-65). The rest of the file is unchanged — `lots.getAll`, `nurture.getActive`, and `ai.healthCheck` are still stubs and still exercised here.
+
+Before:
+```typescript
+const stubs = [
+  { name: "lots.getAll", call: (c: Caller) => c.lots.getAll(), expected: [] },
+  {
+    name: "messages.getPending",
+    call: (c: Caller) => c.messages.getPending(),
+    expected: [],
+  },
+  { name: "nurture.getActive", ... },
+  { name: "ai.healthCheck", ... },
+];
+```
+
+After:
+```typescript
+const stubs = [
+  { name: "lots.getAll", call: (c: Caller) => c.lots.getAll(), expected: [] },
+  { name: "nurture.getActive", ... },
+  { name: "ai.healthCheck", ... },
+];
+```
+
+#### 3. Dedicated router tests
+
+**File**: `src/server/api/__tests__/messages-router.test.ts` (new)
+**Tests**: Each procedure gets a happy-path test, a NOT_FOUND test (where applicable), and a terminal-status guard test. Mock setup mirrors `leads-router.test.ts` — `rs.doMock` for `~/env`, `~/lib/session`, `~/server/db`, and a chainable `update` builder.
+
+```typescript
+import { beforeEach, describe, expect, rs, test } from "@rstest/core";
+import { TRPCError } from "@trpc/server";
+import type { createCaller } from "../root";
+
+type Caller = ReturnType<typeof createCaller>;
+
+const MSG_ID = "550e8400-e29b-41d4-a716-446655440000";
+const LEAD_ID = "660e8400-e29b-41d4-a716-446655440001";
+
+const baseMessage = {
+  id: MSG_ID,
+  leadId: LEAD_ID,
+  channel: "sms" as const,
+  subject: null,
+  body: "Original draft body",
+  aiReasoning: null,
+  priority: 5,
+  status: "pending" as const,
+  snoozedUntil: null,
+  originalBody: null,
+  approvedAt: null,
+  sentAt: null,
+  createdAt: new Date("2026-04-10T00:00:00Z"),
+};
+
+let mockDb: Record<string, unknown>;
+
+beforeEach(() => {
+  rs.resetModules();
+
+  rs.doMock("~/env", () => ({
+    env: {
+      DATABASE_URL: "postgres://mock",
+      HUBSPOT_ACCESS_TOKEN: "mock",
+      HUBSPOT_CLIENT_SECRET: "mock",
+    },
+  }));
+
+  rs.doMock("~/lib/session", () => ({
+    getSession: rs.fn().mockResolvedValue({
+      user: { id: "test-user-id", email: "test@example.com", name: "Test" },
+      session: { id: "test-session-id" },
+    }),
+  }));
+
+  mockDb = {
+    update: rs.fn(),
+    query: {
+      messageQueue: {
+        findFirst: rs.fn(),
+        findMany: rs.fn(),
+      },
+    },
+  };
+
+  rs.doMock("~/server/db", () => ({ db: mockDb }));
+});
+
+async function getCaller(): Promise<Caller> {
+  const { createCaller } = await import("../root");
+  const { createTRPCContext } = await import("../trpc");
+  const ctx = await createTRPCContext({ headers: new Headers() });
+  return createCaller(ctx);
+}
+
+// Helper — wire up a chainable update mock that returns the given row
+function mockUpdateReturning(row: unknown) {
+  const returning = rs.fn().mockResolvedValue([row]);
+  const where = rs.fn().mockReturnValue({ returning });
+  const set = rs.fn().mockReturnValue({ where });
+  (mockDb.update as ReturnType<typeof rs.fn>).mockReturnValue({ set });
+  return { set, where, returning };
+}
+
+// --- messages.listPending ---
+
+describe("messages.listPending", () => {
+  test("returns rows from findMany", async () => {
+    (
+      mockDb.query as { messageQueue: { findMany: ReturnType<typeof rs.fn> } }
+    ).messageQueue.findMany.mockResolvedValue([baseMessage]);
+
+    const caller = await getCaller();
+    const result = await caller.messages.listPending();
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.id).toBe(MSG_ID);
+  });
+
+  test("returns empty array when no pending rows", async () => {
+    (
+      mockDb.query as { messageQueue: { findMany: ReturnType<typeof rs.fn> } }
+    ).messageQueue.findMany.mockResolvedValue([]);
+
+    const caller = await getCaller();
+    const result = await caller.messages.listPending();
+
+    expect(result).toEqual([]);
+  });
+
+  test("orders by priority desc then createdAt asc", async () => {
+    const findMany = (
+      mockDb.query as { messageQueue: { findMany: ReturnType<typeof rs.fn> } }
+    ).messageQueue.findMany;
+    findMany.mockResolvedValue([]);
+
+    const caller = await getCaller();
+    await caller.messages.listPending();
+
+    expect(findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ orderBy: expect.anything(), where: expect.anything() }),
+    );
+  });
+});
+
+// --- messages.approve ---
+
+describe("messages.approve", () => {
+  test("transitions pending → approved and sets approvedAt", async () => {
+    (
+      mockDb.query as { messageQueue: { findFirst: ReturnType<typeof rs.fn> } }
+    ).messageQueue.findFirst.mockResolvedValue(baseMessage);
+
+    const approved = { ...baseMessage, status: "approved" as const, approvedAt: new Date() };
+    const { set } = mockUpdateReturning(approved);
+
+    const caller = await getCaller();
+    const result = await caller.messages.approve({ id: MSG_ID });
+
+    expect(result.status).toBe("approved");
+    expect(result.approvedAt).not.toBeNull();
+    expect(set).toHaveBeenCalledWith(
+      expect.objectContaining({ status: "approved", approvedAt: expect.any(Date) }),
+    );
+  });
+
+  test("allows snoozed → approved", async () => {
+    const snoozed = { ...baseMessage, status: "snoozed" as const };
+    (
+      mockDb.query as { messageQueue: { findFirst: ReturnType<typeof rs.fn> } }
+    ).messageQueue.findFirst.mockResolvedValue(snoozed);
+
+    mockUpdateReturning({ ...snoozed, status: "approved", approvedAt: new Date() });
+
+    const caller = await getCaller();
+    const result = await caller.messages.approve({ id: MSG_ID });
+
+    expect(result.status).toBe("approved");
+  });
+
+  test("throws NOT_FOUND when message does not exist", async () => {
+    (
+      mockDb.query as { messageQueue: { findFirst: ReturnType<typeof rs.fn> } }
+    ).messageQueue.findFirst.mockResolvedValue(undefined);
+
+    const caller = await getCaller();
+    try {
+      await caller.messages.approve({ id: MSG_ID });
+      expect.unreachable("Should have thrown");
+    } catch (e) {
+      expect(e).toBeInstanceOf(TRPCError);
+      expect((e as TRPCError).code).toBe("NOT_FOUND");
+    }
+  });
+
+  test("rejects terminal state (dismissed)", async () => {
+    (
+      mockDb.query as { messageQueue: { findFirst: ReturnType<typeof rs.fn> } }
+    ).messageQueue.findFirst.mockResolvedValue({ ...baseMessage, status: "dismissed" });
+
+    const caller = await getCaller();
+    try {
+      await caller.messages.approve({ id: MSG_ID });
+      expect.unreachable("Should have thrown");
+    } catch (e) {
+      expect(e).toBeInstanceOf(TRPCError);
+      expect((e as TRPCError).code).toBe("BAD_REQUEST");
+      expect((e as TRPCError).message).toContain("dismissed");
+    }
+  });
+
+  test("rejects invalid uuid", async () => {
+    const caller = await getCaller();
+    try {
+      await caller.messages.approve({ id: "not-a-uuid" });
+      expect.unreachable("Should have thrown");
+    } catch (e) {
+      expect(e).toBeInstanceOf(TRPCError);
+      expect((e as TRPCError).code).toBe("BAD_REQUEST");
+    }
+  });
+});
+
+// --- messages.editAndApprove ---
+
+describe("messages.editAndApprove", () => {
+  test("copies existing body into originalBody and sets new body", async () => {
+    (
+      mockDb.query as { messageQueue: { findFirst: ReturnType<typeof rs.fn> } }
+    ).messageQueue.findFirst.mockResolvedValue(baseMessage);
+
+    const edited = {
+      ...baseMessage,
+      status: "edited_and_approved" as const,
+      body: "Rewritten message",
+      originalBody: "Original draft body",
+      approvedAt: new Date(),
+    };
+    const { set } = mockUpdateReturning(edited);
+
+    const caller = await getCaller();
+    const result = await caller.messages.editAndApprove({
+      id: MSG_ID,
+      body: "Rewritten message",
+    });
+
+    expect(result.status).toBe("edited_and_approved");
+    expect(result.body).toBe("Rewritten message");
+    expect(result.originalBody).toBe("Original draft body");
+    expect(set).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: "edited_and_approved",
+        body: "Rewritten message",
+        originalBody: "Original draft body",
+      }),
+    );
+  });
+
+  test("preserves originalBody when row was already edited once", async () => {
+    const previouslyEdited = {
+      ...baseMessage,
+      body: "First edit",
+      originalBody: "The true original",
+    };
+    (
+      mockDb.query as { messageQueue: { findFirst: ReturnType<typeof rs.fn> } }
+    ).messageQueue.findFirst.mockResolvedValue(previouslyEdited);
+
+    const { set } = mockUpdateReturning(previouslyEdited);
+
+    const caller = await getCaller();
+    await caller.messages.editAndApprove({ id: MSG_ID, body: "Second edit" });
+
+    expect(set).toHaveBeenCalledWith(
+      expect.objectContaining({ originalBody: "The true original" }),
+    );
+  });
+
+  test("rejects empty body via Zod", async () => {
+    const caller = await getCaller();
+    try {
+      await caller.messages.editAndApprove({ id: MSG_ID, body: "" });
+      expect.unreachable("Should have thrown");
+    } catch (e) {
+      expect(e).toBeInstanceOf(TRPCError);
+      expect((e as TRPCError).code).toBe("BAD_REQUEST");
+    }
+  });
+
+  test("rejects terminal state", async () => {
+    (
+      mockDb.query as { messageQueue: { findFirst: ReturnType<typeof rs.fn> } }
+    ).messageQueue.findFirst.mockResolvedValue({
+      ...baseMessage,
+      status: "approved",
+    });
+
+    const caller = await getCaller();
+    try {
+      await caller.messages.editAndApprove({ id: MSG_ID, body: "Too late" });
+      expect.unreachable("Should have thrown");
+    } catch (e) {
+      expect((e as TRPCError).code).toBe("BAD_REQUEST");
+    }
+  });
+});
+
+// --- messages.snooze ---
+
+describe("messages.snooze", () => {
+  test("sets snoozedUntil and transitions to snoozed", async () => {
+    (
+      mockDb.query as { messageQueue: { findFirst: ReturnType<typeof rs.fn> } }
+    ).messageQueue.findFirst.mockResolvedValue(baseMessage);
+
+    const future = new Date(Date.now() + 3600_000);
+    const snoozed = { ...baseMessage, status: "snoozed" as const, snoozedUntil: future };
+    const { set } = mockUpdateReturning(snoozed);
+
+    const caller = await getCaller();
+    const result = await caller.messages.snooze({ id: MSG_ID, snoozedUntil: future });
+
+    expect(result.status).toBe("snoozed");
+    expect(set).toHaveBeenCalledWith(
+      expect.objectContaining({ status: "snoozed", snoozedUntil: future }),
+    );
+  });
+
+  test("rejects past snoozedUntil via Zod", async () => {
+    const past = new Date(Date.now() - 1000);
+    const caller = await getCaller();
+    try {
+      await caller.messages.snooze({ id: MSG_ID, snoozedUntil: past });
+      expect.unreachable("Should have thrown");
+    } catch (e) {
+      expect((e as TRPCError).code).toBe("BAD_REQUEST");
+    }
+  });
+
+  test("rejects terminal state", async () => {
+    (
+      mockDb.query as { messageQueue: { findFirst: ReturnType<typeof rs.fn> } }
+    ).messageQueue.findFirst.mockResolvedValue({
+      ...baseMessage,
+      status: "dismissed",
+    });
+
+    const future = new Date(Date.now() + 3600_000);
+    const caller = await getCaller();
+    try {
+      await caller.messages.snooze({ id: MSG_ID, snoozedUntil: future });
+      expect.unreachable("Should have thrown");
+    } catch (e) {
+      expect((e as TRPCError).code).toBe("BAD_REQUEST");
+    }
+  });
+});
+
+// --- messages.dismiss ---
+
+describe("messages.dismiss", () => {
+  test("transitions to dismissed", async () => {
+    (
+      mockDb.query as { messageQueue: { findFirst: ReturnType<typeof rs.fn> } }
+    ).messageQueue.findFirst.mockResolvedValue(baseMessage);
+
+    const dismissed = { ...baseMessage, status: "dismissed" as const };
+    const { set } = mockUpdateReturning(dismissed);
+
+    const caller = await getCaller();
+    const result = await caller.messages.dismiss({ id: MSG_ID });
+
+    expect(result.status).toBe("dismissed");
+    expect(set).toHaveBeenCalledWith(
+      expect.objectContaining({ status: "dismissed" }),
+    );
+  });
+
+  test("allows snoozed → dismissed", async () => {
+    (
+      mockDb.query as { messageQueue: { findFirst: ReturnType<typeof rs.fn> } }
+    ).messageQueue.findFirst.mockResolvedValue({ ...baseMessage, status: "snoozed" });
+
+    mockUpdateReturning({ ...baseMessage, status: "dismissed" });
+
+    const caller = await getCaller();
+    const result = await caller.messages.dismiss({ id: MSG_ID });
+
+    expect(result.status).toBe("dismissed");
+  });
+
+  test("throws NOT_FOUND when missing", async () => {
+    (
+      mockDb.query as { messageQueue: { findFirst: ReturnType<typeof rs.fn> } }
+    ).messageQueue.findFirst.mockResolvedValue(undefined);
+
+    const caller = await getCaller();
+    try {
+      await caller.messages.dismiss({ id: MSG_ID });
+      expect.unreachable("Should have thrown");
+    } catch (e) {
+      expect((e as TRPCError).code).toBe("NOT_FOUND");
+    }
+  });
+
+  test("rejects already-dismissed row", async () => {
+    (
+      mockDb.query as { messageQueue: { findFirst: ReturnType<typeof rs.fn> } }
+    ).messageQueue.findFirst.mockResolvedValue({ ...baseMessage, status: "dismissed" });
+
+    const caller = await getCaller();
+    try {
+      await caller.messages.dismiss({ id: MSG_ID });
+      expect.unreachable("Should have thrown");
+    } catch (e) {
+      expect((e as TRPCError).code).toBe("BAD_REQUEST");
+    }
+  });
+});
+```
+
+### Success Criteria:
+
+#### Automated Verification:
+- [x] Typecheck + lint pass: `make check`
+- [x] All unit tests pass: `make test`
+- [x] `messages-router.test.ts` asserts each procedure's happy path, terminal-state rejection, and (for approve/dismiss) NOT_FOUND handling
+- [x] `router.test.ts` no longer references `messages.getPending`
+- [x] `messagesRouter` has exactly five procedures: `listPending`, `approve`, `editAndApprove`, `snooze`, `dismiss`
+
+#### Manual Verification:
+- [x] Scan `src/server/api/root.ts` to confirm the router is still wired as `messages: messagesRouter`
+- [x] Read through the router diff to confirm status-transition errors mention the current state (e.g. "Cannot approve message in dismissed state") so the action queue UI can surface a meaningful toast
+- [x] Confirm that `editAndApprove`'s `originalBody` semantics — preserve first-ever draft — reads sensibly against the schema comment in `message-queue.ts`
+
+---
+
+## Performance Considerations
+
+- `listPending` uses the `message_queue_status_priority_idx` composite index (`status`, `priority`). The `snoozedUntil` filter is applied as an index-filter, which is fine given pending-queue sizes are small (tens to low hundreds). If the queue ever grows past ~10k rows, revisit with a partial index `WHERE status = 'pending'`.
+- Each mutation does one read + one write. For M0 validation that's irrelevant. If concurrency becomes a worry, the follow-up is a single conditional update with `where: and(eq(id, x), inArray(status, ['pending', 'snoozed']))` — but that loses the exact current-state info we need for the error message.
+
+## Migration Notes
+
+No DB migration required — `message_queue`, `channelEnum`, and `messageStatusEnum` already exist (per issue #126's preamble).
+
+## References
+
+- Original ticket: samjmarshall/rekurve-www#126
+- Parent epic: samjmarshall/rekurve-www#87 (Epic 3: HITL Message Queue + Nurture Sequences)
+- DB schema: `src/server/db/schema/message-queue.ts:13-37`
+- DB enums: `src/server/db/schema/enums.ts:69-77`
+- Router pattern: `src/server/api/routers/leads.ts`
+- Schema pattern: `src/server/api/schemas/leads.ts`
+- Schema test pattern: `src/server/api/schemas/__tests__/leads.test.ts`
+- Router test pattern: `src/server/api/__tests__/leads-router.test.ts`
+- Stale stub entry to remove: `src/server/api/__tests__/router.test.ts:61-65`

--- a/yarn.lock
+++ b/yarn.lock
@@ -1874,65 +1874,65 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@next/env@npm:16.2.1":
-  version: 16.2.1
-  resolution: "@next/env@npm:16.2.1"
-  checksum: 17b5532728a660bd2d2868c4acf5c3092f3bad4506bf6e6e43d3eb122c87b3084c7669c6cc7a6a4cf3bb156d40b408ad7f9068d0bb5b767452aba72c450e3608
+"@next/env@npm:16.2.3":
+  version: 16.2.3
+  resolution: "@next/env@npm:16.2.3"
+  checksum: 5c2ccb3abea35a3db4899a77023a7a25ebc027a9a6cb6a1e3d817ab89dfc3352ffdf172bcb02c050325a600ef3b0bfb8c39da9e81aa4bdccc2c6aa6fcb1178ad
   languageName: node
   linkType: hard
 
-"@next/swc-darwin-arm64@npm:16.2.1":
-  version: 16.2.1
-  resolution: "@next/swc-darwin-arm64@npm:16.2.1"
+"@next/swc-darwin-arm64@npm:16.2.3":
+  version: 16.2.3
+  resolution: "@next/swc-darwin-arm64@npm:16.2.3"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"@next/swc-darwin-x64@npm:16.2.1":
-  version: 16.2.1
-  resolution: "@next/swc-darwin-x64@npm:16.2.1"
+"@next/swc-darwin-x64@npm:16.2.3":
+  version: 16.2.3
+  resolution: "@next/swc-darwin-x64@npm:16.2.3"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"@next/swc-linux-arm64-gnu@npm:16.2.1":
-  version: 16.2.1
-  resolution: "@next/swc-linux-arm64-gnu@npm:16.2.1"
+"@next/swc-linux-arm64-gnu@npm:16.2.3":
+  version: 16.2.3
+  resolution: "@next/swc-linux-arm64-gnu@npm:16.2.3"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@next/swc-linux-arm64-musl@npm:16.2.1":
-  version: 16.2.1
-  resolution: "@next/swc-linux-arm64-musl@npm:16.2.1"
+"@next/swc-linux-arm64-musl@npm:16.2.3":
+  version: 16.2.3
+  resolution: "@next/swc-linux-arm64-musl@npm:16.2.3"
   conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
 
-"@next/swc-linux-x64-gnu@npm:16.2.1":
-  version: 16.2.1
-  resolution: "@next/swc-linux-x64-gnu@npm:16.2.1"
+"@next/swc-linux-x64-gnu@npm:16.2.3":
+  version: 16.2.3
+  resolution: "@next/swc-linux-x64-gnu@npm:16.2.3"
   conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@next/swc-linux-x64-musl@npm:16.2.1":
-  version: 16.2.1
-  resolution: "@next/swc-linux-x64-musl@npm:16.2.1"
+"@next/swc-linux-x64-musl@npm:16.2.3":
+  version: 16.2.3
+  resolution: "@next/swc-linux-x64-musl@npm:16.2.3"
   conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
 
-"@next/swc-win32-arm64-msvc@npm:16.2.1":
-  version: 16.2.1
-  resolution: "@next/swc-win32-arm64-msvc@npm:16.2.1"
+"@next/swc-win32-arm64-msvc@npm:16.2.3":
+  version: 16.2.3
+  resolution: "@next/swc-win32-arm64-msvc@npm:16.2.3"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
-"@next/swc-win32-x64-msvc@npm:16.2.1":
-  version: 16.2.1
-  resolution: "@next/swc-win32-x64-msvc@npm:16.2.1"
+"@next/swc-win32-x64-msvc@npm:16.2.3":
+  version: 16.2.3
+  resolution: "@next/swc-win32-x64-msvc@npm:16.2.3"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -7779,19 +7779,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"next@npm:16.2.1":
-  version: 16.2.1
-  resolution: "next@npm:16.2.1"
+"next@npm:16.2.3":
+  version: 16.2.3
+  resolution: "next@npm:16.2.3"
   dependencies:
-    "@next/env": 16.2.1
-    "@next/swc-darwin-arm64": 16.2.1
-    "@next/swc-darwin-x64": 16.2.1
-    "@next/swc-linux-arm64-gnu": 16.2.1
-    "@next/swc-linux-arm64-musl": 16.2.1
-    "@next/swc-linux-x64-gnu": 16.2.1
-    "@next/swc-linux-x64-musl": 16.2.1
-    "@next/swc-win32-arm64-msvc": 16.2.1
-    "@next/swc-win32-x64-msvc": 16.2.1
+    "@next/env": 16.2.3
+    "@next/swc-darwin-arm64": 16.2.3
+    "@next/swc-darwin-x64": 16.2.3
+    "@next/swc-linux-arm64-gnu": 16.2.3
+    "@next/swc-linux-arm64-musl": 16.2.3
+    "@next/swc-linux-x64-gnu": 16.2.3
+    "@next/swc-linux-x64-musl": 16.2.3
+    "@next/swc-win32-arm64-msvc": 16.2.3
+    "@next/swc-win32-x64-msvc": 16.2.3
     "@swc/helpers": 0.5.15
     baseline-browser-mapping: ^2.9.19
     caniuse-lite: ^1.0.30001579
@@ -7835,7 +7835,7 @@ __metadata:
       optional: true
   bin:
     next: dist/bin/next
-  checksum: 19fc235730d7ae2908c5a6cb92adcb6242ef46fb4065d72fd4c657222117db1162ce627047193fda7104f6f3f83661a1e281e0b9a14a3f6e93c6147df9ac9712
+  checksum: 05a58a01b21cda9077774acb283b1ba78e33f10934b2f1ac000f0f8fe6b3cdd0db0f27f3771463f90a14ceeae2eb0b0e247a6a56f5e19b27279eedfca9b81d94
   languageName: node
   linkType: hard
 
@@ -10743,7 +10743,7 @@ shadcn@latest:
     input-otp: 1.4.2
     lucide-react: 0.563.0
     motion: 12.23.24
-    next: 16.2.1
+    next: 16.2.3
     next-themes: 0.4.6
     pako: ^2.1.0
     portless: ^0.9.4


### PR DESCRIPTION
## Context/Motivation

Closes #126. Part of Epic 3 (HITL Message Queue + Nurture Sequences, #87).

The HITL action queue — where consultants approve, edit, snooze, or dismiss AI-drafted follow-ups before they go out — had a stub backend. This PR ships the real one, unblocking Twilio dispatch (#4), HubSpot dispatch (#5), and the action queue UI.

## Description of Changes

Five tRPC procedures on `messagesRouter`:

- **`listPending`** — returns the queue for the action view, highest-priority first.
- **`approve`** — marks a draft ready to send as-is.
- **`editAndApprove`** — rewrites the body and snapshots the AI's original draft into `originalBody`.
- **`snooze`** — holds a draft until a future date.
- **`dismiss`** — drops a draft without sending.

The router rejects terminal rows (already approved, edited, or dismissed) with an error that names the current state, so the UI can surface a meaningful toast. Actual sending, queue UI, draft generation, and un-snooze cron are all follow-on tickets.

New Zod input schemas (`src/server/api/schemas/messages.ts`) enforce UUID ids, a 1600-char body cap (SMS segment ceiling), and future-dated snoozes.

### Also in this PR

- `thoughts/plans/2026-04-12-ENG-126-messages-router.md` — the implementation plan.
- `docs(ticket-writer)` commit documenting the GitHub sub-issue REST flow. Piggybacked from wiring up #126's parent/child links — happy to split if preferred.

## Testing Information

- [x] **Unit tests** — `make test` → 221 passed / 19 files / 0 failures. New coverage: `schemas/__tests__/messages.test.ts` (Zod paths) and `__tests__/messages-router.test.ts` (every procedure: happy path, NOT_FOUND, terminal-state rejection, Zod rejection).
- [x] **Lint + typecheck** — `make check` → 230 files, clean.
- [x] **Plan validation** — all Phase 1 and Phase 2 success criteria verified against the committed diff via `/validate_plan`.
- [ ] Integration / real-Postgres tests — out of scope (mocked drizzle per plan; real-DB coverage lands with #4/#5).
- [ ] Manual UI testing — no UI yet; the action queue view is a separate ticket.

## Screenshots/Videos

_N/A — backend only._

## Relevant Links

- Closes #126
- Parent epic: #87
- Unblocks: #4 (Twilio dispatch), #5 (HubSpot dispatch), action queue UI
- Implementation plan: `thoughts/plans/2026-04-12-ENG-126-messages-router.md`

## Breaking Changes

None. The old `messages.getPending` stub had no real callers.
