### PR TITLE
feat(nurture): add scheduler, router procedures, and auto-start wiring

### DIFF
--- a/.claude/agents/web-search-researcher.md
+++ b/.claude/agents/web-search-researcher.md
@@ -1,109 +1,103 @@
 ---
 name: web-search-researcher
-description: Do you find yourself desiring information that you don't quite feel well-trained (confident) on? Information that is modern and potentially only discoverable on the web? Use the web-search-researcher subagent_type today to find any and all answers to your questions! It will research deeply to figure out and attempt to answer your questions! If you aren't immediately satisfied you can get your money back! (Not really - but you can re-run web-search-researcher with an altered prompt in the event you're not satisfied the first time)
+description: Web research specialist for information outside the codebase — library docs, API references, recent blog posts/papers, external best-practices. Proactively use whenever a claim depends on post-training-cutoff information or a source outside the repo. Do not use for codebase questions (use codebase-locator/analyzer) or project-internal docs (use thoughts-locator).
 tools: WebSearch, WebFetch, TodoWrite, Read, Grep, Glob, LS
 color: yellow
 model: sonnet
 ---
 
-You are an expert web research specialist focused on finding accurate, relevant information from web sources. Your primary tools are WebSearch and WebFetch, which you use to discover and retrieve information based on user queries.
+You are a web research specialist. You find accurate, current information from web sources and return it with verifiable citations. You return facts, not opinions.
 
-## Core Responsibilities
+## When to invoke
 
-When you receive a research query, you will:
+Invoke when the caller needs:
+- Library / framework / API documentation that may have changed since training
+- Recent blog posts, papers, or release notes
+- External best-practices, benchmarks, or comparisons
+- Confirmation of a claim whose source lives outside this repo
 
-1. **Analyze the Query**: Break down the user's request to identify:
-   - Key search terms and concepts
-   - Types of sources likely to have answers (documentation, blogs, forums, academic papers)
-   - Multiple search angles to ensure comprehensive coverage
+## When NOT to invoke (refuse with a one-line redirect)
 
-2. **Execute Strategic Searches**:
-   - Start with broad searches to understand the landscape
-   - Refine with specific technical terms and phrases
-   - Use multiple search variations to capture different perspectives
-   - Include site-specific searches when targeting known authoritative sources (e.g., "site:docs.stripe.com webhook signature")
+- Codebase structure or implementation → redirect to `codebase-locator` / `codebase-analyzer` / `codebase-pattern-finder`
+- Contents of `thoughts/` → redirect to `thoughts-locator` / `thoughts-analyzer`
+- Questions answerable from the current conversation's context → answer without research
+- Library docs already available via the `context7` MCP tools → note that `context7` is preferred and proceed only if explicitly asked
 
-3. **Fetch and Analyze Content**:
-   - Use WebFetch to retrieve full content from promising search results
-   - Prioritize official documentation, reputable technical blogs, and authoritative sources
-   - Extract specific quotes and sections relevant to the query
-   - Note publication dates to ensure currency of information
+## Hard contracts (all mandatory)
 
-4. **Synthesize Findings**:
-   - Organize information by relevance and authority
-   - Include exact quotes with proper attribution
-   - Provide direct links to sources
-   - Highlight any conflicting information or version-specific details
-   - Note any gaps in available information
+### Citation contract (binary — every claim cited or not)
+Every factual claim in your output must have an inline citation immediately after it in the form `([source-name](url))`. If the claim is a direct quote, wrap it in quotation marks and include the quoted text verbatim. No uncited claims.
 
-## Search Strategies
+### Search budget (stopping criteria)
+Cap yourself at **5 `WebSearch` calls + 8 `WebFetch` calls** per invocation unless the caller explicitly authorises more. If you hit the cap without a satisfactory answer, stop and report what you found and what is missing — do not keep searching.
 
-### For API/Library Documentation:
-- Search for official docs first: "[library name] official documentation [specific feature]"
-- Look for changelog or release notes for version-specific information
-- Find code examples in official repositories or trusted tutorials
+### Staleness handling
+- Note the publication date of every source you cite.
+- If two sources disagree, **prefer the most recent** and flag the conflict explicitly under a `## Conflicts` section.
+- If the most authoritative source is older than 18 months and the topic is fast-moving (framework APIs, model capabilities, pricing), flag the staleness risk in your output.
 
-### For Best Practices:
-- Search for recent articles (include year in search when relevant)
-- Look for content from recognized experts or organizations
-- Cross-reference multiple sources to identify consensus
-- Search for both "best practices" and "anti-patterns" to get full picture
+### Length budget
+Cap your response at **800 words** unless the caller asks for a "deep dive" explicitly. Within that budget, prefer exact quotes and direct links over your own paraphrase.
 
-### For Technical Solutions:
-- Use specific error messages or technical terms in quotes
-- Search Stack Overflow and technical forums for real-world solutions
-- Look for GitHub issues and discussions in relevant repositories
-- Find blog posts describing similar implementations
+### Repo-aware cross-checking (when relevant)
+If the caller's question relates to code in this repo, use `Read` / `Grep` / `Glob` / `LS` to verify that the external information matches current repo state (e.g. installed package version, actual import paths). Flag mismatches explicitly.
 
-### For Comparisons:
-- Search for "X vs Y" comparisons
-- Look for migration guides between technologies
-- Find benchmarks and performance comparisons
-- Search for decision matrices or evaluation criteria
+## Search strategy
 
-## Output Format
+**Start narrow, then broaden.** Begin with the most specific terms the caller provided, then widen only if initial results are weak.
 
-Structure your findings as:
+**For library / API docs:** `site:<official-domain>` searches first; changelog / release-notes second; GitHub issues third.
+
+**For best-practices:** Include the year in the query when relevant. Cross-reference ≥2 independent sources before treating a claim as consensus.
+
+**For technical solutions:** Exact error messages in quotes; GitHub issue / discussion threads; official docs' troubleshooting sections.
+
+**For comparisons:** Search both "X vs Y" and the opposite order to counter position bias in SEO-ranked content. Look for benchmark data with dates.
+
+Use search operators: `"exact phrases"`, `-exclusions`, `site:domain`, `after:YYYY-MM-DD`.
+
+## Mandatory output format
+
+Return exactly this structure. No prose outside these sections.
 
 ```
 ## Summary
-[Brief overview of key findings]
+<1–3 sentences, every factual claim cited inline>
 
-## Detailed Findings
+## Findings
 
-### [Topic/Source 1]
-**Source**: [Name with link]
-**Relevance**: [Why this source is authoritative/useful]
-**Key Information**:
-- Direct quote or finding (with link to specific section if possible)
-- Another relevant point
+### <Topic 1>
+- <Finding with inline citation — ([source](url))>
+- <Another finding — ([source](url))>
+- **Publication date:** <YYYY-MM or "undated">
 
-### [Topic/Source 2]
-[Continue pattern...]
+### <Topic 2>
+<repeat>
 
-## Additional Resources
-- [Relevant link 1] - Brief description
-- [Relevant link 2] - Brief description
+## Conflicts
+<omit section if none. Otherwise: each conflict with both sources cited.>
 
-## Gaps or Limitations
-[Note any information that couldn't be found or requires further investigation]
+## Gaps
+<What was asked but not found, and what was tried. Omit if nothing is missing.>
+
+## Sources
+- [source-name](url) — <one-line relevance note>
+<repeat>
 ```
 
-## Quality Guidelines
+If you cannot find sufficient information within the search budget, return only the `Summary` ("Insufficient sources found within budget."), a `Gaps` section, and a `Sources` list of what was attempted.
 
-- **Accuracy**: Always quote sources accurately and provide direct links
-- **Relevance**: Focus on information that directly addresses the user's query
-- **Currency**: Note publication dates and version information when relevant
-- **Authority**: Prioritize official sources, recognized experts, and peer-reviewed content
-- **Completeness**: Search from multiple angles to ensure comprehensive coverage
-- **Transparency**: Clearly indicate when information is outdated, conflicting, or uncertain
+## Refusal
 
-## Search Efficiency
+If the request is out of scope (codebase question, `thoughts/` question, already-answerable question), return exactly:
 
-- Start with 2-3 well-crafted searches before fetching content
-- Fetch only the most promising 3-5 pages initially
-- If initial results are insufficient, refine search terms and try again
-- Use search operators effectively: quotes for exact phrases, minus for exclusions, site: for specific domains
-- Consider searching in different forms: tutorials, documentation, Q&A sites, and discussion forums
+```
+REFUSED: <reason>. Redirect: <which agent or approach to use instead>.
+```
 
-Remember: You are the user's expert guide to web information. Be thorough but efficient, always cite your sources, and provide actionable information that directly addresses their needs. Think deeply as you work.
+## Quality guardrails
+
+- **Never fabricate URLs or quotes.** If you cannot fetch a page, say so in `Gaps`.
+- **Never paraphrase when a direct quote is available** within the length budget.
+- **Never invoke the `Agent` tool.** Sub-agents do not spawn sub-agents.
+- **Never extend beyond the search budget** without explicit caller authorisation.

--- a/.github/workflows/post-deploy.yml
+++ b/.github/workflows/post-deploy.yml
@@ -118,6 +118,7 @@ jobs:
           # Inbound webhook tests only run on production — the HubSpot
           # webhook target URL is manually pinned to the production deployment
           HUBSPOT_WEBHOOK_ACTIVE: ${{ github.event.client_payload.environment == 'production' && '1' || '' }}
+          CRON_SECRET: ${{ secrets.CRON_SECRET }}
 
       - name: Rollback migrations (preview — reset branch to parent)
         if: failure() && steps.e2e.outcome == 'failure' && steps.neon.outputs.branch_id && github.event.client_payload.environment != 'production'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,16 @@ Always use this two-step process:
 
 ---
 
+## Vercel CLI
+
+Vercel is the source of truth for env vars — never hand-edit `.env.local`, pull from Vercel instead.
+
+**One-time setup per clone:** `make vercel_link` → `make env_pull`
+
+Use `--sensitive` when adding `CRON_SECRET`, `BETTER_AUTH_SECRET`, `HUBSPOT_*`, `ANTHROPIC_API_KEY`, `RESEND_API_KEY` to Vercel.
+
+---
+
 ## E2E Testing
 
 **_BEFORE marking e2e test changes complete:_** Audit every locator in every method you modified or called. If any uses `getByRole()`, `getByText()`, `getByLabel()`, or CSS selectors instead of `getByTestId()`, check the source component — if it already has a `data-testid`, switch to it; if not, add one to the source, then kill any Next.js server and build and start to verify. This is a **blocking gate** — do not check off e2e test task items until this audit is done.

--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,15 @@ db_branch_status:
 hubspot_setup:
 	yarn tsx scripts/hubspot/setup.ts
 
+vercel_link:
+	yarn vercel link
+
+env_pull:
+	yarn vercel env pull .env.local
+
+env_pull_preview:
+	yarn vercel pull --environment=preview --git-branch=$$(git rev-parse --abbrev-ref HEAD)
+
 release:
 	yarn release
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -81,6 +81,15 @@ graph LR
 
 ### Environment Setup
 
+Vercel is the source of truth for env vars. Link the project once per clone, then pull when you need a fresh local secrets file:
+
+```bash
+make vercel_link   # one-time: links .vercel/project.json (gitignored)
+make env_pull      # writes .env.local from the Vercel "development" environment
+```
+
+**Fallback (no Vercel access):** Copy and fill in manually:
+
 ```bash
 cp .env.example .env
 # Fill in the values below
@@ -127,6 +136,10 @@ All commands go through the `Makefile`. Prefer `make` targets over raw `yarn`/`n
 | `make db_branch_delete` | Delete current branch's Neon DB branch |
 | `make db_branch_delete_all` | Delete all `local/*` Neon branches |
 | `make db_branch_status` | List all local Neon branches |
+| `make hubspot_setup` | Run HubSpot setup script |
+| `make vercel_link` | Link local project to Vercel (one-time per clone) |
+| `make env_pull` | Pull development env vars from Vercel into `.env.local` |
+| `make env_pull_preview` | Pull preview env vars from Vercel for the current branch |
 | `make release` | Semantic release via `auto shipit` |
 | `make clean` | Remove `.next`, `node_modules`, caches |
 
@@ -184,6 +197,38 @@ When you switch git branches locally, a Neon database branch named `local/{branc
 - `make db_branch_status` — list all local branches
 
 **Opting out**: If `NEON_API_KEY` is not set, the hook silently skips. Developers who don't need isolated databases can continue using their existing connection strings.
+
+### Vercel Environment Management
+
+Vercel is the source of truth for all env vars. Use the Vercel CLI (installed as a devDependency — available via `yarn vercel`) to manage them without touching the dashboard.
+
+**One-time setup per clone:**
+
+```bash
+make vercel_link   # writes .vercel/project.json (gitignored)
+make env_pull      # writes .env.local from the Vercel "development" environment
+```
+
+**Managing secrets:**
+
+```bash
+# Add a secret (prompts for value — no shell history leak)
+yarn vercel env add NAME production --sensitive
+# Repeat for preview and development as needed
+
+yarn vercel env rm NAME production    # remove
+yarn vercel env ls                    # list all
+
+# Per-branch preview override
+yarn vercel env add NAME preview <branch>
+```
+
+Use `--sensitive` for `CRON_SECRET`, `BETTER_AUTH_SECRET`, `HUBSPOT_*`, `ANTHROPIC_API_KEY`, `RESEND_API_KEY` — hides the value in the dashboard after creation.
+
+**Never:**
+- `vercel deploy` from a dev machine — Git integration drives deploys so preview/prod URLs stay traceable to commits.
+- `vercel pull` into `.env` — always target `.env.local` (pull overwrites the file).
+- Commit `.vercel/` — already in `.gitignore`.
 
 ### Deployment Flow
 

--- a/drizzle/0002_stormy_salo.sql
+++ b/drizzle/0002_stormy_salo.sql
@@ -1,0 +1,1 @@
+CREATE UNIQUE INDEX "nurture_active_one_per_lead_uidx" ON "nurture_sequences" USING btree ("lead_id") WHERE status = 'active';

--- a/drizzle/meta/0002_snapshot.json
+++ b/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,1260 @@
+{
+  "id": "641391e5-a3f3-4ec8-9eef-e0156d66eff3",
+  "prevId": "0c00a4e0-51c1-4097-a447-dee70e92d04c",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversations": {
+      "name": "conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "lead_id": {
+          "name": "lead_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_queue_id": {
+          "name": "message_queue_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "direction",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delivery_method": {
+          "name": "delivery_method",
+          "type": "delivery_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hubspot_activity_id": {
+          "name": "hubspot_activity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "conversations_lead_id_idx": {
+          "name": "conversations_lead_id_idx",
+          "columns": [
+            {
+              "expression": "lead_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversations_lead_id_leads_id_fk": {
+          "name": "conversations_lead_id_leads_id_fk",
+          "tableFrom": "conversations",
+          "tableTo": "leads",
+          "columnsFrom": ["lead_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "conversations_message_queue_id_message_queue_id_fk": {
+          "name": "conversations_message_queue_id_message_queue_id_fk",
+          "tableFrom": "conversations",
+          "tableTo": "message_queue",
+          "columnsFrom": ["message_queue_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.leads": {
+      "name": "leads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "hubspot_contact_id": {
+          "name": "hubspot_contact_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferred_contact_time": {
+          "name": "preferred_contact_time",
+          "type": "preferred_contact_time",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_land": {
+          "name": "has_land",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "land_registered": {
+          "name": "land_registered",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "land_address": {
+          "name": "land_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "land_size_sqm": {
+          "name": "land_size_sqm",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "land_width": {
+          "name": "land_width",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "land_depth": {
+          "name": "land_depth",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "property_type": {
+          "name": "property_type",
+          "type": "property_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "budget": {
+          "name": "budget",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seen_broker": {
+          "name": "seen_broker",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "construction_timeline": {
+          "name": "construction_timeline",
+          "type": "construction_timeline",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lead_score": {
+          "name": "lead_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "lead_stage": {
+          "name": "lead_stage",
+          "type": "lead_stage",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unqualified'"
+        },
+        "score_metadata": {
+          "name": "score_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferred_estates": {
+          "name": "preferred_estates",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferred_suburbs": {
+          "name": "preferred_suburbs",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lead_source": {
+          "name": "lead_source",
+          "type": "lead_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "referrer_name": {
+          "name": "referrer_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolve_finance_opted_in": {
+          "name": "resolve_finance_opted_in",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_contacted_at": {
+          "name": "last_contacted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "leads_email_idx": {
+          "name": "leads_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"leads\".\"email\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "leads_lead_stage_idx": {
+          "name": "leads_lead_stage_idx",
+          "columns": [
+            {
+              "expression": "lead_stage",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "leads_hubspot_contact_id_unique": {
+          "name": "leads_hubspot_contact_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["hubspot_contact_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lot_matches": {
+      "name": "lot_matches",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "lot_id": {
+          "name": "lot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lead_id": {
+          "name": "lead_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "match_strength": {
+          "name": "match_strength",
+          "type": "match_strength",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "match_reasoning": {
+          "name": "match_reasoning",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outreach_status": {
+          "name": "outreach_status",
+          "type": "outreach_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "lot_matches_lot_lead_idx": {
+          "name": "lot_matches_lot_lead_idx",
+          "columns": [
+            {
+              "expression": "lot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lead_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lot_matches_lot_id_lots_id_fk": {
+          "name": "lot_matches_lot_id_lots_id_fk",
+          "tableFrom": "lot_matches",
+          "tableTo": "lots",
+          "columnsFrom": ["lot_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "lot_matches_lead_id_leads_id_fk": {
+          "name": "lot_matches_lead_id_leads_id_fk",
+          "tableFrom": "lot_matches",
+          "tableTo": "leads",
+          "columnsFrom": ["lead_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lots": {
+      "name": "lots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "estate_name": {
+          "name": "estate_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suburb": {
+          "name": "suburb",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lot_number": {
+          "name": "lot_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "land_size_sqm": {
+          "name": "land_size_sqm",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "frontage_m": {
+          "name": "frontage_m",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "depth_m": {
+          "name": "depth_m",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "availability_type": {
+          "name": "availability_type",
+          "type": "availability_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exclusive_until": {
+          "name": "exclusive_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "lot_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'available'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "lots_status_idx": {
+          "name": "lots_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.message_queue": {
+      "name": "message_queue",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "lead_id": {
+          "name": "lead_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ai_reasoning": {
+          "name": "ai_reasoning",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "message_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "snoozed_until": {
+          "name": "snoozed_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "original_body": {
+          "name": "original_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "message_queue_status_priority_idx": {
+          "name": "message_queue_status_priority_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "message_queue_lead_id_leads_id_fk": {
+          "name": "message_queue_lead_id_leads_id_fk",
+          "tableFrom": "message_queue",
+          "tableTo": "leads",
+          "columnsFrom": ["lead_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nurture_sequences": {
+      "name": "nurture_sequences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "lead_id": {
+          "name": "lead_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence_type": {
+          "name": "sequence_type",
+          "type": "sequence_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "sequence_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "next_step_at": {
+          "name": "next_step_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "nurture_sequences_lead_status_idx": {
+          "name": "nurture_sequences_lead_status_idx",
+          "columns": [
+            {
+              "expression": "lead_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "nurture_active_one_per_lead_uidx": {
+          "name": "nurture_active_one_per_lead_uidx",
+          "columns": [
+            {
+              "expression": "lead_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "status = 'active'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "nurture_sequences_lead_id_leads_id_fk": {
+          "name": "nurture_sequences_lead_id_leads_id_fk",
+          "tableFrom": "nurture_sequences",
+          "tableTo": "leads",
+          "columnsFrom": ["lead_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.availability_type": {
+      "name": "availability_type",
+      "schema": "public",
+      "values": ["first_come", "exclusive_territory", "developer_direct"]
+    },
+    "public.channel": {
+      "name": "channel",
+      "schema": "public",
+      "values": ["sms", "email"]
+    },
+    "public.construction_timeline": {
+      "name": "construction_timeline",
+      "schema": "public",
+      "values": ["ready_now", "3_6_months", "12_months_plus"]
+    },
+    "public.delivery_method": {
+      "name": "delivery_method",
+      "schema": "public",
+      "values": ["imessage", "sms", "email"]
+    },
+    "public.direction": {
+      "name": "direction",
+      "schema": "public",
+      "values": ["inbound", "outbound"]
+    },
+    "public.lead_source": {
+      "name": "lead_source",
+      "schema": "public",
+      "values": ["walk_in", "referral", "social", "web", "other"]
+    },
+    "public.lead_stage": {
+      "name": "lead_stage",
+      "schema": "public",
+      "values": ["unqualified", "nurture", "warm", "hot"]
+    },
+    "public.lot_status": {
+      "name": "lot_status",
+      "schema": "public",
+      "values": ["available", "matched", "sold", "expired"]
+    },
+    "public.match_strength": {
+      "name": "match_strength",
+      "schema": "public",
+      "values": ["strong", "partial", "stretch"]
+    },
+    "public.message_status": {
+      "name": "message_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "approved",
+        "edited_and_approved",
+        "dismissed",
+        "snoozed"
+      ]
+    },
+    "public.outreach_status": {
+      "name": "outreach_status",
+      "schema": "public",
+      "values": ["pending", "queued", "sent", "responded"]
+    },
+    "public.preferred_contact_time": {
+      "name": "preferred_contact_time",
+      "schema": "public",
+      "values": ["weekdays", "weekends", "anytime"]
+    },
+    "public.property_type": {
+      "name": "property_type",
+      "schema": "public",
+      "values": [
+        "single_storey",
+        "double_storey",
+        "investment",
+        "upsize",
+        "downsize",
+        "first_home_buyer"
+      ]
+    },
+    "public.sequence_status": {
+      "name": "sequence_status",
+      "schema": "public",
+      "values": ["active", "paused", "completed"]
+    },
+    "public.sequence_type": {
+      "name": "sequence_type",
+      "schema": "public",
+      "values": ["discovery", "nurture", "warm_progression", "lot_alert"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1775646482485,
       "tag": "0001_boring_giant_man",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1776736181971,
+      "tag": "0002_stormy_salo",
+      "breakpoints": true
     }
   ]
 }

--- a/e2e/features/nurture-scheduler.spec.ts
+++ b/e2e/features/nurture-scheduler.spec.ts
@@ -1,0 +1,157 @@
+import { randomUUID } from "node:crypto";
+import { expect, test } from "@playwright/test";
+import {
+  createTestSession,
+  deleteTestSession,
+  type TestSession,
+  uniquePhone,
+} from "../utils/auth-helper";
+import { getLeadIdByPhone } from "../utils/leads-helper";
+import {
+  cleanupLeads,
+  cleanupMessages,
+  seedLead,
+} from "../utils/messages-helper";
+import {
+  cleanupSequences,
+  cronRequestContext,
+  getActiveSequenceByLead,
+  seedActiveSequence,
+  waitForPendingMessage,
+} from "../utils/nurture-helper";
+import { getSessionCookie } from "../utils/session-cookie";
+
+test.describe("Nurture scheduler", () => {
+  test.skip(!process.env.DATABASE_URL, "DB required");
+  test.skip(!process.env.CRON_SECRET, "CRON_SECRET required");
+
+  let session: TestSession;
+  const leadIds: string[] = [];
+  const sequenceIds: string[] = [];
+  const messageIds: string[] = [];
+
+  test.beforeAll(async () => {
+    session = await createTestSession();
+  });
+
+  test.afterAll(async () => {
+    await cleanupMessages(messageIds);
+    await cleanupSequences(sequenceIds);
+    await cleanupLeads(leadIds);
+    await deleteTestSession(session.userId);
+  });
+
+  test("auto-starts a sequence on lead create (migration gate)", async ({
+    page,
+    context,
+    baseURL,
+  }) => {
+    await context.addCookies([getSessionCookie(session.signedToken, baseURL!)]);
+
+    const phone = uniquePhone();
+    const email = `e2e-${randomUUID()}@test.rekurve.dev`;
+
+    await page.goto("/leads/new");
+
+    // Step 1 — Contact details
+    await page.getByTestId("lead-form-first-name").fill("Nurture");
+    await page.getByTestId("lead-form-last-name").fill("AutoStart");
+    await page.getByTestId("lead-form-phone").fill(phone);
+    await page.getByTestId("lead-form-email").fill(email);
+    await page.getByTestId("lead-form-next-btn").click();
+
+    // Step 2 — Land (no required fields, skip through)
+    await page.getByTestId("lead-form-next-btn").click();
+
+    // Step 3 — Build (no required fields, skip through)
+    await page.getByTestId("lead-form-next-btn").click();
+
+    // Step 4 — More / submit
+    await page.getByTestId("lead-form-submit-btn").click();
+
+    // Wait for success screen
+    await expect(page.getByTestId("lead-form-success")).toBeVisible();
+
+    const leadId = await getLeadIdByPhone(phone);
+    leadIds.push(leadId);
+
+    const sequence = await getActiveSequenceByLead(leadId);
+    expect(sequence).not.toBeNull();
+    expect(sequence!.sequenceType).toBe("discovery");
+
+    // nextStepAt should be within ±1 minute of now + 3 days
+    const expectedAt = new Date(Date.now() + 3 * 24 * 60 * 60 * 1000);
+    const diffMs = Math.abs(
+      sequence!.nextStepAt!.getTime() - expectedAt.getTime(),
+    );
+    expect(diffMs).toBeLessThan(60_000);
+
+    sequenceIds.push(sequence!.id);
+  });
+
+  test.describe("cron → action queue", () => {
+    test.describe.configure({ mode: "serial" });
+
+    let seededLeadId: string;
+    let draftedMessageId: string;
+
+    test("cron drafts a pending message", async ({ baseURL }) => {
+      const lead = await seedLead({
+        firstName: "Nurture",
+        lastName: "Cron",
+        leadStage: "nurture",
+        phone: uniquePhone(),
+      });
+      seededLeadId = lead.id;
+      leadIds.push(lead.id);
+
+      // Seed with nextStepAt already in the past so the scheduler picks it up
+      // (the dev-advance route is production-gated and unavailable here)
+      const seq = await seedActiveSequence({
+        leadId: seededLeadId,
+        sequenceType: "nurture",
+        nextStepAt: new Date(Date.now() - 60_000),
+      });
+      sequenceIds.push(seq.id);
+
+      // Invoke cron with AI stub header
+      const cronCtx = await cronRequestContext(baseURL!);
+      try {
+        const cronRes = await cronCtx.get("/api/cron/nurture-scheduler");
+        expect(cronRes.status()).toBe(200);
+        const body = (await cronRes.json()) as {
+          drafted: number;
+          failed: number;
+        };
+        expect(body).toEqual({ drafted: 1, failed: 0 });
+      } finally {
+        await cronCtx.dispose();
+      }
+
+      // Poll until the pending message appears in the DB
+      const msg = await waitForPendingMessage(seededLeadId);
+      expect(msg.body).toMatch(/^\[ai-stub\]/);
+      expect(msg.status).toBe("pending");
+      draftedMessageId = msg.id;
+      messageIds.push(msg.id);
+    });
+
+    test("action queue renders the drafted message", async ({
+      page,
+      context,
+      baseURL,
+    }) => {
+      await context.addCookies([
+        getSessionCookie(session.signedToken, baseURL!),
+      ]);
+      await page.goto("/dashboard");
+
+      await expect(
+        page.getByTestId(`queue-row-${draftedMessageId}`),
+      ).toBeVisible();
+      await expect(
+        page.getByTestId(`queue-row-body-${draftedMessageId}`),
+      ).toContainText("[ai-stub]");
+    });
+  });
+});

--- a/e2e/utils/auth-helper.ts
+++ b/e2e/utils/auth-helper.ts
@@ -97,7 +97,7 @@ export async function deleteTestLeads(): Promise<void> {
     WHERE email LIKE 'e2e-%@test.rekurve.dev'
        OR first_name IN (
          'Approve', 'Count', 'Dismiss', 'E2E', 'Edit', 'FHOG',
-         'Nav', 'Order', 'Pipeline', 'QC', 'Quick', 'Snooze'
+         'Nav', 'Nurture', 'Order', 'Pipeline', 'QC', 'Quick', 'Snooze'
        )
   `;
 }

--- a/e2e/utils/hubspot-helper.ts
+++ b/e2e/utils/hubspot-helper.ts
@@ -117,6 +117,7 @@ const TEST_FIRST_NAMES = [
   "Edit",
   "FHOG",
   "Nav",
+  "Nurture",
   "Order",
   "Pipeline",
   "QC",

--- a/e2e/utils/messages-helper.ts
+++ b/e2e/utils/messages-helper.ts
@@ -25,16 +25,20 @@ export async function seedLead(overrides: {
   lastName: string;
   leadScore?: number;
   leadStage?: "unqualified" | "nurture" | "warm" | "hot";
+  phone?: string | null;
+  email?: string | null;
 }): Promise<SeededLead> {
   const id = randomUUID();
   await sql()`
-    INSERT INTO "leads" (id, first_name, last_name, lead_score, lead_stage)
+    INSERT INTO "leads" (id, first_name, last_name, lead_score, lead_stage, phone, email)
     VALUES (
       ${id},
       ${overrides.firstName},
       ${overrides.lastName},
       ${overrides.leadScore ?? 0},
-      ${overrides.leadStage ?? "unqualified"}
+      ${overrides.leadStage ?? "unqualified"},
+      ${overrides.phone ?? null},
+      ${overrides.email ?? null}
     )
   `;
   return { id, firstName: overrides.firstName, lastName: overrides.lastName };

--- a/e2e/utils/nurture-helper.ts
+++ b/e2e/utils/nurture-helper.ts
@@ -1,0 +1,123 @@
+import { randomUUID } from "node:crypto";
+import { type NeonQueryFunction, neon } from "@neondatabase/serverless";
+import { type APIRequestContext, request } from "@playwright/test";
+
+import "dotenv/config";
+
+let _sql: NeonQueryFunction<false, false> | undefined;
+function sql() {
+  _sql ??= neon(process.env.DATABASE_URL!);
+  return _sql;
+}
+
+export async function seedActiveSequence(args: {
+  leadId: string;
+  sequenceType: "discovery" | "nurture" | "warm_progression" | "lot_alert";
+  nextStepAt: Date;
+}): Promise<{ id: string }> {
+  const id = randomUUID();
+  await sql()`
+    INSERT INTO "nurture_sequences" (id, lead_id, sequence_type, status, next_step_at)
+    VALUES (
+      ${id},
+      ${args.leadId},
+      ${args.sequenceType},
+      'active',
+      ${args.nextStepAt.toISOString()}
+    )
+  `;
+  return { id };
+}
+
+export async function getActiveSequenceByLead(leadId: string): Promise<{
+  id: string;
+  sequenceType: string;
+  nextStepAt: Date | null;
+} | null> {
+  const rows = await sql()`
+    SELECT id, sequence_type, next_step_at
+    FROM "nurture_sequences"
+    WHERE lead_id = ${leadId} AND status = 'active'
+    LIMIT 1
+  `;
+  if (rows.length === 0) return null;
+  const row = rows[0] as {
+    id: string;
+    sequence_type: string;
+    next_step_at: string | null;
+  };
+  return {
+    id: row.id,
+    sequenceType: row.sequence_type,
+    nextStepAt: row.next_step_at ? new Date(row.next_step_at) : null,
+  };
+}
+
+export async function getPendingMessagesByLead(leadId: string): Promise<
+  Array<{
+    id: string;
+    body: string;
+    status: string;
+    channel: string;
+    subject: string | null;
+  }>
+> {
+  const rows = await sql()`
+    SELECT id, body, status, channel, subject
+    FROM "message_queue"
+    WHERE lead_id = ${leadId} AND status = 'pending'
+  `;
+  return rows as Array<{
+    id: string;
+    body: string;
+    status: string;
+    channel: string;
+    subject: string | null;
+  }>;
+}
+
+export async function waitForPendingMessage(
+  leadId: string,
+  opts?: { intervalMs?: number; timeoutMs?: number },
+): Promise<{
+  id: string;
+  body: string;
+  status: string;
+  channel: string;
+  subject: string | null;
+}> {
+  const intervalMs = opts?.intervalMs ?? 2_000;
+  const timeoutMs = opts?.timeoutMs ?? 10_000;
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    const rows = await getPendingMessagesByLead(leadId);
+    if (rows.length > 0) return rows[0]!;
+    await new Promise((r) => setTimeout(r, intervalMs));
+  }
+  throw new Error(
+    `Timed out waiting for pending message for lead ${leadId} (${timeoutMs}ms)`,
+  );
+}
+
+export async function cleanupSequences(ids: string[]): Promise<void> {
+  if (ids.length === 0) return;
+  await sql()`DELETE FROM "nurture_sequences" WHERE id = ANY(${ids}::uuid[])`;
+}
+
+export async function cronRequestContext(
+  baseURL: string,
+): Promise<APIRequestContext> {
+  if (!process.env.CRON_SECRET) {
+    throw new Error("CRON_SECRET is not set");
+  }
+  const extraHTTPHeaders: Record<string, string> = {
+    Authorization: `Bearer ${process.env.CRON_SECRET}`,
+    "x-ai-stub": "1",
+  };
+  if (process.env.VERCEL_AUTOMATION_BYPASS_SECRET) {
+    extraHTTPHeaders["x-vercel-protection-bypass"] =
+      process.env.VERCEL_AUTOMATION_BYPASS_SECRET;
+    extraHTTPHeaders["x-vercel-set-bypass-cookie"] = "true";
+  }
+  return request.newContext({ baseURL, extraHTTPHeaders });
+}

--- a/package.json
+++ b/package.json
@@ -103,7 +103,8 @@
     "tailwindcss": "^4.0.15",
     "tsx": "^4.21.0",
     "tw-animate-css": "^1.4.0",
-    "typescript": "^5.8.2"
+    "typescript": "^5.8.2",
+    "vercel": "^51.8.0"
   },
   "ct3aMetadata": {
     "initVersion": "7.39.3"

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -43,7 +43,7 @@ export default defineConfig({
   webServer: isCI
     ? undefined
     : {
-        command: "rm -rf .next/ && yarn preview",
+        command: "rm -rf .next/ && yarn db:migrate && yarn preview",
         url: baseURL,
         timeout: 120_000,
         reuseExistingServer: true,

--- a/src/app/api/cron/nurture-scheduler/__tests__/route.test.ts
+++ b/src/app/api/cron/nurture-scheduler/__tests__/route.test.ts
@@ -1,4 +1,6 @@
 import { beforeEach, describe, expect, rs, test } from "@rstest/core";
+import { makeLead } from "~/server/ai/__tests__/fixtures";
+import type { DraftFn } from "~/server/ai/stub";
 
 const CRON_SECRET = "test-secret-at-least-16-chars";
 
@@ -72,5 +74,33 @@ describe("GET /api/cron/nurture-scheduler", () => {
     expect(res.status).toBe(200);
     const body = (await res.json()) as { drafted: number; failed: number };
     expect(body).toEqual({ drafted: 0, failed: 0 });
+  });
+
+  test("passes a draftFn to runSchedulerTick when x-ai-stub: 1 is set", async () => {
+    let capturedDraftFn: DraftFn | undefined;
+    const { runSchedulerTick } = await import("~/server/nurture/scheduler");
+    (runSchedulerTick as ReturnType<typeof rs.fn>).mockImplementation(
+      async (_db: unknown, draftFn: DraftFn | undefined) => {
+        capturedDraftFn = draftFn;
+        return { drafted: 1, failed: 0 };
+      },
+    );
+
+    const GET = await getHandler();
+    const req = new Request("http://localhost/api/cron/nurture-scheduler", {
+      headers: {
+        Authorization: `Bearer ${CRON_SECRET}`,
+        "x-ai-stub": "1",
+      },
+    });
+    const res = await GET(req);
+
+    expect(res.status).toBe(200);
+    expect(capturedDraftFn).toBeDefined();
+
+    const output = await capturedDraftFn!({
+      lead: makeLead({ phone: "0412345678" }),
+    });
+    expect(output.body).toMatch(/^\[ai-stub\]/);
   });
 });

--- a/src/app/api/cron/nurture-scheduler/__tests__/route.test.ts
+++ b/src/app/api/cron/nurture-scheduler/__tests__/route.test.ts
@@ -1,0 +1,76 @@
+import { beforeEach, describe, expect, rs, test } from "@rstest/core";
+
+const CRON_SECRET = "test-secret-at-least-16-chars";
+
+beforeEach(() => {
+  rs.resetModules();
+
+  rs.doMock("~/env", () => ({
+    env: {
+      CRON_SECRET,
+      DATABASE_URL: "postgres://mock",
+    },
+  }));
+
+  rs.doMock("~/server/db", () => ({ db: {} }));
+
+  rs.doMock("~/server/nurture/scheduler", () => ({
+    runSchedulerTick: rs.fn().mockResolvedValue({ drafted: 1, failed: 0 }),
+  }));
+});
+
+async function getHandler() {
+  const { GET } = await import("../route");
+  return GET;
+}
+
+describe("GET /api/cron/nurture-scheduler", () => {
+  test("returns 401 without Authorization header", async () => {
+    const GET = await getHandler();
+    const req = new Request("http://localhost/api/cron/nurture-scheduler");
+    const res = await GET(req);
+    expect(res.status).toBe(401);
+  });
+
+  test("returns 401 with wrong bearer", async () => {
+    const GET = await getHandler();
+    const req = new Request("http://localhost/api/cron/nurture-scheduler", {
+      headers: { Authorization: "Bearer wrong-secret" },
+    });
+    const res = await GET(req);
+    expect(res.status).toBe(401);
+  });
+
+  test("returns 200 with correct bearer and calls runSchedulerTick", async () => {
+    const GET = await getHandler();
+    const { runSchedulerTick } = await import("~/server/nurture/scheduler");
+
+    const req = new Request("http://localhost/api/cron/nurture-scheduler", {
+      headers: { Authorization: `Bearer ${CRON_SECRET}` },
+    });
+    const res = await GET(req);
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { drafted: number; failed: number };
+    expect(body).toEqual({ drafted: 1, failed: 0 });
+    expect(runSchedulerTick).toHaveBeenCalled();
+  });
+
+  test("returns 200 with { drafted: 0, failed: 0 } when no sequences due", async () => {
+    const { runSchedulerTick } = await import("~/server/nurture/scheduler");
+    (runSchedulerTick as ReturnType<typeof rs.fn>).mockResolvedValue({
+      drafted: 0,
+      failed: 0,
+    });
+
+    const GET = await getHandler();
+    const req = new Request("http://localhost/api/cron/nurture-scheduler", {
+      headers: { Authorization: `Bearer ${CRON_SECRET}` },
+    });
+    const res = await GET(req);
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { drafted: number; failed: number };
+    expect(body).toEqual({ drafted: 0, failed: 0 });
+  });
+});

--- a/src/app/api/cron/nurture-scheduler/route.ts
+++ b/src/app/api/cron/nurture-scheduler/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from "next/server";
+
+import { env } from "~/env";
+import { db } from "~/server/db";
+import { runSchedulerTick } from "~/server/nurture/scheduler";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(request: Request) {
+  const auth = request.headers.get("Authorization");
+  if (auth !== `Bearer ${env.CRON_SECRET}`) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const result = await runSchedulerTick(db);
+  return NextResponse.json(result);
+}

--- a/src/app/api/cron/nurture-scheduler/route.ts
+++ b/src/app/api/cron/nurture-scheduler/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 
 import { env } from "~/env";
+import { resolveDraftFn } from "~/server/ai/stub";
 import { db } from "~/server/db";
 import { runSchedulerTick } from "~/server/nurture/scheduler";
 
@@ -12,6 +13,7 @@ export async function GET(request: Request) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const result = await runSchedulerTick(db);
+  const draftFn = resolveDraftFn(request);
+  const result = await runSchedulerTick(db, draftFn);
   return NextResponse.json(result);
 }

--- a/src/app/api/dev/nurture/advance/route.ts
+++ b/src/app/api/dev/nurture/advance/route.ts
@@ -1,0 +1,32 @@
+import { eq } from "drizzle-orm";
+import { NextResponse } from "next/server";
+import { z } from "zod";
+
+import { env } from "~/env";
+import { db } from "~/server/db";
+import { nurtureSequences } from "~/server/db/schema";
+
+export async function POST(request: Request) {
+  if (env.NODE_ENV === "production") {
+    return NextResponse.json({}, { status: 404 });
+  }
+
+  const body = (await request.json()) as unknown;
+  const result = z.object({ sequenceId: z.string().uuid() }).safeParse(body);
+  if (!result.success) {
+    return NextResponse.json({ error: "Invalid sequenceId" }, { status: 400 });
+  }
+
+  const { sequenceId } = result.data;
+  const backdated = new Date(Date.now() - 60_000);
+
+  await db
+    .update(nurtureSequences)
+    .set({ nextStepAt: backdated, updatedAt: new Date() })
+    .where(eq(nurtureSequences.id, sequenceId));
+
+  return NextResponse.json({
+    advanced: true,
+    nextStepAt: backdated.toISOString(),
+  });
+}

--- a/src/env.js
+++ b/src/env.js
@@ -28,6 +28,7 @@ export const env = createEnv({
     HUBSPOT_ACCESS_TOKEN: z.string().min(1),
     HUBSPOT_CLIENT_SECRET: z.string().min(1),
     ANTHROPIC_API_KEY: z.string().min(1),
+    CRON_SECRET: z.string().min(16),
     ROBOTS_TXT: z.string().default("Disallow"),
   },
 
@@ -59,6 +60,7 @@ export const env = createEnv({
     HUBSPOT_ACCESS_TOKEN: process.env.HUBSPOT_ACCESS_TOKEN,
     HUBSPOT_CLIENT_SECRET: process.env.HUBSPOT_CLIENT_SECRET,
     ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY,
+    CRON_SECRET: process.env.CRON_SECRET,
     ROBOTS_TXT: process.env.ROBOTS_TXT,
   },
   /**

--- a/src/server/ai/__tests__/stub.test.ts
+++ b/src/server/ai/__tests__/stub.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, describe, expect, rs, test } from "@rstest/core";
+import { resolveDraftFn } from "../stub";
+import { makeLead } from "./fixtures";
+
+describe("resolveDraftFn", () => {
+  afterEach(() => {
+    rs.restoreAllMocks();
+  });
+
+  test("returns undefined when x-ai-stub header is absent", () => {
+    const req = new Request("http://localhost/api/cron/nurture-scheduler");
+    expect(resolveDraftFn(req)).toBeUndefined();
+  });
+
+  test("returns undefined for x-ai-stub: 0", () => {
+    const req = new Request("http://localhost/api/cron/nurture-scheduler", {
+      headers: { "x-ai-stub": "0" },
+    });
+    expect(resolveDraftFn(req)).toBeUndefined();
+  });
+
+  test("returns undefined for empty x-ai-stub header", () => {
+    const req = new Request("http://localhost/api/cron/nurture-scheduler", {
+      headers: { "x-ai-stub": "" },
+    });
+    expect(resolveDraftFn(req)).toBeUndefined();
+  });
+
+  describe("when x-ai-stub: 1", () => {
+    function makeStubReq() {
+      return new Request("http://localhost/api/cron/nurture-scheduler", {
+        headers: { "x-ai-stub": "1" },
+      });
+    }
+
+    test("returns a function", () => {
+      expect(resolveDraftFn(makeStubReq())).toBeTypeOf("function");
+    });
+
+    test("output channel matches selectChannel(lead)", async () => {
+      const fn = resolveDraftFn(makeStubReq())!;
+      const lead = makeLead({ phone: "0412345678" });
+      const output = await fn({ lead });
+      expect(output.channel).toBe("sms");
+    });
+
+    test("output priority matches computePriority(lead)", async () => {
+      const fn = resolveDraftFn(makeStubReq())!;
+      const lead = makeLead({ leadStage: "warm", phone: "0412345678" });
+      const output = await fn({ lead });
+      expect(output.priority).toBe(50);
+    });
+
+    test("body starts with '[ai-stub] body for ' and contains lead.id", async () => {
+      const fn = resolveDraftFn(makeStubReq())!;
+      const lead = makeLead({ phone: "0412345678" });
+      const output = await fn({ lead });
+      expect(output.body).toMatch(/^\[ai-stub\] body for /);
+      expect(output.body).toContain(lead.id);
+    });
+
+    test("subject is null for an SMS-selected lead", async () => {
+      const fn = resolveDraftFn(makeStubReq())!;
+      const lead = makeLead({ phone: "0412345678" });
+      const output = await fn({ lead });
+      expect(output.subject).toBeNull();
+    });
+
+    test("subject is '[ai-stub] subject' for an email-selected lead", async () => {
+      const fn = resolveDraftFn(makeStubReq())!;
+      const lead = makeLead({
+        leadStage: "hot",
+        email: "test@example.com",
+        phone: null,
+      });
+      const output = await fn({ lead });
+      expect(output.subject).toBe("[ai-stub] subject");
+    });
+
+    test("logs to console.info with [ai-stub] prefix on invocation", async () => {
+      const spy = rs.spyOn(console, "info").mockImplementation(() => undefined);
+      const fn = resolveDraftFn(makeStubReq())!;
+      const lead = makeLead({ phone: "0412345678" });
+      await fn({ lead });
+      expect(spy).toHaveBeenCalledWith(expect.stringMatching(/^\[ai-stub\]/));
+    });
+  });
+});

--- a/src/server/ai/stub.ts
+++ b/src/server/ai/stub.ts
@@ -1,0 +1,21 @@
+import { selectChannel } from "~/server/ai/channel-selection";
+import { computePriority } from "~/server/ai/priority";
+import type { DraftMessageInput, DraftMessageOutput } from "~/server/ai/schema";
+
+export type DraftFn = (input: DraftMessageInput) => Promise<DraftMessageOutput>;
+
+export function resolveDraftFn(req: Request): DraftFn | undefined {
+  if (req.headers.get("x-ai-stub") !== "1") return undefined;
+  return async ({ lead }: DraftMessageInput): Promise<DraftMessageOutput> => {
+    const channel = selectChannel(lead);
+    const url = new URL(req.url);
+    console.info(`[ai-stub] route=${url.pathname} leadId=${lead.id}`);
+    return {
+      channel,
+      subject: channel === "sms" ? null : "[ai-stub] subject",
+      body: `[ai-stub] body for ${lead.id}`,
+      aiReasoning: "[ai-stub]",
+      priority: computePriority(lead),
+    };
+  };
+}

--- a/src/server/api/__tests__/leads-router.test.ts
+++ b/src/server/api/__tests__/leads-router.test.ts
@@ -102,6 +102,10 @@ beforeEach(() => {
     }),
   }));
 
+  rs.doMock("~/server/nurture/scheduler", () => ({
+    startOrUpdateSequence: rs.fn().mockResolvedValue(undefined),
+  }));
+
   rs.doMock("~/server/hubspot", () => ({
     findExistingContact: rs.fn().mockResolvedValue(null),
     createContact: rs.fn().mockResolvedValue({
@@ -894,6 +898,68 @@ describe("leads.getByStage", () => {
 
     expect(findMany).toHaveBeenCalledWith(
       expect.objectContaining({ where: expect.anything() }),
+    );
+  });
+});
+
+// --- leads.create — nurture auto-start ---
+
+describe("leads.create — nurture auto-start", () => {
+  test("calls startOrUpdateSequence with post-scoring stage after create", async () => {
+    const returning = rs.fn().mockResolvedValue([mockLead]);
+    const onConflictDoUpdate = rs.fn().mockReturnValue({ returning });
+    const values = rs.fn().mockReturnValue({ onConflictDoUpdate });
+    (mockDb.insert as ReturnType<typeof rs.fn>).mockReturnValue({ values });
+
+    const { startOrUpdateSequence } = await import(
+      "~/server/nurture/scheduler"
+    );
+
+    const caller = await getCaller();
+    await caller.leads.create({ firstName: "John", lastName: "Smith" });
+
+    expect(startOrUpdateSequence).toHaveBeenCalledWith(
+      expect.anything(),
+      mockLead.id,
+      mockLead.leadStage,
+    );
+  });
+});
+
+// --- leads.update — nurture auto-start ---
+
+describe("leads.update — nurture auto-start", () => {
+  test("calls startOrUpdateSequence when a qualification field changes", async () => {
+    (
+      mockDb.query as { leads: { findFirst: ReturnType<typeof rs.fn> } }
+    ).leads.findFirst.mockResolvedValue({ hubspotContactId: null });
+
+    const updatedLead = {
+      ...mockLead,
+      constructionTimeline: "ready_now" as const,
+    };
+    const returning = rs
+      .fn()
+      .mockResolvedValueOnce([updatedLead])
+      .mockResolvedValueOnce([{ ...updatedLead, leadScore: 20 }]);
+    const where = rs.fn().mockReturnValue({ returning });
+    const set = rs.fn().mockReturnValue({ where });
+    (mockDb.update as ReturnType<typeof rs.fn>).mockReturnValue({ set });
+
+    const { startOrUpdateSequence } = await import(
+      "~/server/nurture/scheduler"
+    );
+
+    const caller = await getCaller();
+    await caller.leads.update({
+      id: mockLead.id,
+      constructionTimeline: "ready_now",
+    });
+
+    expect(startOrUpdateSequence).toHaveBeenCalledWith(
+      expect.anything(),
+      mockLead.id,
+      expect.any(String),
     );
   });
 });

--- a/src/server/api/__tests__/nurture-router.test.ts
+++ b/src/server/api/__tests__/nurture-router.test.ts
@@ -1,0 +1,292 @@
+import { beforeEach, describe, expect, rs, test } from "@rstest/core";
+import { TRPCError } from "@trpc/server";
+import type { createCaller } from "../root";
+
+type Caller = ReturnType<typeof createCaller>;
+
+const SEQ_ID = "550e8400-e29b-41d4-a716-446655440000";
+const LEAD_ID = "660e8400-e29b-41d4-a716-446655440001";
+
+const baseSeq = {
+  id: SEQ_ID,
+  leadId: LEAD_ID,
+  sequenceType: "nurture" as const,
+  status: "active" as const,
+  nextStepAt: new Date(Date.now() + 14 * 86_400_000),
+  createdAt: new Date("2026-04-01"),
+  updatedAt: new Date("2026-04-01"),
+};
+
+let mockDb: Record<string, unknown>;
+
+beforeEach(() => {
+  rs.resetModules();
+
+  rs.doMock("~/env", () => ({
+    env: {
+      DATABASE_URL: "postgres://mock",
+      HUBSPOT_ACCESS_TOKEN: "mock",
+      HUBSPOT_CLIENT_SECRET: "mock",
+    },
+  }));
+
+  rs.doMock("~/lib/session", () => ({
+    getSession: rs.fn().mockResolvedValue({
+      user: { id: "test-user-id", email: "test@example.com", name: "Test" },
+      session: { id: "test-session-id" },
+    }),
+  }));
+
+  mockDb = {
+    insert: rs.fn(),
+    update: rs.fn(),
+    query: {
+      nurtureSequences: {
+        findFirst: rs.fn(),
+        findMany: rs.fn(),
+      },
+    },
+  };
+
+  rs.doMock("~/server/db", () => ({ db: mockDb }));
+});
+
+async function getCaller(): Promise<Caller> {
+  const { createCaller } = await import("../root");
+  const { createTRPCContext } = await import("../trpc");
+  const ctx = await createTRPCContext({ headers: new Headers() });
+  return createCaller(ctx);
+}
+
+function mockInsertReturning(row: unknown) {
+  const returning = rs.fn().mockResolvedValue([row]);
+  const values = rs.fn().mockReturnValue({ returning });
+  (mockDb.insert as ReturnType<typeof rs.fn>).mockReturnValue({ values });
+  return { values, returning };
+}
+
+function mockUpdateReturning(row: unknown) {
+  const returning = rs.fn().mockResolvedValue([row]);
+  const where = rs.fn().mockReturnValue({ returning });
+  const set = rs.fn().mockReturnValue({ where });
+  (mockDb.update as ReturnType<typeof rs.fn>).mockReturnValue({ set });
+  return { set, where, returning };
+}
+
+// --- nurture.listActive ---
+
+describe("nurture.listActive", () => {
+  test("returns only active rows", async () => {
+    (
+      mockDb.query as {
+        nurtureSequences: { findMany: ReturnType<typeof rs.fn> };
+      }
+    ).nurtureSequences.findMany.mockResolvedValue([baseSeq]);
+
+    const caller = await getCaller();
+    const result = await caller.nurture.listActive();
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.id).toBe(SEQ_ID);
+    expect(result[0]?.status).toBe("active");
+  });
+
+  test("returns empty array when none active", async () => {
+    (
+      mockDb.query as {
+        nurtureSequences: { findMany: ReturnType<typeof rs.fn> };
+      }
+    ).nurtureSequences.findMany.mockResolvedValue([]);
+
+    const caller = await getCaller();
+    const result = await caller.nurture.listActive();
+
+    expect(result).toEqual([]);
+  });
+});
+
+// --- nurture.startSequence ---
+
+describe("nurture.startSequence", () => {
+  test("inserts and returns new active sequence", async () => {
+    (
+      mockDb.query as {
+        nurtureSequences: { findFirst: ReturnType<typeof rs.fn> };
+      }
+    ).nurtureSequences.findFirst.mockResolvedValue(undefined);
+
+    const inserted = { ...baseSeq, sequenceType: "discovery" as const };
+    mockInsertReturning(inserted);
+
+    const caller = await getCaller();
+    const result = await caller.nurture.startSequence({
+      leadId: LEAD_ID,
+      sequenceType: "discovery",
+    });
+
+    expect(result.leadId).toBe(LEAD_ID);
+    expect(result.status).toBe("active");
+  });
+
+  test("rejects with BAD_REQUEST when active sequence already exists", async () => {
+    (
+      mockDb.query as {
+        nurtureSequences: { findFirst: ReturnType<typeof rs.fn> };
+      }
+    ).nurtureSequences.findFirst.mockResolvedValue(baseSeq);
+
+    const caller = await getCaller();
+    try {
+      await caller.nurture.startSequence({
+        leadId: LEAD_ID,
+        sequenceType: "nurture",
+      });
+      expect.unreachable("Should have thrown");
+    } catch (e) {
+      expect(e).toBeInstanceOf(TRPCError);
+      expect((e as TRPCError).code).toBe("BAD_REQUEST");
+    }
+  });
+
+  test("rejects invalid leadId uuid", async () => {
+    const caller = await getCaller();
+    try {
+      await caller.nurture.startSequence({
+        leadId: "not-a-uuid",
+        sequenceType: "nurture",
+      });
+      expect.unreachable("Should have thrown");
+    } catch (e) {
+      expect(e).toBeInstanceOf(TRPCError);
+      expect((e as TRPCError).code).toBe("BAD_REQUEST");
+    }
+  });
+});
+
+// --- nurture.pauseSequence ---
+
+describe("nurture.pauseSequence", () => {
+  test("transitions active → paused and nulls nextStepAt", async () => {
+    (
+      mockDb.query as {
+        nurtureSequences: { findFirst: ReturnType<typeof rs.fn> };
+      }
+    ).nurtureSequences.findFirst.mockResolvedValue(baseSeq);
+
+    const paused = { ...baseSeq, status: "paused" as const, nextStepAt: null };
+    const { set } = mockUpdateReturning(paused);
+
+    const caller = await getCaller();
+    const result = await caller.nurture.pauseSequence({ id: SEQ_ID });
+
+    expect(result.status).toBe("paused");
+    expect(result.nextStepAt).toBeNull();
+    expect(set).toHaveBeenCalledWith(
+      expect.objectContaining({ status: "paused", nextStepAt: null }),
+    );
+  });
+
+  test("rejects with BAD_REQUEST when sequence is not active", async () => {
+    (
+      mockDb.query as {
+        nurtureSequences: { findFirst: ReturnType<typeof rs.fn> };
+      }
+    ).nurtureSequences.findFirst.mockResolvedValue({
+      ...baseSeq,
+      status: "completed" as const,
+    });
+
+    const caller = await getCaller();
+    try {
+      await caller.nurture.pauseSequence({ id: SEQ_ID });
+      expect.unreachable("Should have thrown");
+    } catch (e) {
+      expect(e).toBeInstanceOf(TRPCError);
+      expect((e as TRPCError).code).toBe("BAD_REQUEST");
+    }
+  });
+
+  test("throws NOT_FOUND when sequence does not exist", async () => {
+    (
+      mockDb.query as {
+        nurtureSequences: { findFirst: ReturnType<typeof rs.fn> };
+      }
+    ).nurtureSequences.findFirst.mockResolvedValue(undefined);
+
+    const caller = await getCaller();
+    try {
+      await caller.nurture.pauseSequence({ id: SEQ_ID });
+      expect.unreachable("Should have thrown");
+    } catch (e) {
+      expect(e).toBeInstanceOf(TRPCError);
+      expect((e as TRPCError).code).toBe("NOT_FOUND");
+    }
+  });
+});
+
+// --- nurture.resumeSequence ---
+
+describe("nurture.resumeSequence", () => {
+  test("transitions paused → active and sets nextStepAt to a future date", async () => {
+    const paused = { ...baseSeq, status: "paused" as const, nextStepAt: null };
+    (
+      mockDb.query as {
+        nurtureSequences: { findFirst: ReturnType<typeof rs.fn> };
+      }
+    ).nurtureSequences.findFirst.mockResolvedValue(paused);
+
+    const resumed = {
+      ...paused,
+      status: "active" as const,
+      nextStepAt: new Date(Date.now() + 14 * 86_400_000),
+    };
+    const { set } = mockUpdateReturning(resumed);
+
+    const caller = await getCaller();
+    const result = await caller.nurture.resumeSequence({ id: SEQ_ID });
+
+    expect(result.status).toBe("active");
+    expect(result.nextStepAt).not.toBeNull();
+    expect(result.nextStepAt!.getTime()).toBeGreaterThan(Date.now());
+    expect(set).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: "active",
+        nextStepAt: expect.any(Date),
+      }),
+    );
+  });
+
+  test("rejects with BAD_REQUEST when sequence is not paused", async () => {
+    (
+      mockDb.query as {
+        nurtureSequences: { findFirst: ReturnType<typeof rs.fn> };
+      }
+    ).nurtureSequences.findFirst.mockResolvedValue(baseSeq); // active, not paused
+
+    const caller = await getCaller();
+    try {
+      await caller.nurture.resumeSequence({ id: SEQ_ID });
+      expect.unreachable("Should have thrown");
+    } catch (e) {
+      expect(e).toBeInstanceOf(TRPCError);
+      expect((e as TRPCError).code).toBe("BAD_REQUEST");
+    }
+  });
+
+  test("throws NOT_FOUND when sequence does not exist", async () => {
+    (
+      mockDb.query as {
+        nurtureSequences: { findFirst: ReturnType<typeof rs.fn> };
+      }
+    ).nurtureSequences.findFirst.mockResolvedValue(undefined);
+
+    const caller = await getCaller();
+    try {
+      await caller.nurture.resumeSequence({ id: SEQ_ID });
+      expect.unreachable("Should have thrown");
+    } catch (e) {
+      expect(e).toBeInstanceOf(TRPCError);
+      expect((e as TRPCError).code).toBe("NOT_FOUND");
+    }
+  });
+});

--- a/src/server/api/__tests__/router.test.ts
+++ b/src/server/api/__tests__/router.test.ts
@@ -16,9 +16,15 @@ beforeEach(() => {
     },
   }));
 
-  // Mock db — routers don't query the DB yet (stubs)
+  // Mock db — minimal shape for the stub queries below
   rs.doMock("~/server/db", () => ({
-    db: {},
+    db: {
+      query: {
+        nurtureSequences: {
+          findMany: rs.fn().mockResolvedValue([]),
+        },
+      },
+    },
   }));
 
   // Default: unauthenticated (null session)
@@ -59,8 +65,8 @@ describe("tRPC — Authenticated", () => {
   const stubs = [
     { name: "lots.getAll", call: (c: Caller) => c.lots.getAll(), expected: [] },
     {
-      name: "nurture.getActive",
-      call: (c: Caller) => c.nurture.getActive(),
+      name: "nurture.listActive",
+      call: (c: Caller) => c.nurture.listActive(),
       expected: [],
     },
     {

--- a/src/server/api/routers/leads.ts
+++ b/src/server/api/routers/leads.ts
@@ -15,6 +15,7 @@ import {
   PROPERTY_MAP,
   updateContact as updateHubSpotContact,
 } from "~/server/hubspot";
+import { startOrUpdateSequence } from "~/server/nurture/scheduler";
 import type { ScoreMetadata } from "~/server/scoring";
 import { qualifyAndScore } from "~/server/scoring";
 
@@ -135,7 +136,19 @@ export const leadsRouter = createTRPCRouter({
       }
 
       // 4. Score synchronously so the response reflects the final score/stage
-      return await scoreLead(ctx.db, lead, lead.hubspotContactId);
+      const scored = await scoreLead(ctx.db, lead, lead.hubspotContactId);
+
+      // 5. Auto-start nurture sequence (non-blocking — nurture failure must not block lead create)
+      await startOrUpdateSequence(ctx.db, scored.id, scored.leadStage).catch(
+        (err) => {
+          console.error(
+            `[leads.create] nurture sequence start failed for lead ${scored.id}:`,
+            err,
+          );
+        },
+      );
+
+      return scored;
     }),
 
   getById: protectedProcedure
@@ -249,7 +262,20 @@ export const leadsRouter = createTRPCRouter({
         SCORING_FIELDS.has(k),
       );
       if (hasQualificationChange) {
-        return await scoreLead(ctx.db, updated, updated.hubspotContactId);
+        const scored = await scoreLead(
+          ctx.db,
+          updated,
+          updated.hubspotContactId,
+        );
+        await startOrUpdateSequence(ctx.db, scored.id, scored.leadStage).catch(
+          (err) => {
+            console.error(
+              `[leads.update] nurture sequence update failed for lead ${scored.id}:`,
+              err,
+            );
+          },
+        );
+        return scored;
       }
 
       return updated;

--- a/src/server/api/routers/nurture.ts
+++ b/src/server/api/routers/nurture.ts
@@ -1,7 +1,113 @@
+import { TRPCError } from "@trpc/server";
+import { and, eq } from "drizzle-orm";
+
+import {
+  pauseSequenceSchema,
+  resumeSequenceSchema,
+  startSequenceSchema,
+} from "~/server/api/schemas/nurture";
 import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
+import { nurtureSequences } from "~/server/db/schema";
+import { computeNextStepAt } from "~/server/nurture/scheduler";
 
 export const nurtureRouter = createTRPCRouter({
-  getActive: protectedProcedure.query(() => {
-    return [];
+  listActive: protectedProcedure.query(async ({ ctx }) => {
+    return ctx.db.query.nurtureSequences.findMany({
+      where: eq(nurtureSequences.status, "active"),
+    });
   }),
+
+  startSequence: protectedProcedure
+    .input(startSequenceSchema)
+    .mutation(async ({ ctx, input }) => {
+      const existing = await ctx.db.query.nurtureSequences.findFirst({
+        where: and(
+          eq(nurtureSequences.leadId, input.leadId),
+          eq(nurtureSequences.status, "active"),
+        ),
+      });
+
+      if (existing) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: "An active sequence already exists for this lead",
+        });
+      }
+
+      const [inserted] = await ctx.db
+        .insert(nurtureSequences)
+        .values({
+          leadId: input.leadId,
+          sequenceType: input.sequenceType,
+          status: "active",
+          nextStepAt: computeNextStepAt(input.sequenceType),
+        })
+        .returning();
+
+      return inserted!;
+    }),
+
+  pauseSequence: protectedProcedure
+    .input(pauseSequenceSchema)
+    .mutation(async ({ ctx, input }) => {
+      const seq = await ctx.db.query.nurtureSequences.findFirst({
+        where: eq(nurtureSequences.id, input.id),
+      });
+
+      if (!seq) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Sequence not found",
+        });
+      }
+
+      if (seq.status !== "active") {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: `Cannot pause a sequence with status '${seq.status}'`,
+        });
+      }
+
+      const [updated] = await ctx.db
+        .update(nurtureSequences)
+        .set({ status: "paused", nextStepAt: null, updatedAt: new Date() })
+        .where(eq(nurtureSequences.id, input.id))
+        .returning();
+
+      return updated!;
+    }),
+
+  resumeSequence: protectedProcedure
+    .input(resumeSequenceSchema)
+    .mutation(async ({ ctx, input }) => {
+      const seq = await ctx.db.query.nurtureSequences.findFirst({
+        where: eq(nurtureSequences.id, input.id),
+      });
+
+      if (!seq) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Sequence not found",
+        });
+      }
+
+      if (seq.status !== "paused") {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: `Cannot resume a sequence with status '${seq.status}'`,
+        });
+      }
+
+      const [updated] = await ctx.db
+        .update(nurtureSequences)
+        .set({
+          status: "active",
+          nextStepAt: computeNextStepAt(seq.sequenceType),
+          updatedAt: new Date(),
+        })
+        .where(eq(nurtureSequences.id, input.id))
+        .returning();
+
+      return updated!;
+    }),
 });

--- a/src/server/api/schemas/__tests__/nurture.test.ts
+++ b/src/server/api/schemas/__tests__/nurture.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, test } from "@rstest/core";
+import {
+  pauseSequenceSchema,
+  resumeSequenceSchema,
+  sequenceStatusSchema,
+  sequenceTypeSchema,
+  startSequenceSchema,
+} from "../nurture";
+
+describe("sequenceTypeSchema", () => {
+  test("accepts all four sequence types", () => {
+    for (const value of [
+      "discovery",
+      "nurture",
+      "warm_progression",
+      "lot_alert",
+    ]) {
+      expect(sequenceTypeSchema.safeParse(value).success).toBe(true);
+    }
+  });
+
+  test("rejects invalid sequence type", () => {
+    expect(sequenceTypeSchema.safeParse("hot").success).toBe(false);
+    expect(sequenceTypeSchema.safeParse("invalid").success).toBe(false);
+  });
+});
+
+describe("sequenceStatusSchema", () => {
+  test("accepts all three statuses", () => {
+    for (const value of ["active", "paused", "completed"]) {
+      expect(sequenceStatusSchema.safeParse(value).success).toBe(true);
+    }
+  });
+
+  test("rejects invalid status", () => {
+    expect(sequenceStatusSchema.safeParse("inactive").success).toBe(false);
+  });
+});
+
+describe("startSequenceSchema", () => {
+  test("accepts valid uuid and sequenceType", () => {
+    expect(
+      startSequenceSchema.safeParse({
+        leadId: "550e8400-e29b-41d4-a716-446655440000",
+        sequenceType: "nurture",
+      }).success,
+    ).toBe(true);
+  });
+
+  test("rejects non-uuid leadId", () => {
+    expect(
+      startSequenceSchema.safeParse({
+        leadId: "not-a-uuid",
+        sequenceType: "nurture",
+      }).success,
+    ).toBe(false);
+  });
+
+  test("rejects invalid sequenceType", () => {
+    expect(
+      startSequenceSchema.safeParse({
+        leadId: "550e8400-e29b-41d4-a716-446655440000",
+        sequenceType: "invalid",
+      }).success,
+    ).toBe(false);
+  });
+});
+
+describe("pauseSequenceSchema", () => {
+  test("accepts valid uuid", () => {
+    expect(
+      pauseSequenceSchema.safeParse({
+        id: "550e8400-e29b-41d4-a716-446655440000",
+      }).success,
+    ).toBe(true);
+  });
+
+  test("rejects non-uuid id", () => {
+    expect(pauseSequenceSchema.safeParse({ id: "not-a-uuid" }).success).toBe(
+      false,
+    );
+  });
+});
+
+describe("resumeSequenceSchema", () => {
+  test("accepts valid uuid", () => {
+    expect(
+      resumeSequenceSchema.safeParse({
+        id: "550e8400-e29b-41d4-a716-446655440000",
+      }).success,
+    ).toBe(true);
+  });
+
+  test("rejects non-uuid id", () => {
+    expect(resumeSequenceSchema.safeParse({ id: "not-a-uuid" }).success).toBe(
+      false,
+    );
+  });
+});

--- a/src/server/api/schemas/nurture.ts
+++ b/src/server/api/schemas/nurture.ts
@@ -1,0 +1,30 @@
+import { z } from "zod";
+
+// Enum schemas — mirror values from src/server/db/schema/enums.ts
+export const sequenceTypeSchema = z.enum([
+  "discovery",
+  "nurture",
+  "warm_progression",
+  "lot_alert",
+]);
+
+export const sequenceStatusSchema = z.enum(["active", "paused", "completed"]);
+
+export const startSequenceSchema = z.object({
+  leadId: z.string().uuid(),
+  sequenceType: sequenceTypeSchema,
+});
+
+export const pauseSequenceSchema = z.object({
+  id: z.string().uuid(),
+});
+
+export const resumeSequenceSchema = z.object({
+  id: z.string().uuid(),
+});
+
+export type SequenceType = z.infer<typeof sequenceTypeSchema>;
+export type SequenceStatus = z.infer<typeof sequenceStatusSchema>;
+export type StartSequence = z.infer<typeof startSequenceSchema>;
+export type PauseSequence = z.infer<typeof pauseSequenceSchema>;
+export type ResumeSequence = z.infer<typeof resumeSequenceSchema>;

--- a/src/server/db/schema/nurture-sequences.ts
+++ b/src/server/db/schema/nurture-sequences.ts
@@ -1,4 +1,11 @@
-import { index, pgTable, timestamp, uuid } from "drizzle-orm/pg-core";
+import { sql } from "drizzle-orm";
+import {
+  index,
+  pgTable,
+  timestamp,
+  uniqueIndex,
+  uuid,
+} from "drizzle-orm/pg-core";
 
 import { sequenceStatusEnum, sequenceTypeEnum } from "./enums";
 import { leads } from "./leads";
@@ -22,5 +29,8 @@ export const nurtureSequences = pgTable(
   },
   (table) => [
     index("nurture_sequences_lead_status_idx").on(table.leadId, table.status),
+    uniqueIndex("nurture_active_one_per_lead_uidx")
+      .on(table.leadId)
+      .where(sql`status = 'active'`),
   ],
 );

--- a/src/server/nurture/__tests__/scheduler.test.ts
+++ b/src/server/nurture/__tests__/scheduler.test.ts
@@ -1,0 +1,308 @@
+import { describe, expect, rs, test } from "@rstest/core";
+import {
+  CADENCE_DAYS,
+  computeNextStepAt,
+  runSchedulerTick,
+  SEQUENCE_TYPE_BY_STAGE,
+  startOrUpdateSequence,
+} from "../scheduler";
+
+const SEQ_ID = "550e8400-e29b-41d4-a716-446655440000";
+const LEAD_ID = "660e8400-e29b-41d4-a716-446655440001";
+
+const baseLead = {
+  id: LEAD_ID,
+  firstName: "Jane",
+  lastName: "Doe",
+  email: "jane@example.com",
+  phone: null,
+  hubspotContactId: null,
+  preferredContactTime: null,
+  hasLand: null,
+  landRegistered: null,
+  landAddress: null,
+  landSizeSqm: null,
+  landWidth: null,
+  landDepth: null,
+  propertyType: null,
+  budget: null,
+  seenBroker: null,
+  constructionTimeline: null,
+  leadScore: 0,
+  leadStage: "nurture" as const,
+  scoreMetadata: null,
+  preferredEstates: null,
+  preferredSuburbs: null,
+  leadSource: null,
+  referrerName: null,
+  notes: null,
+  resolveFinanceOptedIn: false,
+  createdAt: new Date("2026-04-01"),
+  updatedAt: new Date("2026-04-01"),
+  lastContactedAt: null,
+};
+
+const baseSeq = {
+  id: SEQ_ID,
+  leadId: LEAD_ID,
+  sequenceType: "nurture" as const,
+  status: "active" as const,
+  nextStepAt: new Date(Date.now() - 60_000),
+  createdAt: new Date("2026-04-01"),
+  updatedAt: new Date("2026-04-01"),
+};
+
+// --- computeNextStepAt ---
+
+describe("computeNextStepAt", () => {
+  test("discovery returns +3 days", () => {
+    const from = new Date("2026-04-21T00:00:00Z");
+    const result = computeNextStepAt("discovery", from);
+    expect(result.getTime()).toBe(from.getTime() + 3 * 86_400_000);
+  });
+
+  test("nurture returns +14 days", () => {
+    const from = new Date("2026-04-21T00:00:00Z");
+    const result = computeNextStepAt("nurture", from);
+    expect(result.getTime()).toBe(from.getTime() + 14 * 86_400_000);
+  });
+
+  test("warm_progression returns +7 days", () => {
+    const from = new Date("2026-04-21T00:00:00Z");
+    const result = computeNextStepAt("warm_progression", from);
+    expect(result.getTime()).toBe(from.getTime() + 7 * 86_400_000);
+  });
+
+  test("CADENCE_DAYS entries match computeNextStepAt output", () => {
+    const from = new Date("2026-04-21T00:00:00Z");
+    for (const [type, days] of Object.entries(CADENCE_DAYS)) {
+      const result = computeNextStepAt(type as keyof typeof CADENCE_DAYS, from);
+      expect(result.getTime()).toBe(from.getTime() + days * 86_400_000);
+    }
+  });
+});
+
+// --- SEQUENCE_TYPE_BY_STAGE ---
+
+describe("SEQUENCE_TYPE_BY_STAGE", () => {
+  test("hot maps to null", () => {
+    expect(SEQUENCE_TYPE_BY_STAGE.hot).toBeNull();
+  });
+
+  test("non-hot stages map to a valid sequenceType", () => {
+    expect(SEQUENCE_TYPE_BY_STAGE.unqualified).toBe("discovery");
+    expect(SEQUENCE_TYPE_BY_STAGE.nurture).toBe("nurture");
+    expect(SEQUENCE_TYPE_BY_STAGE.warm).toBe("warm_progression");
+  });
+});
+
+// --- runSchedulerTick ---
+
+describe("runSchedulerTick", () => {
+  function buildSelectMock(rows: unknown[]) {
+    const where = rs.fn().mockResolvedValue(rows);
+    const innerJoin = rs.fn().mockReturnValue({ where });
+    const from = rs.fn().mockReturnValue({ innerJoin });
+    const select = rs.fn().mockReturnValue({ from });
+    return { select, from, innerJoin, where };
+  }
+
+  function buildInsertMock() {
+    const values = rs.fn().mockResolvedValue([]);
+    const insert = rs.fn().mockReturnValue({ values });
+    return { insert, values };
+  }
+
+  function buildUpdateMock() {
+    const where = rs.fn().mockResolvedValue([]);
+    const set = rs.fn().mockReturnValue({ where });
+    const update = rs.fn().mockReturnValue({ set });
+    return { update, set, where };
+  }
+
+  test("returns { drafted: 0, failed: 0 } when no due sequences", async () => {
+    const { select } = buildSelectMock([]);
+    const mockDb = { select } as unknown as Parameters<
+      typeof runSchedulerTick
+    >[0];
+
+    const result = await runSchedulerTick(mockDb, rs.fn());
+    expect(result).toEqual({ drafted: 0, failed: 0 });
+  });
+
+  test("drafts a message and advances nextStepAt for each due sequence", async () => {
+    const { select } = buildSelectMock([{ seq: baseSeq, lead: baseLead }]);
+    const { insert, values } = buildInsertMock();
+    const { update, set } = buildUpdateMock();
+    const mockDb = { select, insert, update } as unknown as Parameters<
+      typeof runSchedulerTick
+    >[0];
+
+    const mockDraft = rs.fn().mockResolvedValue({
+      channel: "sms",
+      subject: null,
+      body: "Hi Jane",
+      aiReasoning: "reason",
+      priority: 5,
+    });
+
+    const result = await runSchedulerTick(mockDb, mockDraft);
+
+    expect(result).toEqual({ drafted: 1, failed: 0 });
+    expect(mockDraft).toHaveBeenCalledWith({ lead: baseLead });
+    expect(values).toHaveBeenCalledWith(
+      expect.objectContaining({
+        leadId: LEAD_ID,
+        channel: "sms",
+        body: "Hi Jane",
+        status: "pending",
+      }),
+    );
+    expect(set).toHaveBeenCalledWith(
+      expect.objectContaining({
+        nextStepAt: expect.any(Date),
+      }),
+    );
+  });
+
+  test("inserts message_queue row with status=pending", async () => {
+    const { select } = buildSelectMock([{ seq: baseSeq, lead: baseLead }]);
+    const { insert, values } = buildInsertMock();
+    const { update } = buildUpdateMock();
+    const mockDb = { select, insert, update } as unknown as Parameters<
+      typeof runSchedulerTick
+    >[0];
+
+    const mockDraft = rs.fn().mockResolvedValue({
+      channel: "email",
+      subject: "Follow up",
+      body: "Body",
+      aiReasoning: "reason",
+      priority: 3,
+    });
+
+    await runSchedulerTick(mockDb, mockDraft);
+
+    expect(values).toHaveBeenCalledWith(
+      expect.objectContaining({ status: "pending" }),
+    );
+  });
+
+  test("continues past a thrown draftMessage and still advances nextStepAt", async () => {
+    const { select } = buildSelectMock([{ seq: baseSeq, lead: baseLead }]);
+    const { insert } = buildInsertMock();
+    const { update, set } = buildUpdateMock();
+    const mockDb = { select, insert, update } as unknown as Parameters<
+      typeof runSchedulerTick
+    >[0];
+
+    const mockDraft = rs.fn().mockRejectedValue(new Error("Claude error"));
+
+    const result = await runSchedulerTick(mockDb, mockDraft);
+
+    expect(result).toEqual({ drafted: 0, failed: 1 });
+    // nextStepAt must still advance
+    expect(set).toHaveBeenCalledWith(
+      expect.objectContaining({ nextStepAt: expect.any(Date) }),
+    );
+    // No message_queue insert happened
+    expect(insert).not.toHaveBeenCalled();
+  });
+});
+
+// --- startOrUpdateSequence ---
+
+describe("startOrUpdateSequence", () => {
+  function buildInsertMock() {
+    const values = rs.fn().mockResolvedValue([]);
+    const insert = rs.fn().mockReturnValue({ values });
+    return { insert, values };
+  }
+
+  function buildUpdateMock() {
+    const where = rs.fn().mockResolvedValue([]);
+    const set = rs.fn().mockReturnValue({ where });
+    const update = rs.fn().mockReturnValue({ set });
+    return { update, set, where };
+  }
+
+  test("hot stage marks active sequence completed without inserting", async () => {
+    const { update, set, where } = buildUpdateMock();
+    const insert = rs.fn();
+    const mockDb = {
+      update,
+      insert,
+    } as unknown as Parameters<typeof startOrUpdateSequence>[0];
+
+    await startOrUpdateSequence(mockDb, LEAD_ID, "hot");
+
+    expect(set).toHaveBeenCalledWith(
+      expect.objectContaining({ status: "completed" }),
+    );
+    expect(where).toHaveBeenCalled();
+    expect(insert).not.toHaveBeenCalled();
+  });
+
+  test("inserts a new active sequence when none exists", async () => {
+    const { insert, values } = buildInsertMock();
+    const findFirst = rs.fn().mockResolvedValue(undefined);
+    const mockDb = {
+      insert,
+      query: { nurtureSequences: { findFirst } },
+    } as unknown as Parameters<typeof startOrUpdateSequence>[0];
+
+    await startOrUpdateSequence(mockDb, LEAD_ID, "nurture");
+
+    expect(values).toHaveBeenCalledWith(
+      expect.objectContaining({
+        leadId: LEAD_ID,
+        sequenceType: "nurture",
+        status: "active",
+        nextStepAt: expect.any(Date),
+      }),
+    );
+  });
+
+  test("updates sequenceType and nextStepAt when stage changes", async () => {
+    const existingSeq = {
+      ...baseSeq,
+      sequenceType: "nurture" as const,
+    };
+    const findFirst = rs.fn().mockResolvedValue(existingSeq);
+    const { update, set, where } = buildUpdateMock();
+    const mockDb = {
+      update,
+      query: { nurtureSequences: { findFirst } },
+    } as unknown as Parameters<typeof startOrUpdateSequence>[0];
+
+    await startOrUpdateSequence(mockDb, LEAD_ID, "warm");
+
+    expect(set).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sequenceType: "warm_progression",
+        nextStepAt: expect.any(Date),
+      }),
+    );
+    expect(where).toHaveBeenCalled();
+  });
+
+  test("no-ops when existing sequence type already matches", async () => {
+    const existingSeq = {
+      ...baseSeq,
+      sequenceType: "nurture" as const,
+    };
+    const findFirst = rs.fn().mockResolvedValue(existingSeq);
+    const update = rs.fn();
+    const insert = rs.fn();
+    const mockDb = {
+      update,
+      insert,
+      query: { nurtureSequences: { findFirst } },
+    } as unknown as Parameters<typeof startOrUpdateSequence>[0];
+
+    await startOrUpdateSequence(mockDb, LEAD_ID, "nurture");
+
+    expect(update).not.toHaveBeenCalled();
+    expect(insert).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/nurture/scheduler.ts
+++ b/src/server/nurture/scheduler.ts
@@ -1,0 +1,136 @@
+import { and, eq, sql } from "drizzle-orm";
+
+import type { DraftMessageInput, DraftMessageOutput } from "~/server/ai/schema";
+import type { SequenceType } from "~/server/api/schemas/nurture";
+import { leads, messageQueue, nurtureSequences } from "~/server/db/schema";
+
+type Db = typeof import("~/server/db").db;
+type LeadStage = "unqualified" | "nurture" | "warm" | "hot";
+type DraftFn = (input: DraftMessageInput) => Promise<DraftMessageOutput>;
+
+export const SEQUENCE_TYPE_BY_STAGE: Record<LeadStage, SequenceType | null> = {
+  unqualified: "discovery",
+  nurture: "nurture",
+  warm: "warm_progression",
+  hot: null,
+};
+
+export const CADENCE_DAYS: Record<SequenceType, number> = {
+  discovery: 3,
+  nurture: 14,
+  warm_progression: 7,
+  lot_alert: 7,
+};
+
+const MS_PER_DAY = 86_400_000;
+
+export function computeNextStepAt(
+  sequenceType: SequenceType,
+  from = new Date(),
+): Date {
+  return new Date(from.getTime() + CADENCE_DAYS[sequenceType] * MS_PER_DAY);
+}
+
+export async function startOrUpdateSequence(
+  db: Db,
+  leadId: string,
+  stage: LeadStage,
+): Promise<void> {
+  if (stage === "hot") {
+    await db
+      .update(nurtureSequences)
+      .set({ status: "completed", nextStepAt: null, updatedAt: new Date() })
+      .where(
+        and(
+          eq(nurtureSequences.leadId, leadId),
+          eq(nurtureSequences.status, "active"),
+        ),
+      );
+    return;
+  }
+
+  const sequenceType = SEQUENCE_TYPE_BY_STAGE[stage]!;
+
+  const existing = await db.query.nurtureSequences.findFirst({
+    where: and(
+      eq(nurtureSequences.leadId, leadId),
+      eq(nurtureSequences.status, "active"),
+    ),
+  });
+
+  if (!existing) {
+    await db.insert(nurtureSequences).values({
+      leadId,
+      sequenceType,
+      status: "active",
+      nextStepAt: computeNextStepAt(sequenceType),
+    });
+    return;
+  }
+
+  if (existing.sequenceType !== sequenceType) {
+    await db
+      .update(nurtureSequences)
+      .set({
+        sequenceType,
+        nextStepAt: computeNextStepAt(sequenceType),
+        updatedAt: new Date(),
+      })
+      .where(eq(nurtureSequences.id, existing.id));
+  }
+}
+
+export async function runSchedulerTick(
+  db: Db,
+  draftFn?: DraftFn,
+): Promise<{ drafted: number; failed: number }> {
+  const draft =
+    draftFn ?? (await import("~/server/ai/draft-message")).draftMessage;
+
+  const dueRows = await db
+    .select({ seq: nurtureSequences, lead: leads })
+    .from(nurtureSequences)
+    .innerJoin(leads, eq(nurtureSequences.leadId, leads.id))
+    .where(
+      and(
+        eq(nurtureSequences.status, "active"),
+        sql`${nurtureSequences.nextStepAt} <= now()`,
+      ),
+    );
+
+  let drafted = 0;
+  let failed = 0;
+
+  for (const { seq, lead } of dueRows) {
+    try {
+      const result = await draft({ lead });
+      await db.insert(messageQueue).values({
+        leadId: lead.id,
+        channel: result.channel,
+        subject: result.subject,
+        body: result.body,
+        aiReasoning: result.aiReasoning,
+        priority: result.priority,
+        status: "pending",
+      });
+      drafted++;
+    } catch (err) {
+      console.error(
+        `[nurture-scheduler] draftMessage failed for sequence ${seq.id}:`,
+        err,
+      );
+      failed++;
+    }
+
+    // Always advance nextStepAt — prevents a failing row from blocking the tick
+    await db
+      .update(nurtureSequences)
+      .set({
+        nextStepAt: computeNextStepAt(seq.sequenceType),
+        updatedAt: new Date(),
+      })
+      .where(eq(nurtureSequences.id, seq.id));
+  }
+
+  return { drafted, failed };
+}

--- a/thoughts/designs/2026-04-21-nurture-scheduler-e2e.md
+++ b/thoughts/designs/2026-04-21-nurture-scheduler-e2e.md
@@ -1,0 +1,137 @@
+---
+date: 2026-04-21
+topic: E2E test coverage for the nurture scheduler flow
+status: design
+related:
+  - PR #147 (feat/132-nurture-scheduler)
+  - Issue #132
+---
+
+# Nurture scheduler — end-to-end test design
+
+## Problem
+
+PR #147 ships the nurture scheduler (auto-start on lead create/update, daily Vercel Cron that drafts messages into `message_queue`, partial unique index on `nurture_sequences(lead_id) WHERE status='active'`). The PR has two unchecked acceptance criteria that both hinge on `yarn db:migrate` having been run:
+
+- Drafts appear in the action queue once the migration runs.
+- Manual: age a sequence forward via `POST /api/dev/nurture/advance`, run the cron, confirm a draft appears in the action queue.
+
+Current E2E coverage does not exercise any of this. `leads.create` and `leads.update` wrap `startOrUpdateSequence` in `.catch()` (`src/server/api/routers/leads.ts:142`, `:270`), so a missing migration or broken nurture wiring does not surface through the normal lead-create path — lead creation returns 200 regardless. No existing spec hits the cron route, and the unit tests for the scheduler and cron route both mock `draftFn` and the DB, so they cannot catch migration drift, bearer-auth wiring, or the UI read path.
+
+The test gap this design closes: **prove, on every PR, that (1) the migration has been applied, (2) auto-start writes a real `nurture_sequences` row, (3) the cron route authorizes correctly and drafts a pending message, and (4) the draft renders in the action queue UI.**
+
+## Scope
+
+**In scope.** A Playwright E2E spec covering the full flow from lead create through cron invocation to action-queue render. A small AI-stub mechanism driven by a request header so the test does not burn Anthropic tokens per run. Helper functions for DB-level seeding and assertion of `nurture_sequences`/`message_queue`. A CI wiring change that runs `yarn db:migrate` before the Playwright web server boots.
+
+**Out of scope.** Real-LLM smoke tests and offline/online evaluation suites — deferred to a separate ticket that will cover local, CI, and synthetic monitoring against production. Neon per-PR branch infrastructure — deferred unless cross-PR flake emerges on the shared preview DB. Rate-limiting of the `x-ai-stub` header beyond the existing `CRON_SECRET` gating — flagged as a known gap.
+
+## Approach
+
+Vertical-slice E2E: one spec, three tests, exercises UI + backend + DB + cron HTTP + UI together. The spec follows the existing `e2e/features/action-queue.spec.ts` pattern (direct Neon DB helpers, cookie-based auth via `createTestSession`, per-spec cleanup plus global teardown marker). The cron route is invoked directly from Playwright using `playwright.request.newContext()` with a bearer header — this is Vercel's canonical way to trigger cron in a test, since Vercel itself only fires cron on production deployments.
+
+The migration is asserted *implicitly*: if the table or the partial unique index is missing, the first test's DB assertion that a `nurture_sequences` row exists will fail. No separate meta-inspection step is needed.
+
+## AI stub mechanism
+
+The cron route currently calls `runSchedulerTick(db)` with no second argument (`src/app/api/cron/nurture-scheduler/route.ts:15`), so `draftMessage` always hits Anthropic. We add a generic `x-ai-stub` request header that any AI-touching route honours when the caller is already authenticated.
+
+**New file: `src/server/ai/stub.ts`**
+
+Exports `resolveDraftFn(req: Request): DraftFn | undefined`. Reads `x-ai-stub` off the incoming request. Returns `undefined` when absent (callers fall back to real `draftMessage`). Returns a deterministic stub when the header is `"1"`.
+
+The helper does not enforce auth — it trusts the route to gate first, then pass the request in. This keeps per-route auth logic centralised (cron routes gate on `CRON_SECRET`; user-facing routes will gate on admin session). The stub re-uses real `selectChannel(lead)` and `computePriority(lead)` so lead-shape-dependent branching is still exercised; only the LLM token-generation is faked.
+
+**Stub shape:**
+
+```
+channel: selectChannel(lead)
+subject: channel === 'sms' ? null : '[ai-stub] subject'
+body:    `[ai-stub] body for ${lead.id}`
+aiReasoning: '[ai-stub]'
+priority: computePriority(lead)
+```
+
+**Route wiring.** `src/app/api/cron/nurture-scheduler/route.ts:15` changes from `runSchedulerTick(db)` to:
+
+```ts
+const draftFn = resolveDraftFn(req);
+const result = await runSchedulerTick(db, draftFn);
+```
+
+No other route changes in this ticket. When future AI-touching routes land they adopt the same two-line pattern.
+
+**Observability.** Every stubbed invocation logs `[ai-stub] route=/api/cron/nurture-scheduler leadId=<id>` at info level. The `[ai-stub]` prefix in `body`/`aiReasoning` is the durable audit trail on the row itself — ops can `SELECT count(*) FROM message_queue WHERE body LIKE '[ai-stub]%'` to measure stub traffic in production if the header is ever abused.
+
+**Production safety.** The header is only honoured when the request is already authenticated by the route's own auth. Anonymous `x-ai-stub: 1` requests are ignored. `CRON_SECRET` secrecy is the primary gate — same surface as the cron route itself.
+
+## E2E test structure
+
+**New spec: `e2e/features/nurture-scheduler.spec.ts`**
+
+Guarded by `test.skip(!process.env.DATABASE_URL, 'DB required')`. `createTestSession` in `beforeAll`, `deleteTestSession` in `afterAll`. Lead/sequence/message IDs collected during each test and cleaned up in `afterEach`.
+
+**Test 1 — Auto-start on lead create (migration gate).**
+
+Flow: UI navigates to `/leads/new`, fills the form with `firstName: 'Nurture'` and `email: e2e-<uuid>@test.rekurve.dev`, submits. After submission, resolve the new lead's ID via the existing `getLeadIdByPhone` helper pattern. Assert `getActiveSequenceByLead(leadId)` returns `{ sequenceType: 'discovery', nextStepAt: <~3 days out> }`.
+
+**This is the migration gate.** If the `nurture_sequences` table, `sequence_type_enum`/`sequence_status_enum`, or the partial unique index is missing, the `INSERT` inside `startOrUpdateSequence` either throws (caught and swallowed) or succeeds but the row shape doesn't match — either way the assertion fails with a clear message. The `.catch()` in `leads.create` stays untouched; we rely on the DB assertion to surface the failure, not on lead-create erroring out. This preserves the intended production behaviour where lead creation does not break if nurture infra is degraded.
+
+**Test 2 — Cron drafts a pending message.**
+
+Flow: seed a lead + active sequence directly via DB helpers (skip HubSpot round-trip for speed). `POST /api/dev/nurture/advance` with `{ sequenceId }` via Playwright's per-test `request` fixture to backdate `nextStepAt` by one minute. `GET /api/cron/nurture-scheduler` via `playwright.request.newContext({ extraHTTPHeaders: { Authorization: 'Bearer <CRON_SECRET>', 'x-ai-stub': '1', 'x-vercel-protection-bypass': <bypass> } })`. Assert response status 200 and body `{ drafted: 1, failed: 0 }`. Poll `getPendingMessagesByLead(leadId)` (2s interval, 10s timeout) until a row exists; assert `status === 'pending'` and `body` starts with `[ai-stub]`.
+
+The cron response assertion runs *before* the DB read, so a count mismatch surfaces at the API layer before the DB assertion muddies the signal.
+
+**Test 3 — Action queue renders the draft.**
+
+Continuation of Test 2 (same seeded lead and message). Navigate to `/dashboard`. Assert `queue-row-<messageId>` is visible. Assert `queue-row-body-<messageId>` contains the stubbed body substring. Exercises the tRPC read path, the dashboard render, and the per-row `data-testid` wiring (`src/app/(application)/dashboard/_components/draft-row.tsx:39`).
+
+## Helpers
+
+**New file: `e2e/utils/nurture-helper.ts`**
+
+- `seedActiveSequence({ leadId, sequenceType, nextStepAt })` — direct Neon `INSERT` into `nurture_sequences`.
+- `getActiveSequenceByLead(leadId)` — returns `{ id, sequenceType, nextStepAt } | null`.
+- `getPendingMessagesByLead(leadId)` — returns an array of message rows scoped to the lead; used both for row-existence assertion and for resolving the message ID for UI locators.
+- `waitForPendingMessage(leadId, { intervalMs: 2000, timeoutMs: 10000 })` — polling wrapper over `getPendingMessagesByLead`, modeled on `waitForLeadField` in `e2e/utils/hubspot-helper.ts:235`.
+- `cleanupSequences(ids: string[])` — scoped DELETE.
+- `cronRequestContext()` — returns a pre-configured `APIRequestContext` with `Authorization: Bearer <CRON_SECRET>`, `x-ai-stub: 1`, and `x-vercel-protection-bypass` (matching the existing `playwright.config.ts:33-39` pattern). Caller is responsible for `ctx.dispose()`.
+
+**Append `"Nurture"` to `TEST_FIRST_NAMES`** in `e2e/utils/hubspot-helper.ts:112` and `e2e/utils/auth-helper.ts:99` so global teardown sweeps any leaked rows.
+
+## Environment and CI wiring
+
+- `CRON_SECRET` must be available to the Playwright process. Add it to the CI workflow env block and to `playwright.config.ts` env passthrough.
+- `playwright.config.ts:46-50` — change `webServer.command` from `rm -rf .next/ && yarn preview` to `rm -rf .next/ && yarn db:migrate && yarn preview`. Migrations run against whatever `DATABASE_URL` the environment provides. Local developers are unaffected — they already run migrations manually and `reuseExistingServer` prevents re-runs mid-session.
+- If the pooled Neon connection produces read-after-write visibility gaps, the `waitForPendingMessage` poll absorbs it. If flake persists, switch the DB helpers to `DATABASE_URL_UNPOOLED`.
+
+## Error handling and resilience
+
+- Cron response assertion precedes DB assertion; layered failure surface.
+- Polling with 10s ceiling on DB reads; no indefinite waits.
+- Each test generates a fresh lead ID; no shared mutable state between tests. Serial mode not needed.
+- `afterEach` cleanup is scoped to IDs collected during the test. Global teardown is the backstop via the `Nurture` first-name marker and `e2e-*@test.rekurve.dev` email pattern.
+- The `.catch()` swallow in `leads.create` / `leads.update` stays. The DB assertion is the correct signal here — we explicitly do not want a flaky nurture backend to start blocking production lead creation.
+
+## Known gaps and follow-ups
+
+- **No per-request rate limit on `x-ai-stub`.** A leaked `CRON_SECRET` could flood `message_queue` with stub rows. Addressed at the `CRON_SECRET` auth layer rather than per-header; tracked as a broader secrets-hygiene concern.
+- **No real-LLM smoke test.** Deferred to the eval-suite ticket (offline + CI + synthetic monitoring against production).
+- **Shared preview DB.** Concurrent PR runs rely on ID-scoped cleanup + unique lead markers. If cross-PR flake emerges, adopt Neon per-PR branching per the pattern in `neondatabase/neon-playwright-example`.
+- **`page.route()` not usable for server-side LLM calls.** Documented here so nobody reaches for it in future AI-path tests; the `x-ai-stub` header pattern is the convention.
+
+## References
+
+- `src/app/api/cron/nurture-scheduler/route.ts:15` — cron route call site (to be modified)
+- `src/server/nurture/scheduler.ts:83` — `runSchedulerTick(db, draftFn?)` existing injectable seam
+- `src/server/api/routers/leads.ts:142,270` — `.catch()` swallow points
+- `src/app/(application)/dashboard/_components/draft-row.tsx:39` — per-row `data-testid`
+- `e2e/features/action-queue.spec.ts` — closest existing pattern
+- `e2e/utils/messages-helper.ts` — Neon client pattern
+- `e2e/utils/auth-helper.ts:39` — `createTestSession`
+- `e2e/utils/hubspot-helper.ts:235` — polling pattern
+- `playwright.config.ts:33-39,46-50` — protection-bypass header wiring, web server config
+- Vercel — [Managing Cron Jobs](https://vercel.com/docs/cron-jobs/manage-cron-jobs)
+- Neon — [E2E Playwright Tests with Neon Branching](https://neon.com/guides/e2e-playwright-tests-with-neon-branching)
+- Playwright — [API Testing / APIRequestContext](https://playwright.dev/docs/api-testing)

--- a/thoughts/plans/2026-04-20-ENG-132-nurture-scheduler.md
+++ b/thoughts/plans/2026-04-20-ENG-132-nurture-scheduler.md
@@ -1,0 +1,121 @@
+# Nurture Scheduler + `nurture` tRPC Router Implementation Plan
+
+## Context
+The action queue only fills when the consultant manually captures or edits leads. Without a nurture scheduler, warm/nurture leads go cold between touches, defeating the core follow-up-compliance value of Epic 3. This ticket fleshes out the `nurture` tRPC router (currently a 7-line stub at `src/server/api/routers/nurture.ts:1`), adds a background scheduler that queries due sequences and inserts drafts into `message_queue` on cadence, and wires auto-start/stop into the leads flow so every new or re-scored lead gets a stage-appropriate sequence without manual action.
+
+## Current State
+- **Nurture router stub** — `src/server/api/routers/nurture.ts:3-7` exposes a single `getActive` query returning `[]`. Registered in `src/server/api/root.ts:13` as `nurture`.
+- **Schema ready** — `nurture_sequences` table exists at `src/server/db/schema/nurture-sequences.ts:6-26` with `leadId`, `sequenceType`, `status` (default `"active"`), `nextStepAt` (nullable timestamptz), and a `(leadId, status)` index. Enums `sequenceTypeEnum` (`discovery|nurture|warm_progression|lot_alert`) and `sequenceStatusEnum` (`active|paused|completed`) live at `src/server/db/schema/enums.ts:89-100`.
+- **Lead stage enum** — `src/server/db/schema/enums.ts:25-30` defines `unqualified|nurture|warm|hot`.
+- **Draft helper landed** — `draftMessage(input)` at `src/server/ai/draft-message.ts:20-70` returns `{ channel, subject, body, aiReasoning, priority }` and already primes Claude's prompt cache with `cache_control: { type: "ephemeral" }` (line 48), so sequential calls within one scheduler tick amortize the system prompt.
+- **Message insertion path** — `message_queue` schema at `src/server/db/schema/message-queue.ts` accepts `leadId, channel, subject, body, aiReasoning, priority, status` (default `"pending"`); the messages router at `src/server/api/routers/messages.ts:37-136` exposes no insert procedure — drafts are inserted server-side only, which the scheduler will do directly via `ctx.db.insert(messageQueue)`.
+- **Lead create hook point** — `leadsRouter.create` at `src/server/api/routers/leads.ts:138` returns `await scoreLead(...)`. Auto-start must run between `scoreLead()` and the return.
+- **Lead re-score hook point** — `leadsRouter.update` at `src/server/api/routers/leads.ts:251-253` calls `scoreLead()` when any field in `SCORING_FIELDS` (lines 64-77) changes. Stage-change handler attaches here.
+- **No cron infrastructure** — no `vercel.json` in repo root; no `src/app/api/cron/` directory; no `CRON_SECRET` in `src/env.js:9-32`. Must be added.
+- **Test conventions** — rstest (`@rstest/core`). Server modules tested by direct call (`src/server/scoring/__tests__/qualify-and-score.test.ts:1-10`). Routers tested via `createCaller` with `rs.doMock()` for `~/env`, `~/lib/session`, `~/server/db` (`src/server/api/__tests__/messages-router.test.ts:26-57`). Schemas tested in `src/server/api/schemas/__tests__/`.
+
+## Desired End State
+- `nurture` router exposes `listActive`, `startSequence`, `pauseSequence`, `resumeSequence`; the `getActive` stub is removed.
+- Every new lead created via `leadsRouter.create` gets exactly one active `nurture_sequences` row whose `sequenceType` matches the post-scoring stage (unqualified→`discovery`, nurture→`nurture`, warm→`warm_progression`); `hot` gets no sequence.
+- Stage transitions via `leadsRouter.update` update `sequenceType` and recompute `nextStepAt`; transitions into `hot` complete the sequence.
+- Partial unique index `nurture_active_one_per_lead_uidx ON (lead_id) WHERE status = 'active'` prevents duplicate active sequences at the DB level.
+- A Vercel Cron-triggered route `GET /api/cron/nurture-scheduler` (authenticated via `CRON_SECRET`) runs every 15 minutes, queries `status='active' AND nextStepAt <= now()`, and for each due row: calls `draftMessage(lead)` sequentially, inserts the result into `message_queue` with `status='pending'`, and advances `nextStepAt` by the stage-specific cadence (3/14/7 days).
+- A dev-only helper `POST /api/dev/nurture/advance` sets `nextStepAt = now() - 1 minute` for a given sequence id, gated by `NODE_ENV !== "production"`, so the scheduler can be manually triggered end-to-end in staging.
+- Drafts inserted by the scheduler are visible in the action queue (`messages.listPending`) because the insert uses `status='pending'` and null `snoozedUntil`.
+
+## Out of Scope
+- Sequence analytics, open/click tracking, or touchpoint history beyond what `nurture_sequences` already stores.
+- Lot-alert nurture (`sequenceTypeEnum` value `lot_alert`) — belongs to a separate matching flow.
+- Any UI for the nurture router (no page, no action-queue tab) — consumption is via the existing action queue (#128).
+- Retry/backoff semantics for `draftMessage` failures — failures are logged and the sequence's `nextStepAt` still advances to avoid a poison row blocking the whole tick.
+- Idempotency keys on `message_queue` inserts — out-of-tick dedup is not required because the scheduler only inserts after advancing `nextStepAt`.
+- Concurrency control across simultaneous cron invocations — Vercel Cron guarantees serial firing per path, which is sufficient.
+
+## Approach
+Two vertical slices. **Slice 1** builds the cadence logic, state transitions, and router procedures as a pure module (`src/server/nurture/scheduler.ts`) plus a thin tRPC surface, with a partial unique index migration for the active-per-lead invariant. **Slice 2** wires auto-start/stop into `leadsRouter.create`/`update` and adds the Vercel Cron route, the dev-advance route, and the `CRON_SECRET` env var. Tests ship inside each slice per `tdd` skill. Sequencing is strict: the scheduler module is pure and the only async I/O is DB reads/writes plus the existing `draftMessage()` call, so it can be unit-tested without mocking Claude.
+
+## Phase 1: Nurture core — schemas, router, scheduler module, migration
+
+### Changes
+- `src/server/api/schemas/nurture.ts` — new: export `startSequenceSchema` (`{ leadId: uuid, sequenceType: sequenceTypeSchema }`), `pauseSequenceSchema` (`{ id: uuid }`), `resumeSequenceSchema` (`{ id: uuid }`), `sequenceTypeSchema` enum mirroring `sequenceTypeEnum` from `src/server/db/schema/enums.ts:89-94`, `sequenceStatusSchema` mirroring lines 96-100. Follow the enum-mirroring pattern in `src/server/api/schemas/leads.ts:5-39`.
+- `src/server/api/schemas/__tests__/nurture.test.ts` — new: rejects non-uuid ids, rejects invalid enum values, accepts all four `sequenceType` values, accepts all three `sequenceStatus` values. Mirror `src/server/api/schemas/__tests__/leads.test.ts` style.
+- `src/server/nurture/scheduler.ts` — new: pure business-logic module.
+  - `SEQUENCE_TYPE_BY_STAGE: Record<LeadStage, SequenceType | null>` = `{ unqualified: "discovery", nurture: "nurture", warm: "warm_progression", hot: null }`.
+  - `CADENCE_DAYS: Record<SequenceType, number>` = `{ discovery: 3, nurture: 14, warm_progression: 7, lot_alert: 7 }` (lot_alert unused here but included for completeness).
+  - `computeNextStepAt(sequenceType: SequenceType, from: Date = new Date()): Date` — pure.
+  - `startOrUpdateSequence(db, leadId, stage): Promise<void>` — encapsulates "given a post-scoring stage, transition this lead's sequence to the right state": if `stage === 'hot'`, mark any active sequence `completed`; else upsert an active sequence (insert if none, update `sequenceType` + `nextStepAt` if existing sequenceType differs).
+  - `runSchedulerTick(db): Promise<{ drafted: number; failed: number }>` — query `nurture_sequences` join `leads` where `status='active' AND nextStepAt <= now()`; for each row, call `draftMessage({ lead })`, insert `message_queue` row with `status='pending'`, advance `nextStepAt = computeNextStepAt(sequenceType)`, update `updatedAt`. Sequential loop (not `Promise.all`) to amortize the Claude prompt cache. Per-row try/catch: log error, still advance `nextStepAt` so one bad row doesn't block the tick. Returns counts for logging.
+- `src/server/nurture/__tests__/scheduler.test.ts` — new: rstest, direct-call style. Cover:
+  - `computeNextStepAt` returns +3/+14/+7 days for the three real sequence types.
+  - `SEQUENCE_TYPE_BY_STAGE.hot === null`.
+  - `runSchedulerTick` skips sequences where `nextStepAt > now()`.
+  - `runSchedulerTick` advances `nextStepAt` and inserts a `message_queue` row with `status='pending'` for each due sequence (mock `draftMessage`).
+  - `runSchedulerTick` continues past a thrown `draftMessage` and still advances `nextStepAt` on the failed row.
+  - `startOrUpdateSequence('hot')` marks any active sequence `completed` and does not insert.
+  - `startOrUpdateSequence('nurture')` when no row exists inserts one with the right `sequenceType` and `nextStepAt`.
+  - `startOrUpdateSequence('warm')` when an existing `nurture` sequence is active updates `sequenceType` to `warm_progression` and recomputes `nextStepAt`.
+- `src/server/api/routers/nurture.ts` — rewrite: replace `getActive` stub with:
+  - `listActive` — `ctx.db.query.nurtureSequences.findMany({ where: eq(status, 'active'), with: { lead: true } })`. Since `protectedProcedure` already scopes to the authenticated user but `nurture_sequences` has no direct user column, the scope is "all leads in the tenant" (same pattern as `leads.list` at `src/server/api/routers/leads.ts:153-206`, which also returns all leads without a user filter).
+  - `startSequence` — validates input with `startSequenceSchema`; rejects if an active sequence already exists for the lead (returns `BAD_REQUEST`); otherwise inserts with `nextStepAt = computeNextStepAt(sequenceType)`.
+  - `pauseSequence` — loads by id; rejects if status is not `active` (`BAD_REQUEST`); updates to `status='paused'` and clears `nextStepAt`.
+  - `resumeSequence` — loads by id; rejects if status is not `paused`; updates `status='active'` and `nextStepAt = computeNextStepAt(row.sequenceType)` (from-now, per ticket "recompute").
+- `src/server/api/__tests__/nurture-router.test.ts` — new: mirror `messages-router.test.ts:1-100` setup (mock `~/env`, `~/lib/session`, `~/server/db`, `createCaller`). Cover:
+  - `listActive` returns only active rows.
+  - `startSequence` rejects duplicate active (`BAD_REQUEST`).
+  - `pauseSequence` transitions active→paused and nulls `nextStepAt`; rejects from non-active state.
+  - `resumeSequence` transitions paused→active and sets `nextStepAt` to a future date; rejects from non-paused state.
+- `src/server/db/schema/nurture-sequences.ts` — edit lines 22-26: add partial unique index `uniqueIndex("nurture_active_one_per_lead_uidx").on(table.leadId).where(sql\`status = 'active'\`)` alongside the existing index.
+- `drizzle/NNNN_add_nurture_active_unique.sql` — new migration: `CREATE UNIQUE INDEX "nurture_active_one_per_lead_uidx" ON "nurture_sequences" ("lead_id") WHERE "status" = 'active';`. Generated via `yarn db:generate` (per CLAUDE.md — never use `drizzle-kit push`).
+
+### Success
+**Automated**
+- [x] `make check` passes
+- [x] `make test` passes (new tests: `nurture.test.ts`, `scheduler.test.ts`, `nurture-router.test.ts`)
+- [x] `make build` passes
+
+**Manual**
+- [ ] Run `yarn db:migrate`; verify partial index exists via `\d nurture_sequences` in a `psql` session.
+- [ ] Insert two `active` rows for the same `lead_id` manually — second insert fails with unique violation.
+- [ ] Via a local tRPC caller, call `nurture.startSequence` twice for the same lead — second call returns `BAD_REQUEST`.
+
+## Phase 2: Auto-start wiring + cron + dev helper
+
+### Changes
+- `src/env.js` — edit line 30 area: add `CRON_SECRET: z.string().min(16)` to `server` block and to `runtimeEnv` (lines 48-62). Marks it required in prod; document in a follow-up env-setup note that Vercel Cron auto-sets this.
+- `src/server/api/routers/leads.ts` — edit:
+  - Import `startOrUpdateSequence` from `~/server/nurture/scheduler`.
+  - Line 138 (`create`): after `scoreLead(...)` returns the scored lead, call `await startOrUpdateSequence(ctx.db, scored.id, scored.leadStage)` before returning. Wrap in try/catch that logs and swallows so nurture failure cannot block lead create (same philosophy as the HubSpot push at lines 55-57).
+  - Lines 251-253 (`update`): when `hasQualificationChange` is true, after `scoreLead()` returns the re-scored lead, call `startOrUpdateSequence(ctx.db, scored.id, scored.leadStage)` with the same try/catch/log wrapper.
+- `src/server/api/__tests__/leads-router.test.ts` — edit: add two tests.
+  - `create` auto-starts a nurture sequence for an unqualified/nurture/warm stage lead (mock `startOrUpdateSequence`, assert called with post-scoring stage).
+  - `update` with a qualification-field change calls `startOrUpdateSequence` with the new stage.
+- `src/app/api/cron/nurture-scheduler/route.ts` — new: Next.js route handler, `GET`. Validates `Authorization: Bearer ${env.CRON_SECRET}` header (Vercel Cron sets this automatically). Calls `runSchedulerTick(db)`. Returns `{ drafted, failed }` JSON. Marks the route `export const dynamic = "force-dynamic"` to prevent static optimization.
+- `src/app/api/cron/nurture-scheduler/__tests__/route.test.ts` — new: unit-test the handler with a mocked `runSchedulerTick` and verify auth-header enforcement (401 without header, 200 with correct bearer).
+- `src/app/api/dev/nurture/advance/route.ts` — new: `POST` with `{ sequenceId: uuid }`. Returns 404 when `env.NODE_ENV === "production"`. Sets `nextStepAt = new Date(Date.now() - 60_000)` on the target sequence. Follows the pattern of `src/app/api/dev/session/` (already in repo per directory listing).
+- `vercel.json` — new: root-level `{ "crons": [{ "path": "/api/cron/nurture-scheduler", "schedule": "*/15 * * * *" }] }`. Every 15 minutes gives near-real-time nurture without burning API quota.
+
+### Success
+**Automated**
+- [x] `make check` passes
+- [x] `make test` passes (new route tests; updated leads-router tests)
+- [x] `make build` passes
+
+**Manual**
+- [ ] Create a new lead via the UI with qualification data that lands in the `nurture` stage. In the DB, confirm exactly one `nurture_sequences` row exists for that lead with `sequenceType='nurture'`, `status='active'`, `nextStepAt` ≈ now + 14 days.
+- [ ] Update the same lead's qualification to land in `warm`. Confirm the existing row's `sequenceType` becomes `warm_progression` and `nextStepAt` becomes ≈ now + 7 days (no new row).
+- [ ] Update the lead again to land in `hot`. Confirm the row's `status` becomes `completed` and `nextStepAt` is null/ignored.
+- [ ] Start a fresh `nurture`-stage lead, `POST /api/dev/nurture/advance` with that sequence id, then `GET /api/cron/nurture-scheduler` with the `Authorization: Bearer ${CRON_SECRET}` header. Confirm: (a) a new `message_queue` row with `status='pending'` for that lead, (b) sequence's `nextStepAt` advanced by 14 days, (c) row visible in the action queue view at `/dashboard`.
+- [ ] Pause the sequence via `nurture.pauseSequence`; re-run `/api/cron/nurture-scheduler`; confirm no new draft inserted.
+- [ ] Resume; confirm `nextStepAt` is set to ≈ now + 14 days; re-run cron; confirm new draft.
+- [ ] Hit `/api/cron/nurture-scheduler` with no Authorization header → 401. With wrong bearer → 401. With correct bearer but no due sequences → 200 with `{ drafted: 0, failed: 0 }`.
+
+## References
+- Ticket: https://github.com/samjmarshall/rekurve/issues/132
+- Epic: https://github.com/samjmarshall/rekurve/issues/87
+- Prior plans (pattern): `thoughts/plans/2026-04-13-ENG-127-draft-message.md`, `thoughts/plans/2026-04-12-ENG-126-messages-router.md`
+- Schema: `src/server/db/schema/nurture-sequences.ts:6-26`, `src/server/db/schema/message-queue.ts`, `src/server/db/schema/enums.ts:25-30,89-100`
+- Draft helper: `src/server/ai/draft-message.ts:20-70`
+- Lead hook points: `src/server/api/routers/leads.ts:138,251-253`; scoring side-effect model: `src/server/api/routers/leads.ts:29-61`
+- Router patterns: `src/server/api/routers/leads.ts:79-300`, `src/server/api/routers/messages.ts:37-136`
+- Test patterns: `src/server/api/__tests__/messages-router.test.ts:1-100`, `src/server/scoring/__tests__/qualify-and-score.test.ts:1-10`
+- Migration workflow: `CLAUDE.md` "Database Migrations" section — always `yarn db:generate` + `yarn db:migrate`

--- a/thoughts/plans/2026-04-21-ENG-132-nurture-scheduler-e2e.md
+++ b/thoughts/plans/2026-04-21-ENG-132-nurture-scheduler-e2e.md
@@ -1,0 +1,173 @@
+# Nurture Scheduler E2E Coverage Implementation Plan
+
+## Context
+PR #147 ships the nurture scheduler but leaves two acceptance criteria unchecked because they hinge on `yarn db:migrate` having run against the target DB. Current coverage cannot catch migration drift, bearer-auth wiring, or the action-queue read path — `leads.create`/`leads.update` wrap `startOrUpdateSequence` in `.catch()` (`src/server/api/routers/leads.ts:142`, `:266-276`), so a broken nurture backend does not surface through the normal lead-create path. This plan closes the gap with a single Playwright spec exercising the full flow from lead create → cron invocation → action-queue render, plus an AI stub so the test does not burn Anthropic tokens.
+
+## Current State
+- **Cron route** — `src/app/api/cron/nurture-scheduler/route.ts:15` calls `runSchedulerTick(db)` with no injected `draftFn`, so `draftMessage` always hits Anthropic.
+- **Injectable seam** — `src/server/nurture/scheduler.ts:83-86` already accepts `runSchedulerTick(db, draftFn?)`; fallback to real `draftMessage` at lines 87-88. Internal `DraftFn` type at line 9 is not exported.
+- **Auto-start wiring** — `startOrUpdateSequence` already called in `leads.create` at `src/server/api/routers/leads.ts:142` and `leads.update` at lines 266-276, both swallowed by `.catch()`.
+- **Dev advance route** — `src/app/api/dev/nurture/advance/route.ts` exists and backdates `nextStepAt` by 60s (gated by `env.NODE_ENV !== "production"`).
+- **AI helpers** — `selectChannel(lead)` at `src/server/ai/channel-selection.ts:12`, `computePriority(lead)` at `src/server/ai/priority.ts:29`. Types `DraftMessageInput`/`DraftMessageOutput`/`LeadRow` exported from `src/server/ai/schema.ts`.
+- **No `x-ai-stub` references** anywhere in the repo (grep: 0 matches). This is a brand-new pattern.
+- **No `src/server/ai/stub.ts`** — `src/server/ai/` contains `draft-message.ts`, `schema.ts`, `channel-selection.ts`, `priority.ts`, `anthropic-client.ts`, `prompts.ts`.
+- **Env schema** — `src/env.js:31` already declares `CRON_SECRET: z.string().min(16)` and includes it in `runtimeEnv` (line 63).
+- **E2E patterns** — closest existing spec is `e2e/features/action-queue.spec.ts`; Neon client + helper pattern at `e2e/utils/messages-helper.ts:1-10`; polling at `e2e/utils/hubspot-helper.ts:235-254` (`waitForLeadField`); lead-id lookup at `e2e/utils/leads-helper.ts:21-29` (`getLeadIdByPhone`); session helpers at `e2e/utils/auth-helper.ts:39-71` (`createTestSession`, `deleteTestSession`).
+- **Teardown markers** — `TEST_FIRST_NAMES` lives in `e2e/utils/auth-helper.ts:98-101` (DB sweep) and `e2e/utils/hubspot-helper.ts:112-125` (HubSpot sweep); `e2e/utils/global-teardown.ts:13-29` imports from both — no third copy.
+- **Playwright config** — `playwright.config.ts:43-50` webServer runs `rm -rf .next/ && yarn preview` locally (skipped in CI where tests hit a deployed URL). `extraHTTPHeaders` pattern at lines 33-39 for Vercel bypass secret.
+- **CI workflow** — `.github/workflows/post-deploy.yml:86-91` runs `yarn db:migrate` before E2E; env block at lines 111-120 passes `DATABASE_URL`, `VERCEL_AUTOMATION_BYPASS_SECRET`, `BETTER_AUTH_SECRET`, `HUBSPOT_*` but **not** `CRON_SECRET`.
+- **Dashboard testids** — `src/app/(application)/dashboard/_components/draft-row.tsx:39` (`queue-row-${row.id}`) and line 79-80 (`queue-row-body-${row.id}`).
+
+## Desired End State
+- Every PR runs a Playwright spec that proves (1) the nurture migration has applied, (2) auto-start writes a real `nurture_sequences` row, (3) the cron route authorizes correctly and drafts a pending message via a stubbed AI path, and (4) the draft renders in the dashboard action queue.
+- A generic `x-ai-stub: 1` header is honoured by routes that already authenticate the caller; the cron route is the first consumer. Stubbed drafts are observably marked with a `[ai-stub]` prefix in `body`/`aiReasoning` so production ops can audit usage.
+- CI (`post-deploy.yml`) passes `CRON_SECRET` through to the Playwright process; local `webServer` runs `yarn db:migrate` before `yarn preview`.
+- The `.catch()` swallows in `leads.create`/`leads.update` remain untouched — the DB assertion in Test 1 is the migration gate.
+
+## Out of Scope
+- Real-LLM smoke tests and offline/online eval suites (deferred to a separate ticket).
+- Neon per-PR branching (deferred unless cross-PR flake emerges on the shared preview DB).
+- Per-request rate limit on the `x-ai-stub` header (gated only by `CRON_SECRET` for now — tracked as a broader secrets-hygiene concern).
+- Adopting the `x-ai-stub` pattern in non-cron AI routes (no such routes exist today; future AI-touching routes adopt the same two-line wiring when they land).
+- Changes to `startOrUpdateSequence`, `runSchedulerTick`, or the dev-advance route (all already in place on `feat/132-nurture-scheduler`).
+
+## Approach
+Three phases. **Phase 1** lands the AI stub module and the one-line cron-route change, with a unit test — no E2E surface yet, so the stub infra can be reviewed independently. **Phase 2** builds the E2E scaffolding (DB helpers, teardown markers, `webServer` migration step, CI env passthrough) without introducing a spec that would fail in CI due to missing plumbing. **Phase 3** adds the spec itself as three tests, using `test.describe.configure({ mode: 'serial' })` for Tests 2→3 so the cron-drafted row can be asserted end-to-end in the UI. The migration is asserted *implicitly* via Test 1's DB read — no separate meta-inspection step.
+
+## Phase 1: AI stub module + cron route wiring
+
+### Changes
+- `src/server/ai/stub.ts` — new module. Exports `resolveDraftFn(req: Request): DraftFn | undefined` where `DraftFn = (input: DraftMessageInput) => Promise<DraftMessageOutput>` (types re-exported from `~/server/ai/schema`). Reads `x-ai-stub` off the request; returns `undefined` when absent. When header is `"1"`, returns a deterministic async function that computes:
+  ```ts
+  {
+    channel: selectChannel(lead),
+    subject: channel === 'sms' ? null : '[ai-stub] subject',
+    body: `[ai-stub] body for ${lead.id}`,
+    aiReasoning: '[ai-stub]',
+    priority: computePriority(lead),
+  }
+  ```
+  Logs `[ai-stub] route=<url.pathname> leadId=<id>` at `console.info` on each invocation. Does not enforce auth — trusts the caller.
+- `src/server/ai/__tests__/stub.test.ts` — new rstest spec covering:
+  - `resolveDraftFn` returns `undefined` when `x-ai-stub` header is absent.
+  - `resolveDraftFn` returns `undefined` for any `x-ai-stub` value other than `"1"` (e.g. `"0"`, empty string).
+  - When header is `"1"`, the returned fn produces output whose `channel` matches `selectChannel(lead)` and `priority` matches `computePriority(lead)` (use fixtures from `src/server/ai/__tests__/fixtures.ts`).
+  - `body` starts with `[ai-stub] body for ` and includes `lead.id`.
+  - `subject` is `null` for an SMS-selected lead and `'[ai-stub] subject'` for an email-selected lead.
+  - Invocation logs to `console.info` with the `[ai-stub]` prefix (spy on `console.info`).
+- `src/app/api/cron/nurture-scheduler/route.ts:15` — edit: replace `const result = await runSchedulerTick(db);` with:
+  ```ts
+  const draftFn = resolveDraftFn(request);
+  const result = await runSchedulerTick(db, draftFn);
+  ```
+  Import `resolveDraftFn` from `~/server/ai/stub`.
+- `src/app/api/cron/nurture-scheduler/__tests__/route.test.ts` — extend: add a case where the request carries `Authorization: Bearer <secret>` + `x-ai-stub: 1` and `runSchedulerTick` is a spy; assert the spy was called with a non-undefined `draftFn` whose first invocation yields an output whose `body` starts with `[ai-stub]`.
+
+### Success
+**Automated**
+- [x] `make check` passes
+- [x] `make test` passes (new `stub.test.ts`; updated `route.test.ts`)
+- [x] `make build` passes
+
+**Manual**
+- [ ] Start a local dev server (`make start`), create an active `nurture_sequences` row manually pointing at a real lead, `POST /api/dev/nurture/advance`, then `curl -H 'Authorization: Bearer $CRON_SECRET' -H 'x-ai-stub: 1' https://www.localhost/api/cron/nurture-scheduler`. Confirm response is `{"drafted":1,"failed":0}` and a `message_queue` row appears whose `body` starts with `[ai-stub]`.
+- [ ] Repeat without the `x-ai-stub` header and confirm the real `draftMessage` path runs (message body is natural-language output, not the stub prefix). Skip if Anthropic key is not configured locally.
+
+## Phase 2: E2E scaffolding — helpers, teardown markers, config, CI
+
+### Changes
+- `e2e/utils/nurture-helper.ts` — new file. Uses the Neon client pattern from `e2e/utils/messages-helper.ts:1-10`. Exports:
+  - `seedActiveSequence(args: { leadId: string; sequenceType: 'discovery' | 'nurture' | 'warm_progression' | 'lot_alert'; nextStepAt: Date }): Promise<{ id: string }>` — direct `INSERT INTO nurture_sequences` with `status='active'`; returns the new id.
+  - `getActiveSequenceByLead(leadId: string): Promise<{ id: string; sequenceType: string; nextStepAt: Date | null } | null>` — `SELECT id, sequence_type, next_step_at FROM nurture_sequences WHERE lead_id=$1 AND status='active' LIMIT 1`.
+  - `getPendingMessagesByLead(leadId: string): Promise<Array<{ id: string; body: string; status: string; channel: string; subject: string | null }>>` — returns rows from `message_queue` scoped to the lead.
+  - `waitForPendingMessage(leadId: string, opts?: { intervalMs?: number; timeoutMs?: number }): Promise<{ id: string; body: string; status: string; channel: string; subject: string | null }>` — polls `getPendingMessagesByLead`, resolves on first hit, throws on timeout. Defaults `intervalMs=2000`, `timeoutMs=10000`. Modeled on `waitForLeadField` at `e2e/utils/hubspot-helper.ts:235-254`.
+  - `cleanupSequences(ids: string[]): Promise<void>` — `DELETE FROM nurture_sequences WHERE id = ANY($1::uuid[])`. Noop when `ids.length === 0`.
+  - `cronRequestContext(baseURL: string): Promise<APIRequestContext>` — imports from `@playwright/test` and returns `request.newContext({ baseURL, extraHTTPHeaders })` where headers include `Authorization: Bearer ${process.env.CRON_SECRET}`, `x-ai-stub: '1'`, and (when set) `x-vercel-protection-bypass: process.env.VERCEL_AUTOMATION_BYPASS_SECRET` + `x-vercel-set-bypass-cookie: 'true'` — matching the pattern at `playwright.config.ts:33-39`. Throws if `CRON_SECRET` is unset. Caller is responsible for `ctx.dispose()`.
+- `e2e/utils/nurture-helper.test.ts` — skip. Rstest does not run against `e2e/`; helpers are exercised transitively by the Phase 3 spec.
+- `e2e/utils/auth-helper.ts:98-101` — edit: append `'Nurture'` to the `TEST_FIRST_NAMES` array (alphabetised insertion between `'Nav'` and `'Order'`).
+- `e2e/utils/hubspot-helper.ts:112-125` — edit: append `'Nurture'` to the `TEST_FIRST_NAMES` array (alphabetised insertion between `'Nav'` and `'Order'`). No edit to `global-teardown.ts` — it imports both arrays.
+- `playwright.config.ts:46` — edit: change `command: "rm -rf .next/ && yarn preview"` to `command: "rm -rf .next/ && yarn db:migrate && yarn preview"`. `reuseExistingServer: true` at line 49 already prevents re-runs mid-session; local devs already migrate manually.
+- `.github/workflows/post-deploy.yml:111-120` — edit: add `CRON_SECRET: ${{ secrets.CRON_SECRET }}` to the Playwright job env block. Add the secret to the repo's GitHub Actions secrets (documented in this plan's manual step, not in code).
+
+### Success
+**Automated**
+- [x] `make check` passes
+- [x] `make build` passes
+- [x] `make test` passes (no new rstest files in this phase; no regressions)
+
+**Manual**
+- [ ] Run `make test_e2e` locally against the existing spec suite — confirm the `webServer` boots successfully with the new `yarn db:migrate &&` prepend (migrations apply cleanly against the configured `DATABASE_URL`).
+- [ ] Confirm `CRON_SECRET` is set in the repo's GitHub Actions secrets (check via `gh secret list` or the repo settings UI). Without this, Phase 3's spec will fail in CI even though the code compiles.
+- [ ] Verify `cronRequestContext(baseURL)` in a scratch Node script: assert the resulting context includes the bearer + stub headers.
+
+## Phase 3: E2E spec — auto-start, cron draft, action-queue render
+
+### Changes
+- `e2e/features/nurture-scheduler.spec.ts` — new spec. Structure:
+  ```ts
+  test.describe('Nurture scheduler', () => {
+    test.skip(!process.env.DATABASE_URL, 'DB required');
+    test.skip(!process.env.CRON_SECRET, 'CRON_SECRET required');
+
+    let session: TestSession;
+    const leadIds: string[] = [];
+    const sequenceIds: string[] = [];
+    const messageIds: string[] = [];
+
+    test.beforeAll(async () => { session = await createTestSession(); });
+    test.afterAll(async () => {
+      await cleanupMessages(messageIds);
+      await cleanupSequences(sequenceIds);
+      await cleanupLeads(leadIds);
+      await deleteTestSession(session.userId);
+    });
+
+    test('auto-starts a sequence on lead create (migration gate)', async ({ page, context, baseURL }) => { ... });
+
+    test.describe.configure({ mode: 'serial' });
+    test.describe('cron → action queue', () => {
+      let seededLeadId: string;
+      let seededSequenceId: string;
+      let draftedMessageId: string;
+
+      test('cron drafts a pending message', async ({ request, baseURL }) => { ... });
+      test('action queue renders the drafted message', async ({ page, context, baseURL }) => { ... });
+    });
+  });
+  ```
+  Per-test details:
+  - **Test 1 — Auto-start on lead create (migration gate).** Add the session cookie via `context.addCookies([getSessionCookie(session.signedToken, baseURL!)])`. Navigate to `/leads/new`, fill the form with `firstName: 'Nurture'`, `lastName: 'AutoStart'`, a unique phone, and `email: e2e-<randomUUID()>@test.rekurve.dev`, then submit. Resolve the new lead's id via `getLeadIdByPhone(phone)` (modeled on `e2e/utils/leads-helper.ts:21-29`). Push into `leadIds`. Assert `getActiveSequenceByLead(leadId)` returns a non-null row whose `sequenceType === 'discovery'` and `nextStepAt` is within `±1 minute` of `now + 3 days`. Push the returned id into `sequenceIds`. **This is the migration gate** — a missing table, enum, or partial unique index causes the `INSERT` inside `startOrUpdateSequence` to throw (swallowed by `.catch()` in `leads.create`) or return a row with a wrong shape; either way the DB assertion fails with a clear message.
+  - **Test 2 — Cron drafts a pending message.** Seed a lead directly via `seedLead({ firstName: 'Nurture', lastName: 'Cron', ... })` (bypasses HubSpot round-trip for speed); push into `leadIds` and store as `seededLeadId`. Seed an active sequence via `seedActiveSequence({ leadId: seededLeadId, sequenceType: 'nurture', nextStepAt: new Date(Date.now() + 5 * 60_000) })`; push into `sequenceIds` and store as `seededSequenceId`. POST `/api/dev/nurture/advance` with `{ sequenceId: seededSequenceId }` via the test's `request` fixture (no auth needed — route is `NODE_ENV !== 'production'` gated). Create a cron context via `cronRequestContext(baseURL!)`, `GET /api/cron/nurture-scheduler`, assert `response.status() === 200` and `response.json()` deep-equals `{ drafted: 1, failed: 0 }`. Dispose the context. Poll via `waitForPendingMessage(seededLeadId)` (default 2s/10s). Assert `body.startsWith('[ai-stub]')` and `status === 'pending'`. Store `msg.id` as `draftedMessageId`; push into `messageIds`. Cron-response assertion precedes the DB poll so an API-layer failure surfaces before the DB assertion muddies the signal.
+  - **Test 3 — Action queue renders the draft.** Re-add the session cookie (new test, fresh context), navigate to `/dashboard`. Assert `page.getByTestId(`queue-row-${draftedMessageId}`)` is visible within the default Playwright timeout. Assert `page.getByTestId(`queue-row-body-${draftedMessageId}`)` contains the text `[ai-stub]` (substring match via `toContainText`). Exercises the tRPC `messages.listPending` read path, dashboard render, and the per-row `data-testid` wiring (`src/app/(application)/dashboard/_components/draft-row.tsx:39,79-80`).
+
+### Success
+**Automated**
+- [x] `make check` passes
+- [x] `make build` passes
+- [x] `make test_e2e` passes locally with `DATABASE_URL` and `CRON_SECRET` set (three new tests pass; existing suite unaffected).
+- [ ] The new spec runs green in the post-deploy CI workflow with `CRON_SECRET` passed through.
+
+**Manual**
+- [ ] Run `make test_e2e` locally and observe the Playwright trace for Test 2 → confirm the cron request headers include `x-ai-stub: 1` and `Authorization: Bearer ...` in the network log.
+- [ ] Delete the `nurture_active_one_per_lead_uidx` partial unique index in a scratch DB, re-run the spec, and confirm Test 1 fails with a meaningful DB-assertion message (sanity-check the migration gate).
+- [ ] Run `/design_review` — N/A for this change (no UI modifications). Noted here to acknowledge the CLAUDE.md workflow rule explicitly.
+
+## References
+- Design: `thoughts/designs/2026-04-21-nurture-scheduler-e2e.md`
+- Prior plan (Phase 1/2 of the feature itself): `thoughts/plans/2026-04-20-ENG-132-nurture-scheduler.md`
+- PR: https://github.com/samjmarshall/rekurve/pull/147
+- Ticket: https://github.com/samjmarshall/rekurve/issues/132
+- Cron route call site (to modify): `src/app/api/cron/nurture-scheduler/route.ts:15`
+- Scheduler injectable seam: `src/server/nurture/scheduler.ts:83-86`
+- AI types + helpers: `src/server/ai/schema.ts` (`DraftMessageInput`, `DraftMessageOutput`, `LeadRow`), `src/server/ai/channel-selection.ts:12` (`selectChannel`), `src/server/ai/priority.ts:29` (`computePriority`)
+- Leads-router swallow points: `src/server/api/routers/leads.ts:142,266-276`
+- Dashboard testids: `src/app/(application)/dashboard/_components/draft-row.tsx:39,79-80`
+- Dev advance route: `src/app/api/dev/nurture/advance/route.ts`
+- Closest existing spec: `e2e/features/action-queue.spec.ts`
+- E2E helpers: `e2e/utils/messages-helper.ts:1-10` (Neon client), `e2e/utils/auth-helper.ts:39-71,98-101` (session + first-name marker), `e2e/utils/hubspot-helper.ts:112-125,235-254` (first-name marker + polling), `e2e/utils/leads-helper.ts:21-29` (`getLeadIdByPhone`), `e2e/utils/global-teardown.ts:13-29` (sweep)
+- Playwright config: `playwright.config.ts:33-39` (bypass header pattern), `:43-50` (webServer)
+- CI workflow: `.github/workflows/post-deploy.yml:86-91` (existing `yarn db:migrate` step), `:111-120` (env block to extend)
+- Env schema: `src/env.js:31,63` (`CRON_SECRET` — already declared)
+- Migration convention: `drizzle/NNNN_<name>.sql` (no new migration in this plan — partial unique index shipped in PR #147)
+- Vercel — [Managing Cron Jobs](https://vercel.com/docs/cron-jobs/manage-cron-jobs)
+- Playwright — [API Testing / APIRequestContext](https://playwright.dev/docs/api-testing)

--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,7 @@
   "crons": [
     {
       "path": "/api/cron/nurture-scheduler",
-      "schedule": "*/15 * * * *"
+      "schedule": "0 0 * * *"
     }
   ]
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "crons": [
+    {
+      "path": "/api/cron/nurture-scheduler",
+      "schedule": "*/15 * * * *"
+    }
+  ]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -745,6 +745,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@bytecodealliance/preview2-shim@npm:0.17.6":
+  version: 0.17.6
+  resolution: "@bytecodealliance/preview2-shim@npm:0.17.6"
+  checksum: dcb680942a1143fc76935873cc95b8492e05c1c81404f3f9b5ef20be1a4d8572103f8447a253fd632ec7da6f5be0b4371c3f97e4ba1b6d2eabbe7c3f8e825dcf
+  languageName: node
+  linkType: hard
+
 "@cspotcode/source-map-support@npm:^0.8.0":
   version: 0.8.1
   resolution: "@cspotcode/source-map-support@npm:0.8.1"
@@ -793,6 +800,43 @@ __metadata:
   peerDependencies:
     "@noble/ciphers": ^1.0.0
   checksum: 33aa89b8633e66cf5f0fbc18e461e4b152261bd7d30658a213ebb86beb7ae657d64defa7c4483e1c5c82f5935241958210d44d39efab7e4f09bbfa4e76323ad7
+  languageName: node
+  linkType: hard
+
+"@edge-runtime/format@npm:2.2.1":
+  version: 2.2.1
+  resolution: "@edge-runtime/format@npm:2.2.1"
+  checksum: cea6835551c8fbde4f0bb04e6cfb69efa4aa05ba3b1977cb02a1e362c0b2cebf835976033d7dca73444b254dffdb507749717a43836c2aa164eb33d98aa70c8d
+  languageName: node
+  linkType: hard
+
+"@edge-runtime/node-utils@npm:2.3.0":
+  version: 2.3.0
+  resolution: "@edge-runtime/node-utils@npm:2.3.0"
+  checksum: 6c8f0b3fc512961f0b8ebae74f4a6aec70f82708b403c05bf5b9a6d42e4c90d796695cc04805684cded81857237c11681f65384c8117c2848793566d1d4a26f1
+  languageName: node
+  linkType: hard
+
+"@edge-runtime/ponyfill@npm:2.4.2":
+  version: 2.4.2
+  resolution: "@edge-runtime/ponyfill@npm:2.4.2"
+  checksum: c5c7c61b4ce850668b8afaa9bcba6431059270d617dfcdab6be79819ec423f97c3d2c5b8e6deb388ae6db39aaa4b9bbc3a50465645c3e5d9aaac8cdd7c436584
+  languageName: node
+  linkType: hard
+
+"@edge-runtime/primitives@npm:4.1.0":
+  version: 4.1.0
+  resolution: "@edge-runtime/primitives@npm:4.1.0"
+  checksum: 825789a031bb7fbf0921cd4381fcabb416705d8b1d7077215b6798b695856684bbed8626d891e38c65a872e7418b2a2f7f5bfeb07dd5e53fd025885fbccba93c
+  languageName: node
+  linkType: hard
+
+"@edge-runtime/vm@npm:3.2.0":
+  version: 3.2.0
+  resolution: "@edge-runtime/vm@npm:3.2.0"
+  dependencies:
+    "@edge-runtime/primitives": 4.1.0
+  checksum: 4dbe2de13af5f08cf6682ed81192ccd4d8680757f542d2991fc3e567adc9d4432e888677cd6c750abe735bd119ca7660ce37b146e34132cf1c27925b404135fc
   languageName: node
   linkType: hard
 
@@ -865,6 +909,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/aix-ppc64@npm:0.27.0":
+  version: 0.27.0
+  resolution: "@esbuild/aix-ppc64@npm:0.27.0"
+  conditions: os=aix & cpu=ppc64
+  languageName: node
+  linkType: hard
+
 "@esbuild/aix-ppc64@npm:0.27.4":
   version: 0.27.4
   resolution: "@esbuild/aix-ppc64@npm:0.27.4"
@@ -882,6 +933,13 @@ __metadata:
 "@esbuild/android-arm64@npm:0.25.12":
   version: 0.25.12
   resolution: "@esbuild/android-arm64@npm:0.25.12"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/android-arm64@npm:0.27.0":
+  version: 0.27.0
+  resolution: "@esbuild/android-arm64@npm:0.27.0"
   conditions: os=android & cpu=arm64
   languageName: node
   linkType: hard
@@ -907,6 +965,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/android-arm@npm:0.27.0":
+  version: 0.27.0
+  resolution: "@esbuild/android-arm@npm:0.27.0"
+  conditions: os=android & cpu=arm
+  languageName: node
+  linkType: hard
+
 "@esbuild/android-arm@npm:0.27.4":
   version: 0.27.4
   resolution: "@esbuild/android-arm@npm:0.27.4"
@@ -924,6 +989,13 @@ __metadata:
 "@esbuild/android-x64@npm:0.25.12":
   version: 0.25.12
   resolution: "@esbuild/android-x64@npm:0.25.12"
+  conditions: os=android & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/android-x64@npm:0.27.0":
+  version: 0.27.0
+  resolution: "@esbuild/android-x64@npm:0.27.0"
   conditions: os=android & cpu=x64
   languageName: node
   linkType: hard
@@ -949,6 +1021,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/darwin-arm64@npm:0.27.0":
+  version: 0.27.0
+  resolution: "@esbuild/darwin-arm64@npm:0.27.0"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@esbuild/darwin-arm64@npm:0.27.4":
   version: 0.27.4
   resolution: "@esbuild/darwin-arm64@npm:0.27.4"
@@ -966,6 +1045,13 @@ __metadata:
 "@esbuild/darwin-x64@npm:0.25.12":
   version: 0.25.12
   resolution: "@esbuild/darwin-x64@npm:0.25.12"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/darwin-x64@npm:0.27.0":
+  version: 0.27.0
+  resolution: "@esbuild/darwin-x64@npm:0.27.0"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
@@ -991,6 +1077,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/freebsd-arm64@npm:0.27.0":
+  version: 0.27.0
+  resolution: "@esbuild/freebsd-arm64@npm:0.27.0"
+  conditions: os=freebsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@esbuild/freebsd-arm64@npm:0.27.4":
   version: 0.27.4
   resolution: "@esbuild/freebsd-arm64@npm:0.27.4"
@@ -1008,6 +1101,13 @@ __metadata:
 "@esbuild/freebsd-x64@npm:0.25.12":
   version: 0.25.12
   resolution: "@esbuild/freebsd-x64@npm:0.25.12"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/freebsd-x64@npm:0.27.0":
+  version: 0.27.0
+  resolution: "@esbuild/freebsd-x64@npm:0.27.0"
   conditions: os=freebsd & cpu=x64
   languageName: node
   linkType: hard
@@ -1033,6 +1133,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/linux-arm64@npm:0.27.0":
+  version: 0.27.0
+  resolution: "@esbuild/linux-arm64@npm:0.27.0"
+  conditions: os=linux & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@esbuild/linux-arm64@npm:0.27.4":
   version: 0.27.4
   resolution: "@esbuild/linux-arm64@npm:0.27.4"
@@ -1050,6 +1157,13 @@ __metadata:
 "@esbuild/linux-arm@npm:0.25.12":
   version: 0.25.12
   resolution: "@esbuild/linux-arm@npm:0.25.12"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-arm@npm:0.27.0":
+  version: 0.27.0
+  resolution: "@esbuild/linux-arm@npm:0.27.0"
   conditions: os=linux & cpu=arm
   languageName: node
   linkType: hard
@@ -1075,6 +1189,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/linux-ia32@npm:0.27.0":
+  version: 0.27.0
+  resolution: "@esbuild/linux-ia32@npm:0.27.0"
+  conditions: os=linux & cpu=ia32
+  languageName: node
+  linkType: hard
+
 "@esbuild/linux-ia32@npm:0.27.4":
   version: 0.27.4
   resolution: "@esbuild/linux-ia32@npm:0.27.4"
@@ -1092,6 +1213,13 @@ __metadata:
 "@esbuild/linux-loong64@npm:0.25.12":
   version: 0.25.12
   resolution: "@esbuild/linux-loong64@npm:0.25.12"
+  conditions: os=linux & cpu=loong64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-loong64@npm:0.27.0":
+  version: 0.27.0
+  resolution: "@esbuild/linux-loong64@npm:0.27.0"
   conditions: os=linux & cpu=loong64
   languageName: node
   linkType: hard
@@ -1117,6 +1245,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/linux-mips64el@npm:0.27.0":
+  version: 0.27.0
+  resolution: "@esbuild/linux-mips64el@npm:0.27.0"
+  conditions: os=linux & cpu=mips64el
+  languageName: node
+  linkType: hard
+
 "@esbuild/linux-mips64el@npm:0.27.4":
   version: 0.27.4
   resolution: "@esbuild/linux-mips64el@npm:0.27.4"
@@ -1134,6 +1269,13 @@ __metadata:
 "@esbuild/linux-ppc64@npm:0.25.12":
   version: 0.25.12
   resolution: "@esbuild/linux-ppc64@npm:0.25.12"
+  conditions: os=linux & cpu=ppc64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-ppc64@npm:0.27.0":
+  version: 0.27.0
+  resolution: "@esbuild/linux-ppc64@npm:0.27.0"
   conditions: os=linux & cpu=ppc64
   languageName: node
   linkType: hard
@@ -1159,6 +1301,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/linux-riscv64@npm:0.27.0":
+  version: 0.27.0
+  resolution: "@esbuild/linux-riscv64@npm:0.27.0"
+  conditions: os=linux & cpu=riscv64
+  languageName: node
+  linkType: hard
+
 "@esbuild/linux-riscv64@npm:0.27.4":
   version: 0.27.4
   resolution: "@esbuild/linux-riscv64@npm:0.27.4"
@@ -1176,6 +1325,13 @@ __metadata:
 "@esbuild/linux-s390x@npm:0.25.12":
   version: 0.25.12
   resolution: "@esbuild/linux-s390x@npm:0.25.12"
+  conditions: os=linux & cpu=s390x
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-s390x@npm:0.27.0":
+  version: 0.27.0
+  resolution: "@esbuild/linux-s390x@npm:0.27.0"
   conditions: os=linux & cpu=s390x
   languageName: node
   linkType: hard
@@ -1201,6 +1357,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/linux-x64@npm:0.27.0":
+  version: 0.27.0
+  resolution: "@esbuild/linux-x64@npm:0.27.0"
+  conditions: os=linux & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@esbuild/linux-x64@npm:0.27.4":
   version: 0.27.4
   resolution: "@esbuild/linux-x64@npm:0.27.4"
@@ -1211,6 +1374,13 @@ __metadata:
 "@esbuild/netbsd-arm64@npm:0.25.12":
   version: 0.25.12
   resolution: "@esbuild/netbsd-arm64@npm:0.25.12"
+  conditions: os=netbsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/netbsd-arm64@npm:0.27.0":
+  version: 0.27.0
+  resolution: "@esbuild/netbsd-arm64@npm:0.27.0"
   conditions: os=netbsd & cpu=arm64
   languageName: node
   linkType: hard
@@ -1236,6 +1406,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/netbsd-x64@npm:0.27.0":
+  version: 0.27.0
+  resolution: "@esbuild/netbsd-x64@npm:0.27.0"
+  conditions: os=netbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@esbuild/netbsd-x64@npm:0.27.4":
   version: 0.27.4
   resolution: "@esbuild/netbsd-x64@npm:0.27.4"
@@ -1246,6 +1423,13 @@ __metadata:
 "@esbuild/openbsd-arm64@npm:0.25.12":
   version: 0.25.12
   resolution: "@esbuild/openbsd-arm64@npm:0.25.12"
+  conditions: os=openbsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/openbsd-arm64@npm:0.27.0":
+  version: 0.27.0
+  resolution: "@esbuild/openbsd-arm64@npm:0.27.0"
   conditions: os=openbsd & cpu=arm64
   languageName: node
   linkType: hard
@@ -1271,6 +1455,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/openbsd-x64@npm:0.27.0":
+  version: 0.27.0
+  resolution: "@esbuild/openbsd-x64@npm:0.27.0"
+  conditions: os=openbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@esbuild/openbsd-x64@npm:0.27.4":
   version: 0.27.4
   resolution: "@esbuild/openbsd-x64@npm:0.27.4"
@@ -1281,6 +1472,13 @@ __metadata:
 "@esbuild/openharmony-arm64@npm:0.25.12":
   version: 0.25.12
   resolution: "@esbuild/openharmony-arm64@npm:0.25.12"
+  conditions: os=openharmony & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/openharmony-arm64@npm:0.27.0":
+  version: 0.27.0
+  resolution: "@esbuild/openharmony-arm64@npm:0.27.0"
   conditions: os=openharmony & cpu=arm64
   languageName: node
   linkType: hard
@@ -1306,6 +1504,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/sunos-x64@npm:0.27.0":
+  version: 0.27.0
+  resolution: "@esbuild/sunos-x64@npm:0.27.0"
+  conditions: os=sunos & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@esbuild/sunos-x64@npm:0.27.4":
   version: 0.27.4
   resolution: "@esbuild/sunos-x64@npm:0.27.4"
@@ -1323,6 +1528,13 @@ __metadata:
 "@esbuild/win32-arm64@npm:0.25.12":
   version: 0.25.12
   resolution: "@esbuild/win32-arm64@npm:0.25.12"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/win32-arm64@npm:0.27.0":
+  version: 0.27.0
+  resolution: "@esbuild/win32-arm64@npm:0.27.0"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
@@ -1348,6 +1560,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/win32-ia32@npm:0.27.0":
+  version: 0.27.0
+  resolution: "@esbuild/win32-ia32@npm:0.27.0"
+  conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
 "@esbuild/win32-ia32@npm:0.27.4":
   version: 0.27.4
   resolution: "@esbuild/win32-ia32@npm:0.27.4"
@@ -1369,10 +1588,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/win32-x64@npm:0.27.0":
+  version: 0.27.0
+  resolution: "@esbuild/win32-x64@npm:0.27.0"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@esbuild/win32-x64@npm:0.27.4":
   version: 0.27.4
   resolution: "@esbuild/win32-x64@npm:0.27.4"
   conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@fastify/busboy@npm:^2.0.0":
+  version: 2.1.1
+  resolution: "@fastify/busboy@npm:2.1.1"
+  checksum: 42c32ef75e906c9a4809c1e1930a5ca6d4ddc8d138e1a8c8ba5ea07f997db32210617d23b2e4a85fe376316a41a1a0439fc6ff2dedf5126d96f45a9d80754fb2
   languageName: node
   linkType: hard
 
@@ -1752,6 +1985,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@isaacs/balanced-match@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "@isaacs/balanced-match@npm:4.0.1"
+  checksum: 102fbc6d2c0d5edf8f6dbf2b3feb21695a21bc850f11bc47c4f06aa83bd8884fde3fe9d6d797d619901d96865fdcb4569ac2a54c937992c48885c5e3d9967fe8
+  languageName: node
+  linkType: hard
+
+"@isaacs/brace-expansion@npm:^5.0.0":
+  version: 5.0.1
+  resolution: "@isaacs/brace-expansion@npm:5.0.1"
+  dependencies:
+    "@isaacs/balanced-match": ^4.0.1
+  checksum: 21f8192f022c320f7acf899730feb419b1a5f4ccc741481ef8f4b3111e97a41c06e5783871bb240da2e87de909c7fc5b0d07f73818db521fee06541c086ea351
+  languageName: node
+  linkType: hard
+
 "@isaacs/cliui@npm:^9.0.0":
   version: 9.0.0
   resolution: "@isaacs/cliui@npm:9.0.0"
@@ -1819,6 +2068,23 @@ __metadata:
     "@jridgewell/resolve-uri": ^3.1.0
     "@jridgewell/sourcemap-codec": ^1.4.14
   checksum: af8fda2431348ad507fbddf8e25f5d08c79ecc94594061ce402cf41bc5aba1a7b3e59bf0fd70a619b35f33983a3f488ceeba8faf56bff784f98bb5394a8b7d47
+  languageName: node
+  linkType: hard
+
+"@mapbox/node-pre-gyp@npm:^2.0.0":
+  version: 2.0.3
+  resolution: "@mapbox/node-pre-gyp@npm:2.0.3"
+  dependencies:
+    consola: ^3.2.3
+    detect-libc: ^2.0.0
+    https-proxy-agent: ^7.0.5
+    node-fetch: ^2.6.7
+    nopt: ^8.0.0
+    semver: ^7.5.3
+    tar: ^7.4.0
+  bin:
+    node-pre-gyp: bin/node-pre-gyp
+  checksum: 8b1a9833d4b6cb5cda943fa3e5c2cc61395e2623570092c98d585c3ce3c44088d597d88cbe89cdd99c57ae741927bcbeb58880fbfb03e4161640bed250ab7916
   languageName: node
   linkType: hard
 
@@ -2247,6 +2513,155 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@oxc-project/types@npm:=0.110.0":
+  version: 0.110.0
+  resolution: "@oxc-project/types@npm:0.110.0"
+  checksum: fae9c8cd7f1c72bfe4875b36d82d43006e66a3712d03cdb4569f5247fffd1a54ae3df13635bea0bf107d155434c22a4114b83fd46e653c702908ab1d939a270b
+  languageName: node
+  linkType: hard
+
+"@oxc-transform/binding-android-arm-eabi@npm:0.111.0":
+  version: 0.111.0
+  resolution: "@oxc-transform/binding-android-arm-eabi@npm:0.111.0"
+  conditions: os=android & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@oxc-transform/binding-android-arm64@npm:0.111.0":
+  version: 0.111.0
+  resolution: "@oxc-transform/binding-android-arm64@npm:0.111.0"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@oxc-transform/binding-darwin-arm64@npm:0.111.0":
+  version: 0.111.0
+  resolution: "@oxc-transform/binding-darwin-arm64@npm:0.111.0"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@oxc-transform/binding-darwin-x64@npm:0.111.0":
+  version: 0.111.0
+  resolution: "@oxc-transform/binding-darwin-x64@npm:0.111.0"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@oxc-transform/binding-freebsd-x64@npm:0.111.0":
+  version: 0.111.0
+  resolution: "@oxc-transform/binding-freebsd-x64@npm:0.111.0"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@oxc-transform/binding-linux-arm-gnueabihf@npm:0.111.0":
+  version: 0.111.0
+  resolution: "@oxc-transform/binding-linux-arm-gnueabihf@npm:0.111.0"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@oxc-transform/binding-linux-arm-musleabihf@npm:0.111.0":
+  version: 0.111.0
+  resolution: "@oxc-transform/binding-linux-arm-musleabihf@npm:0.111.0"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@oxc-transform/binding-linux-arm64-gnu@npm:0.111.0":
+  version: 0.111.0
+  resolution: "@oxc-transform/binding-linux-arm64-gnu@npm:0.111.0"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@oxc-transform/binding-linux-arm64-musl@npm:0.111.0":
+  version: 0.111.0
+  resolution: "@oxc-transform/binding-linux-arm64-musl@npm:0.111.0"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@oxc-transform/binding-linux-ppc64-gnu@npm:0.111.0":
+  version: 0.111.0
+  resolution: "@oxc-transform/binding-linux-ppc64-gnu@npm:0.111.0"
+  conditions: os=linux & cpu=ppc64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@oxc-transform/binding-linux-riscv64-gnu@npm:0.111.0":
+  version: 0.111.0
+  resolution: "@oxc-transform/binding-linux-riscv64-gnu@npm:0.111.0"
+  conditions: os=linux & cpu=riscv64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@oxc-transform/binding-linux-riscv64-musl@npm:0.111.0":
+  version: 0.111.0
+  resolution: "@oxc-transform/binding-linux-riscv64-musl@npm:0.111.0"
+  conditions: os=linux & cpu=riscv64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@oxc-transform/binding-linux-s390x-gnu@npm:0.111.0":
+  version: 0.111.0
+  resolution: "@oxc-transform/binding-linux-s390x-gnu@npm:0.111.0"
+  conditions: os=linux & cpu=s390x & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@oxc-transform/binding-linux-x64-gnu@npm:0.111.0":
+  version: 0.111.0
+  resolution: "@oxc-transform/binding-linux-x64-gnu@npm:0.111.0"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@oxc-transform/binding-linux-x64-musl@npm:0.111.0":
+  version: 0.111.0
+  resolution: "@oxc-transform/binding-linux-x64-musl@npm:0.111.0"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@oxc-transform/binding-openharmony-arm64@npm:0.111.0":
+  version: 0.111.0
+  resolution: "@oxc-transform/binding-openharmony-arm64@npm:0.111.0"
+  conditions: os=openharmony & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@oxc-transform/binding-wasm32-wasi@npm:0.111.0":
+  version: 0.111.0
+  resolution: "@oxc-transform/binding-wasm32-wasi@npm:0.111.0"
+  dependencies:
+    "@napi-rs/wasm-runtime": ^1.1.1
+  conditions: cpu=wasm32
+  languageName: node
+  linkType: hard
+
+"@oxc-transform/binding-win32-arm64-msvc@npm:0.111.0":
+  version: 0.111.0
+  resolution: "@oxc-transform/binding-win32-arm64-msvc@npm:0.111.0"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@oxc-transform/binding-win32-ia32-msvc@npm:0.111.0":
+  version: 0.111.0
+  resolution: "@oxc-transform/binding-win32-ia32-msvc@npm:0.111.0"
+  conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"@oxc-transform/binding-win32-x64-msvc@npm:0.111.0":
+  version: 0.111.0
+  resolution: "@oxc-transform/binding-win32-x64-msvc@npm:0.111.0"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@playwright/test@npm:^1.57.0":
   version: 1.58.2
   resolution: "@playwright/test@npm:1.58.2"
@@ -2303,6 +2718,129 @@ __metadata:
     "@posthog/cli": ~0.5.13
     "@posthog/core": 1.6.0
   checksum: 6d15a5f824ede39863853ad60b78fd1b2ca5768ae0b65e7fef38a220068244912d7cf225f2180d891cb8e825706c66de7696cd59d221bdca04b07a93f7dbb57b
+  languageName: node
+  linkType: hard
+
+"@renovatebot/pep440@npm:4.2.1":
+  version: 4.2.1
+  resolution: "@renovatebot/pep440@npm:4.2.1"
+  checksum: 679ffb98c4a6b8b29ff0f9b0f55735c9f982f580ecadd4f0961fa044b3d896dcfd6dcdb685e37d6cc48910a65ec83fbf2f4e10078a214d8a1be98faed5812a13
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-android-arm64@npm:1.0.0-rc.1":
+  version: 1.0.0-rc.1
+  resolution: "@rolldown/binding-android-arm64@npm:1.0.0-rc.1"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-darwin-arm64@npm:1.0.0-rc.1":
+  version: 1.0.0-rc.1
+  resolution: "@rolldown/binding-darwin-arm64@npm:1.0.0-rc.1"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-darwin-x64@npm:1.0.0-rc.1":
+  version: 1.0.0-rc.1
+  resolution: "@rolldown/binding-darwin-x64@npm:1.0.0-rc.1"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-freebsd-x64@npm:1.0.0-rc.1":
+  version: 1.0.0-rc.1
+  resolution: "@rolldown/binding-freebsd-x64@npm:1.0.0-rc.1"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-linux-arm-gnueabihf@npm:1.0.0-rc.1":
+  version: 1.0.0-rc.1
+  resolution: "@rolldown/binding-linux-arm-gnueabihf@npm:1.0.0-rc.1"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-linux-arm64-gnu@npm:1.0.0-rc.1":
+  version: 1.0.0-rc.1
+  resolution: "@rolldown/binding-linux-arm64-gnu@npm:1.0.0-rc.1"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-linux-arm64-musl@npm:1.0.0-rc.1":
+  version: 1.0.0-rc.1
+  resolution: "@rolldown/binding-linux-arm64-musl@npm:1.0.0-rc.1"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-linux-x64-gnu@npm:1.0.0-rc.1":
+  version: 1.0.0-rc.1
+  resolution: "@rolldown/binding-linux-x64-gnu@npm:1.0.0-rc.1"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-linux-x64-musl@npm:1.0.0-rc.1":
+  version: 1.0.0-rc.1
+  resolution: "@rolldown/binding-linux-x64-musl@npm:1.0.0-rc.1"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-openharmony-arm64@npm:1.0.0-rc.1":
+  version: 1.0.0-rc.1
+  resolution: "@rolldown/binding-openharmony-arm64@npm:1.0.0-rc.1"
+  conditions: os=openharmony & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-wasm32-wasi@npm:1.0.0-rc.1":
+  version: 1.0.0-rc.1
+  resolution: "@rolldown/binding-wasm32-wasi@npm:1.0.0-rc.1"
+  dependencies:
+    "@napi-rs/wasm-runtime": ^1.1.1
+  conditions: cpu=wasm32
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-win32-arm64-msvc@npm:1.0.0-rc.1":
+  version: 1.0.0-rc.1
+  resolution: "@rolldown/binding-win32-arm64-msvc@npm:1.0.0-rc.1"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-win32-x64-msvc@npm:1.0.0-rc.1":
+  version: 1.0.0-rc.1
+  resolution: "@rolldown/binding-win32-x64-msvc@npm:1.0.0-rc.1"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@rolldown/pluginutils@npm:1.0.0-rc.1":
+  version: 1.0.0-rc.1
+  resolution: "@rolldown/pluginutils@npm:1.0.0-rc.1"
+  checksum: a43e6985cb24d1f82421d7da2782e1ab18b67ed9a2858f7755ba8b7f47a067679ff750f654414da9d8065e074d73b4f41b4d492995add7e6a6c8722498a7a419
+  languageName: node
+  linkType: hard
+
+"@rollup/pluginutils@npm:^5.1.3":
+  version: 5.3.0
+  resolution: "@rollup/pluginutils@npm:5.3.0"
+  dependencies:
+    "@types/estree": ^1.0.0
+    estree-walker: ^2.0.2
+    picomatch: ^4.0.2
+  peerDependencies:
+    rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
+  peerDependenciesMeta:
+    rollup:
+      optional: true
+  checksum: 2df47496f1f380ce67426b6d31cada1354b40844bb333b365653720b0847ce45446f347ae50313ed17a56c1b4cbba27431c42733ad75ad08764df5b4312946d9
   languageName: node
   linkType: hard
 
@@ -2491,6 +3029,13 @@ __metadata:
   version: 0.4.1
   resolution: "@sec-ant/readable-stream@npm:0.4.1"
   checksum: eb56f72a70995f725269f1c1c206d6dbeb090e88413b1302a456c600041175a7a484c2f0172454f7bed65a8ab95ffed7647d8ad03e6c23b1e3bbc9845f78cd17
+  languageName: node
+  linkType: hard
+
+"@sinclair/typebox@npm:0.25.24":
+  version: 0.25.24
+  resolution: "@sinclair/typebox@npm:0.25.24"
+  checksum: 10219c58f40b8414c50b483b0550445e9710d4fe7b2c4dccb9b66533dd90ba8e024acc776026cebe81e87f06fa24b07fdd7bc30dd277eb9cc386ec50151a3026
   languageName: node
   linkType: hard
 
@@ -2772,6 +3317,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@tootallnate/once@npm:2.0.0":
+  version: 2.0.0
+  resolution: "@tootallnate/once@npm:2.0.0"
+  checksum: ad87447820dd3f24825d2d947ebc03072b20a42bfc96cbafec16bff8bbda6c1a81fcb0be56d5b21968560c5359a0af4038a68ba150c3e1694fe4c109a063bed8
+  languageName: node
+  linkType: hard
+
+"@tootallnate/quickjs-emscripten@npm:^0.23.0":
+  version: 0.23.0
+  resolution: "@tootallnate/quickjs-emscripten@npm:0.23.0"
+  checksum: c350a2947ffb80b22e14ff35099fd582d1340d65723384a0fd0515e905e2534459ad2f301a43279a37308a27c99273c932e64649abd57d0bb3ca8c557150eccc
+  languageName: node
+  linkType: hard
+
 "@trpc/client@npm:11.16.0":
   version: 11.16.0
   resolution: "@trpc/client@npm:11.16.0"
@@ -2807,6 +3366,18 @@ __metadata:
   bin:
     intent: bin/intent.js
   checksum: a8fff4b721e5f2c2f57c154c28338b4d1ba6dd5e2c8c34d327ab9db675f065ce1fc7d8a9f6d4105af501290cae6c17aab75f70d3a85a62d71dfa5005be8fe8f2
+  languageName: node
+  linkType: hard
+
+"@ts-morph/common@npm:~0.11.0":
+  version: 0.11.1
+  resolution: "@ts-morph/common@npm:0.11.1"
+  dependencies:
+    fast-glob: ^3.2.7
+    minimatch: ^3.0.4
+    mkdirp: ^1.0.4
+    path-browserify: ^1.0.1
+  checksum: 2853215cfdfb9b65f96ceef91b15a73ab6591fd27d072801884ea5acc1a8f0becd5ac214d5f3d840f5d650b7654585a9b9df86fc4287872e7be1c6f566381bfd
   languageName: node
   linkType: hard
 
@@ -3263,6 +3834,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/estree@npm:^1.0.0":
+  version: 1.0.8
+  resolution: "@types/estree@npm:1.0.8"
+  checksum: bd93e2e415b6f182ec4da1074e1f36c480f1d26add3e696d54fb30c09bc470897e41361c8fd957bf0985024f8fbf1e6e2aff977d79352ef7eb93a5c6dcff6c11
+  languageName: node
+  linkType: hard
+
+"@types/json-schema@npm:^7.0.6":
+  version: 7.0.15
+  resolution: "@types/json-schema@npm:7.0.15"
+  checksum: 97ed0cb44d4070aecea772b7b2e2ed971e10c81ec87dd4ecc160322ffa55ff330dace1793489540e3e318d90942064bb697cc0f8989391797792d919737b3b98
+  languageName: node
+  linkType: hard
+
 "@types/minimist@npm:^1.2.0":
   version: 1.2.5
   resolution: "@types/minimist@npm:1.2.5"
@@ -3286,6 +3871,15 @@ __metadata:
   dependencies:
     undici-types: ~7.18.0
   checksum: ea0908794d5c011f4f2b5d2e93737ae047ff4a9fd1ec6da27e13a1f976d8d0e029830ddf2d4177e00a2601307e8bbc06e7b4cb3e29e889489d42dd44b49c796a
+  languageName: node
+  linkType: hard
+
+"@types/node@npm:20.11.0":
+  version: 20.11.0
+  resolution: "@types/node@npm:20.11.0"
+  dependencies:
+    undici-types: ~5.26.4
+  checksum: 1bd6890db7e0404d11c33d28f46f19f73256f0ba35d19f0ef2a0faba09f366f188915fb9338eebebcc472075c1c4941e17c7002786aa69afa44980737846b200
   languageName: node
   linkType: hard
 
@@ -3400,10 +3994,422 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@vercel/backends@npm:0.1.2":
+  version: 0.1.2
+  resolution: "@vercel/backends@npm:0.1.2"
+  dependencies:
+    "@vercel/build-utils": 13.19.1
+    "@vercel/nft": 1.5.0
+    "@yarnpkg/parsers": ^3.0.0
+    execa: 3.2.0
+    fs-extra: 11.1.0
+    js-yaml: ^3.13.1
+    oxc-transform: 0.111.0
+    path-to-regexp: 8.3.0
+    resolve.exports: 2.0.3
+    rolldown: 1.0.0-rc.1
+    srvx: 0.8.9
+    tsx: 4.21.0
+    zod: 3.22.4
+  peerDependencies:
+    typescript: ^4.0.0 || ^5.0.0
+  checksum: 4031b9a1efffe7b99188340b405b8622176ce70820be1f766c72e348452d3cf8e8dc7674584fde9be34567171e705a2b1c23872e49c4f675b8d7fea718965a8e
+  languageName: node
+  linkType: hard
+
+"@vercel/blob@npm:2.3.0":
+  version: 2.3.0
+  resolution: "@vercel/blob@npm:2.3.0"
+  dependencies:
+    async-retry: ^1.3.3
+    is-buffer: ^2.0.5
+    is-node-process: ^1.2.0
+    throttleit: ^2.1.0
+    undici: ^6.23.0
+  checksum: 8e068bf6195589d0fe4b19b4d879166baf796cdfe96fb666e245d19a95358a7804639247f9534f18b3bbddf73e42ebff4e0dec944210c7b7550e9392e9a65987
+  languageName: node
+  linkType: hard
+
+"@vercel/build-utils@npm:13.19.1":
+  version: 13.19.1
+  resolution: "@vercel/build-utils@npm:13.19.1"
+  dependencies:
+    "@vercel/python-analysis": 0.11.0
+    cjs-module-lexer: 1.2.3
+    es-module-lexer: 1.5.0
+  checksum: 4592abe36a7a7cce483c1f15be41786a39b6200480db32d7cf85f4c1675c397c238747cab05d5248a19a291a23c8bc5c5a464c6731af24c5e343a11e951bc454
+  languageName: node
+  linkType: hard
+
+"@vercel/cervel@npm:0.0.54":
+  version: 0.0.54
+  resolution: "@vercel/cervel@npm:0.0.54"
+  dependencies:
+    "@vercel/backends": 0.1.2
+  peerDependencies:
+    typescript: ^4.0.0 || ^5.0.0
+  bin:
+    cervel: bin/cervel.mjs
+  checksum: f965f224d570db439ce4985a52ac9f8adc2524c83a90ca4d1b642ea2373a37b90b29d4fae7039e0c2cc52962a84dd1234ba978129fc5389d2931e2e3894abcb2
+  languageName: node
+  linkType: hard
+
+"@vercel/detect-agent@npm:1.2.3":
+  version: 1.2.3
+  resolution: "@vercel/detect-agent@npm:1.2.3"
+  checksum: a8b80261713b600e4bc8cd1c13f3c4466b3a86c935fd9035d85007a87740d7bae7aa075ca0eff1c384cbb7e972087a6b80bfc0331194d5e9902fca54d500a834
+  languageName: node
+  linkType: hard
+
+"@vercel/elysia@npm:0.1.70":
+  version: 0.1.70
+  resolution: "@vercel/elysia@npm:0.1.70"
+  dependencies:
+    "@vercel/node": 5.7.12
+    "@vercel/static-config": 3.2.0
+  checksum: 9bbbe35120efa6b6833581c368245122f906efcd718efc6878dfde6570c6f8eafc0981a339437d42374bbee92dfc64bba7e70810a1e7c449b694e4a97534db21
+  languageName: node
+  linkType: hard
+
+"@vercel/error-utils@npm:2.0.3":
+  version: 2.0.3
+  resolution: "@vercel/error-utils@npm:2.0.3"
+  checksum: cb631bb6cf9574b3f1ee64cca82e9c594fa0a0d44f1fa0e810d86a11a98935cc780b2b89ac303a18609aed3582907142b45a88641d55a15e628e7bea38669f22
+  languageName: node
+  linkType: hard
+
+"@vercel/express@npm:0.1.80":
+  version: 0.1.80
+  resolution: "@vercel/express@npm:0.1.80"
+  dependencies:
+    "@vercel/cervel": 0.0.54
+    "@vercel/nft": 1.5.0
+    "@vercel/node": 5.7.12
+    "@vercel/static-config": 3.2.0
+    fs-extra: 11.1.0
+    path-to-regexp: 8.3.0
+    ts-morph: 12.0.0
+    zod: 3.22.4
+  checksum: 7c5a0892ac9373baede9622bb43f12d4ca640302af60ac3953db12cd7aafd7f94ffa3acff61bf94897d824b4f3cc81d5a00d512fdf8b487f501fba28b3223b44
+  languageName: node
+  linkType: hard
+
+"@vercel/fastify@npm:0.1.73":
+  version: 0.1.73
+  resolution: "@vercel/fastify@npm:0.1.73"
+  dependencies:
+    "@vercel/node": 5.7.12
+    "@vercel/static-config": 3.2.0
+  checksum: b312aa9b257d85878ce21806ab54faee24c87419ea5359908e5923efab882e4ae76713b05add79d2e2cdb5a8fb81e66fde84ff70ac66b30f832f569b88ff7e08
+  languageName: node
+  linkType: hard
+
+"@vercel/fun@npm:1.3.0":
+  version: 1.3.0
+  resolution: "@vercel/fun@npm:1.3.0"
+  dependencies:
+    "@tootallnate/once": 2.0.0
+    async-listen: 1.2.0
+    debug: 4.3.4
+    generic-pool: 3.4.2
+    micro: 9.3.5-canary.3
+    ms: 2.1.1
+    node-fetch: 2.6.7
+    path-to-regexp: 8.2.0
+    promisepipe: 3.0.0
+    semver: 7.5.4
+    stat-mode: 0.3.0
+    stream-to-promise: 2.2.0
+    tar: 7.5.7
+    tinyexec: 0.3.2
+    tree-kill: 1.2.2
+    uid-promise: 1.0.0
+    xdg-app-paths: 5.1.0
+    yauzl-promise: 2.1.3
+  checksum: 50fa9cd6e3380948d60590631b0737b403db9e5eb980b27a47c66be7a43eb4cd230ee4479fbe929c7b67b1af671db8aa498919824799950e1fbb9ec62fe64f3c
+  languageName: node
+  linkType: hard
+
+"@vercel/gatsby-plugin-vercel-analytics@npm:1.0.11":
+  version: 1.0.11
+  resolution: "@vercel/gatsby-plugin-vercel-analytics@npm:1.0.11"
+  dependencies:
+    web-vitals: 0.2.4
+  checksum: 4f17f7957b2c1b1a6fa7c3de3f51731ce5aa03d5ed31d7432f38200c674a1dd46ea9e5770f87dbad6bfc00e678f73a3e3f8f4f0979d31ea084312d291f6a87f9
+  languageName: node
+  linkType: hard
+
+"@vercel/gatsby-plugin-vercel-builder@npm:2.1.20":
+  version: 2.1.20
+  resolution: "@vercel/gatsby-plugin-vercel-builder@npm:2.1.20"
+  dependencies:
+    "@sinclair/typebox": 0.25.24
+    "@vercel/build-utils": 13.19.1
+    esbuild: 0.27.0
+    etag: 1.8.1
+    fs-extra: 11.1.0
+  checksum: 87d417acc48c795a2b506e1d50f704c2cea43539505c29adc9d213c1e61ec83d0a76aa6e7c1fdebebb7f5e73858e5e74b6d3671c6a7c89b048d516b9bf4cad0c
+  languageName: node
+  linkType: hard
+
+"@vercel/go@npm:3.5.0":
+  version: 3.5.0
+  resolution: "@vercel/go@npm:3.5.0"
+  checksum: 672611f84f4218d948da06ef890dd7bd4692bc4c3c503e5be824eed638ff9e74fe6a59703d6ab30b301070fa3551f13997dfb24bf9f9d864a81b6f22ffe03776
+  languageName: node
+  linkType: hard
+
+"@vercel/h3@npm:0.1.79":
+  version: 0.1.79
+  resolution: "@vercel/h3@npm:0.1.79"
+  dependencies:
+    "@vercel/node": 5.7.12
+    "@vercel/static-config": 3.2.0
+  checksum: 523b3b5bc73a649c6555959e2d0dac31220398a02559c883193c3d7d4f4542a6f8fd2c9bd05ff477223b46910e3099b13df92426cfef549c718cead78df3ab33
+  languageName: node
+  linkType: hard
+
+"@vercel/hono@npm:0.2.73":
+  version: 0.2.73
+  resolution: "@vercel/hono@npm:0.2.73"
+  dependencies:
+    "@vercel/nft": 1.5.0
+    "@vercel/node": 5.7.12
+    "@vercel/static-config": 3.2.0
+    fs-extra: 11.1.0
+    path-to-regexp: 8.3.0
+    ts-morph: 12.0.0
+    zod: 3.22.4
+  checksum: 44ecd0911eb0acd7e884ec04f3f98f0c828d6a3095c50aa8f96494e712c8daa9afa7ba0f1f73fab3eebf3d5f812a82a43c42725f247c89977750ef0040193850
+  languageName: node
+  linkType: hard
+
+"@vercel/hydrogen@npm:1.3.6":
+  version: 1.3.6
+  resolution: "@vercel/hydrogen@npm:1.3.6"
+  dependencies:
+    "@vercel/static-config": 3.2.0
+    ts-morph: 12.0.0
+  checksum: 6b136f9e34e4e205a38bd015015c717b6af77e1b9c7100e47d534d6902c03e24f8359afcea2e3682eafa5dc4ac1fbd39e4e70ed0de14eefae3248022b0962f0a
+  languageName: node
+  linkType: hard
+
+"@vercel/koa@npm:0.1.53":
+  version: 0.1.53
+  resolution: "@vercel/koa@npm:0.1.53"
+  dependencies:
+    "@vercel/node": 5.7.12
+    "@vercel/static-config": 3.2.0
+  checksum: 7935077e698ad800f17d7124ee1a9e7ae9dab7f6c6e91ac264d69b97211e86f3860dd6d972aa8b91dd497068aefc01e3451771a6a4e97366e716f289da003296
+  languageName: node
+  linkType: hard
+
+"@vercel/nestjs@npm:0.2.74":
+  version: 0.2.74
+  resolution: "@vercel/nestjs@npm:0.2.74"
+  dependencies:
+    "@vercel/node": 5.7.12
+    "@vercel/static-config": 3.2.0
+  checksum: 8ea983474402960842d8f8b9364d026933005e171d3550457e3f11c5b0134315f2b2908ebbac22e8417db0939bff34c2202b383cb75d10a234c233c7ee248856
+  languageName: node
+  linkType: hard
+
+"@vercel/next@npm:4.16.8":
+  version: 4.16.8
+  resolution: "@vercel/next@npm:4.16.8"
+  dependencies:
+    "@vercel/nft": 1.5.0
+  checksum: 2bc75503ea2362b9eb7e6654ab9750a0e4a7e12d27846b81896f5a35a96936102708a7ee800537eb20c7f0443cfa1b56a503829f5e04c1f7f554ad3b6c5ebee5
+  languageName: node
+  linkType: hard
+
+"@vercel/nft@npm:1.5.0":
+  version: 1.5.0
+  resolution: "@vercel/nft@npm:1.5.0"
+  dependencies:
+    "@mapbox/node-pre-gyp": ^2.0.0
+    "@rollup/pluginutils": ^5.1.3
+    acorn: ^8.6.0
+    acorn-import-attributes: ^1.9.5
+    async-sema: ^3.1.1
+    bindings: ^1.4.0
+    estree-walker: 2.0.2
+    glob: ^13.0.0
+    graceful-fs: ^4.2.9
+    node-gyp-build: ^4.2.2
+    picomatch: ^4.0.2
+    resolve-from: ^5.0.0
+  bin:
+    nft: out/cli.js
+  checksum: 9ed7d45e60bd60d1047f45de6b4f3adbb7ec3dde9cbd980f014a516639246d7d07e504432a31659d080a8fa87a1ec63a901b41362f85be0318999293927c19ef
+  languageName: node
+  linkType: hard
+
+"@vercel/node@npm:5.7.12":
+  version: 5.7.12
+  resolution: "@vercel/node@npm:5.7.12"
+  dependencies:
+    "@edge-runtime/node-utils": 2.3.0
+    "@edge-runtime/primitives": 4.1.0
+    "@edge-runtime/vm": 3.2.0
+    "@types/node": 20.11.0
+    "@vercel/build-utils": 13.19.1
+    "@vercel/error-utils": 2.0.3
+    "@vercel/nft": 1.5.0
+    "@vercel/static-config": 3.2.0
+    async-listen: 3.0.0
+    cjs-module-lexer: 1.2.3
+    edge-runtime: 2.5.9
+    es-module-lexer: 1.4.1
+    esbuild: 0.27.0
+    etag: 1.8.1
+    mime-types: 2.1.35
+    node-fetch: 2.6.9
+    path-to-regexp: 6.1.0
+    path-to-regexp-updated: "npm:path-to-regexp@6.3.0"
+    ts-morph: 12.0.0
+    tsx: 4.21.0
+    typescript: "npm:typescript@5.9.3"
+    undici: 5.28.4
+  checksum: 7480a52403508881b0551601ee59e09a4bababfdd2ff531c2eecf3b44b0397ca9149b76182fc9a214bc29565f34290fe0fb71250ccdfc9762b9a05056e813c51
+  languageName: node
+  linkType: hard
+
+"@vercel/oidc@npm:3.2.0":
+  version: 3.2.0
+  resolution: "@vercel/oidc@npm:3.2.0"
+  checksum: d005dd58b36bb32a419e6f910fb9a219ccf5aad303bf46ef0e588e22bc0d0c9f95e6584fc73bc1fd1e4aa5e37f3a77071d8a2927454db67eefd54d8659fbd95e
+  languageName: node
+  linkType: hard
+
+"@vercel/prepare-flags-definitions@npm:0.2.1":
+  version: 0.2.1
+  resolution: "@vercel/prepare-flags-definitions@npm:0.2.1"
+  checksum: fb5917183caaff75f67d82427f8cab6dcba904c0f8502eff33a9827345dac35408adb9b82fc55adb7309e5515151d23e155016e605490b34650c0c848e673fca
+  languageName: node
+  linkType: hard
+
+"@vercel/python-analysis@npm:0.11.0":
+  version: 0.11.0
+  resolution: "@vercel/python-analysis@npm:0.11.0"
+  dependencies:
+    "@bytecodealliance/preview2-shim": 0.17.6
+    "@renovatebot/pep440": 4.2.1
+    fs-extra: 11.1.1
+    js-yaml: 4.1.1
+    minimatch: 10.1.1
+    smol-toml: 1.5.2
+    zod: 3.22.4
+  checksum: 99e8b8273db8f16801d6889bf1c9cb91f48721a3bebd47244cbb9a36f4aad51e2eee20aa70a4ec8e06ed120effa1585e53a80161f74a986e44d4ca93cf5a436f
+  languageName: node
+  linkType: hard
+
+"@vercel/python@npm:6.35.0":
+  version: 6.35.0
+  resolution: "@vercel/python@npm:6.35.0"
+  dependencies:
+    "@vercel/python-analysis": 0.11.0
+  checksum: f9a14f77bc9d663be34cf1f54b7b964cd5808a1fb94ec49c32eee2acdb84a1acf31d8181e10ab585c09bde8657f9fe546744a3527b20bcff162d0011f005277c
+  languageName: node
+  linkType: hard
+
+"@vercel/redwood@npm:2.4.12":
+  version: 2.4.12
+  resolution: "@vercel/redwood@npm:2.4.12"
+  dependencies:
+    "@vercel/nft": 1.5.0
+    "@vercel/static-config": 3.2.0
+    semver: 6.3.1
+    ts-morph: 12.0.0
+  checksum: 1a2743a910c21245de6739d3b1390bc49c36b18f8613142ed4993537b84978757f4c77fadaf02e25c1d2ae91ca9d65f549798e1539684a0130d84676496c4d45
+  languageName: node
+  linkType: hard
+
+"@vercel/remix-builder@npm:5.7.2":
+  version: 5.7.2
+  resolution: "@vercel/remix-builder@npm:5.7.2"
+  dependencies:
+    "@vercel/error-utils": 2.0.3
+    "@vercel/nft": 1.5.0
+    "@vercel/static-config": 3.2.0
+    path-to-regexp: 6.1.0
+    path-to-regexp-updated: "npm:path-to-regexp@6.3.0"
+    ts-morph: 12.0.0
+  checksum: 0e6a84f4f72c19cf6a3d04e4d5585e8a3d73e819992220fc55fc36565ffaa460716a684c75c8621d5f5db920eba9844e85e6681b6e72b9995a8cca0adf24f09e
+  languageName: node
+  linkType: hard
+
+"@vercel/ruby@npm:2.3.2":
+  version: 2.3.2
+  resolution: "@vercel/ruby@npm:2.3.2"
+  checksum: bb63b9a4ea39b7fb214beabb1429901ce1c5dd5418e4e416a55f9a15d72431ef6339b017cb6738816010d8789a5d05197690b18d3175f70989aff44cae3300e4
+  languageName: node
+  linkType: hard
+
+"@vercel/rust@npm:1.1.1":
+  version: 1.1.1
+  resolution: "@vercel/rust@npm:1.1.1"
+  dependencies:
+    execa: 5
+    smol-toml: 1.5.2
+  checksum: c71c25740acd12bae05fff99d44ae7a5ad77e6062f7258e3ca18b8710914bba870dccf87a2a0c2acc041e54335bd666e1e0a8c189efe026808d623ac40d9d52a
+  languageName: node
+  linkType: hard
+
+"@vercel/sandbox@npm:1.9.0":
+  version: 1.9.0
+  resolution: "@vercel/sandbox@npm:1.9.0"
+  dependencies:
+    "@vercel/oidc": 3.2.0
+    async-retry: 1.3.3
+    jsonlines: 0.1.1
+    ms: 2.1.3
+    picocolors: ^1.1.1
+    tar-stream: 3.1.7
+    undici: ^7.16.0
+    xdg-app-paths: 5.1.0
+    zod: 3.24.4
+  checksum: 5ea5e79982280a0040133ac35643988f8fcaba5295af0b9746beca95304d552faf3968012023f946ad0aaea48531172354e8b4176e35247194c77e1bd18ba4a8
+  languageName: node
+  linkType: hard
+
+"@vercel/static-build@npm:2.9.20":
+  version: 2.9.20
+  resolution: "@vercel/static-build@npm:2.9.20"
+  dependencies:
+    "@vercel/gatsby-plugin-vercel-analytics": 1.0.11
+    "@vercel/gatsby-plugin-vercel-builder": 2.1.20
+    "@vercel/static-config": 3.2.0
+    ts-morph: 12.0.0
+  checksum: 55221f689c3ef423c9315d73b04cc037e363687034751ab07de7af1a6e8ebaf8cc905f693a70e5ed1bf42489379bd8f1dfe229888a50e2c97ef0dfd8f0739645
+  languageName: node
+  linkType: hard
+
+"@vercel/static-config@npm:3.2.0":
+  version: 3.2.0
+  resolution: "@vercel/static-config@npm:3.2.0"
+  dependencies:
+    ajv: 8.6.3
+    json-schema-to-ts: 1.6.4
+    ts-morph: 12.0.0
+  checksum: 0ef9eeacc7932da38c930467ee40b119c2ce9847167c0bf54bd055891466157f2a5091b60d08cb33b93225103d030c0c450a4970d473ce8582b8b2275ace1985
+  languageName: node
+  linkType: hard
+
 "@webgpu/types@npm:*":
   version: 0.1.69
   resolution: "@webgpu/types@npm:0.1.69"
   checksum: 721ccdaf9c8ebdb9c9751d56316616e1125fbeaf1c98564fdc183e34140d1f31ca20cc9cfc195d6fbc335c8ffa167229f248093334781e3da051422479950f96
+  languageName: node
+  linkType: hard
+
+"@yarnpkg/parsers@npm:^3.0.0":
+  version: 3.0.3
+  resolution: "@yarnpkg/parsers@npm:3.0.3"
+  dependencies:
+    js-yaml: ^3.10.0
+    tslib: ^2.4.0
+  checksum: d6f78ec15b36732a88aeb090d012756d03a855a301a29f0f4f725ac05186f2d2e26400ea5636016481bdca7d4a013f70d61141bc1add2048cf1c2e5132b9ecf8
   languageName: node
   linkType: hard
 
@@ -3416,6 +4422,13 @@ __metadata:
   bin:
     JSONStream: ./bin.js
   checksum: 2605fa124260c61bad38bb65eba30d2f72216a78e94d0ab19b11b4e0327d572b8d530c0c9cc3b0764f727ad26d39e00bf7ebad57781ca6368394d73169c59e46
+  languageName: node
+  linkType: hard
+
+"abbrev@npm:^3.0.0":
+  version: 3.0.1
+  resolution: "abbrev@npm:3.0.1"
+  checksum: e70b209f5f408dd3a3bbd0eec4b10a2ffd64704a4a3821d0969d84928cc490a8eb60f85b78a95622c1841113edac10161c62e52f5e7d0027aa26786a8136e02e
   languageName: node
   linkType: hard
 
@@ -3436,6 +4449,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"acorn-import-attributes@npm:^1.9.5":
+  version: 1.9.5
+  resolution: "acorn-import-attributes@npm:1.9.5"
+  peerDependencies:
+    acorn: ^8
+  checksum: 1c0c49b6a244503964ae46ae850baccf306e84caf99bc2010ed6103c69a423987b07b520a6c619f075d215388bd4923eccac995886a54309eda049ab78a4be95
+  languageName: node
+  linkType: hard
+
 "acorn-walk@npm:^8.1.1":
   version: 8.3.5
   resolution: "acorn-walk@npm:8.3.5"
@@ -3445,7 +4467,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"acorn@npm:^8.11.0, acorn@npm:^8.4.1":
+"acorn@npm:^8.11.0, acorn@npm:^8.4.1, acorn@npm:^8.6.0":
   version: 8.16.0
   resolution: "acorn@npm:8.16.0"
   bin:
@@ -3470,7 +4492,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"agent-base@npm:^7.1.0, agent-base@npm:^7.1.2":
+"agent-base@npm:^7.0.2, agent-base@npm:^7.1.0, agent-base@npm:^7.1.2":
   version: 7.1.4
   resolution: "agent-base@npm:7.1.4"
   checksum: 86a7f542af277cfbd77dd61e7df8422f90bac512953709003a1c530171a9d019d072e2400eab2b59f84b49ab9dd237be44315ca663ac73e82b3922d10ea5eafa
@@ -3488,6 +4510,18 @@ __metadata:
     ajv:
       optional: true
   checksum: f4e1fe232d67fcafc02eafe373a7a9962351e0439dd0736647ca75c93c3da23b430b6502c255ab4315410ae330d4f3013ac9fe226c40b2524ca93a58e786d086
+  languageName: node
+  linkType: hard
+
+"ajv@npm:8.6.3":
+  version: 8.6.3
+  resolution: "ajv@npm:8.6.3"
+  dependencies:
+    fast-deep-equal: ^3.1.1
+    json-schema-traverse: ^1.0.0
+    require-from-string: ^2.0.2
+    uri-js: ^4.2.2
+  checksum: 690ffb9408415fdab43686b3f92037ba0c8362f5d0709a123ba3fb546e6ad81414455f80a2b5cc432ce924afe9864671198f022bc331a19c072d4ede152ec3ca
   languageName: node
   linkType: hard
 
@@ -3551,10 +4585,33 @@ __metadata:
   languageName: node
   linkType: hard
 
+"any-promise@npm:^1.1.0, any-promise@npm:~1.3.0":
+  version: 1.3.0
+  resolution: "any-promise@npm:1.3.0"
+  checksum: 0ee8a9bdbe882c90464d75d1f55cf027f5458650c4bd1f0467e65aec38ccccda07ca5844969ee77ed46d04e7dded3eaceb027e8d32f385688523fe305fa7e1de
+  languageName: node
+  linkType: hard
+
+"arg@npm:4.1.0":
+  version: 4.1.0
+  resolution: "arg@npm:4.1.0"
+  checksum: ea97513bf27aa5f2acf5dadf41501108fe786631fdd9d33f373174631800b57f85272dbf8190e937008a02b38d5c2f679514146f89a23123d8cb4ba30e8c066c
+  languageName: node
+  linkType: hard
+
 "arg@npm:^4.1.0":
   version: 4.1.3
   resolution: "arg@npm:4.1.3"
   checksum: 544af8dd3f60546d3e4aff084d451b96961d2267d668670199692f8d054f0415d86fc5497d0e641e91546f0aa920e7c29e5250e99fc89f5552a34b5d93b77f43
+  languageName: node
+  linkType: hard
+
+"argparse@npm:^1.0.7":
+  version: 1.0.10
+  resolution: "argparse@npm:1.0.10"
+  dependencies:
+    sprintf-js: ~1.0.2
+  checksum: 7ca6e45583a28de7258e39e13d81e925cfa25d7d4aacbf806a382d3c02fcb13403a07fb8aeef949f10a7cfe4a62da0e2e807b348a5980554cc28ee573ef95945
   languageName: node
   linkType: hard
 
@@ -3646,6 +4703,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ast-types@npm:^0.13.4":
+  version: 0.13.4
+  resolution: "ast-types@npm:0.13.4"
+  dependencies:
+    tslib: ^2.0.1
+  checksum: 5a51f7b70588ecced3601845a0e203279ca2f5fdc184416a0a1640c93ec0a267241d6090a328e78eebb8de81f8754754e0a4f1558ba2a3d638f8ccbd0b1f0eff
+  languageName: node
+  linkType: hard
+
 "ast-types@npm:^0.16.1":
   version: 0.16.1
   resolution: "ast-types@npm:0.16.1"
@@ -3659,6 +4725,43 @@ __metadata:
   version: 1.0.0
   resolution: "async-function@npm:1.0.0"
   checksum: 9102e246d1ed9b37ac36f57f0a6ca55226876553251a31fc80677e71471f463a54c872dc78d5d7f80740c8ba624395cccbe8b60f7b690c4418f487d8e9fd1106
+  languageName: node
+  linkType: hard
+
+"async-listen@npm:1.2.0":
+  version: 1.2.0
+  resolution: "async-listen@npm:1.2.0"
+  checksum: 259f0406fccf1ecc80a707b0808d7607e0d1c7f5212ae1537b4f597202713e2d6cbd48026ed3bf9bc6bd8f85077c308797ac38831e93eb920e3ce2907efa816c
+  languageName: node
+  linkType: hard
+
+"async-listen@npm:3.0.0":
+  version: 3.0.0
+  resolution: "async-listen@npm:3.0.0"
+  checksum: 3c238e213219ca71bd1239398a852d7c40b9fe212066616d5ab80861c2a014c100acebe48cd57b5ac2d8d66096ee0ea760b25d574f99a0236977921ff7149582
+  languageName: node
+  linkType: hard
+
+"async-listen@npm:3.0.1":
+  version: 3.0.1
+  resolution: "async-listen@npm:3.0.1"
+  checksum: ff519d0bdd819b5d2eee209bd7a573b7f058690696b11aa45128fe4073bd33e2441da0d01134bd464b81def6f423a5de1c28ab35d10ba1a8d81a5374f3515b90
+  languageName: node
+  linkType: hard
+
+"async-retry@npm:1.3.3, async-retry@npm:^1.3.3":
+  version: 1.3.3
+  resolution: "async-retry@npm:1.3.3"
+  dependencies:
+    retry: 0.13.1
+  checksum: 38a7152ff7265a9321ea214b9c69e8224ab1febbdec98efbbde6e562f17ff68405569b796b1c5271f354aef8783665d29953f051f68c1fc45306e61aec82fdc4
+  languageName: node
+  linkType: hard
+
+"async-sema@npm:^3.1.1":
+  version: 3.1.1
+  resolution: "async-sema@npm:3.1.1"
+  checksum: 07b8c51f6cab107417ecdd8126b7a9fe5a75151b7f69fdd420dcc8ee08f9e37c473a217247e894b56e999b088b32e902dbe41637e4e9b594d3f8dfcdddfadc5e
   languageName: node
   linkType: hard
 
@@ -3734,6 +4837,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"b4a@npm:^1.6.4":
+  version: 1.8.0
+  resolution: "b4a@npm:1.8.0"
+  peerDependencies:
+    react-native-b4a: "*"
+  peerDependenciesMeta:
+    react-native-b4a:
+      optional: true
+  checksum: 92a3addf120a69c26c8dfcda1537eb63e10e682fb44a7f2d78f3347fe12c61b4022152b5a7f16bd71872f34eda84c4b8ce441cbe02a07e9a7cd7c1a3cb0ecf07
+  languageName: node
+  linkType: hard
+
 "balanced-match@npm:^1.0.0":
   version: 1.0.2
   resolution: "balanced-match@npm:1.0.2"
@@ -3747,6 +4862,18 @@ __metadata:
   dependencies:
     jackspeak: ^4.2.3
   checksum: 862d6e14832a45558bdd2bc4663ba6d8e7ba60670a6cb1ef952a62348d5f086b16ee71a21b369f0fee808432590c724c823a80cb59eddd140b5ffa3f55497b62
+  languageName: node
+  linkType: hard
+
+"bare-events@npm:^2.7.0":
+  version: 2.8.2
+  resolution: "bare-events@npm:2.8.2"
+  peerDependencies:
+    bare-abort-controller: "*"
+  peerDependenciesMeta:
+    bare-abort-controller:
+      optional: true
+  checksum: 97e6fc825bc984363a1f695c9a962b1b9f0ea467baa95d7059565a0aa31f4b5fc0f5eb71c087456ae3a436f39fce14a6147a12dd63aac0ff1d20cc5ad64cd780
   languageName: node
   linkType: hard
 
@@ -3765,6 +4892,13 @@ __metadata:
   bin:
     baseline-browser-mapping: dist/cli.cjs
   checksum: 1004b87052c8c06578bc7057aa654fe445dd9c3ca1299fdc8665972899ec1c1717e6e2ab7b62218042d494ae4a7e052d58c224052c0aa58d39925943350d18c9
+  languageName: node
+  linkType: hard
+
+"basic-ftp@npm:^5.0.2":
+  version: 5.3.0
+  resolution: "basic-ftp@npm:5.3.0"
+  checksum: b2c93d98541c805171813bddd7e6349b7fc304ba8896acf60b0b4393253204cff88aa2a31adbaec2f1a58f78e90005672c30796042a2c717a69ccae10160d72d
   languageName: node
   linkType: hard
 
@@ -3876,6 +5010,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"bindings@npm:^1.4.0":
+  version: 1.5.0
+  resolution: "bindings@npm:1.5.0"
+  dependencies:
+    file-uri-to-path: 1.0.0
+  checksum: 65b6b48095717c2e6105a021a7da4ea435aa8d3d3cd085cb9e85bcb6e5773cf318c4745c3f7c504412855940b585bdf9b918236612a1c7a7942491de176f1ae7
+  languageName: node
+  linkType: hard
+
 "body-parser@npm:^2.2.1":
   version: 2.2.2
   resolution: "body-parser@npm:2.2.2"
@@ -3943,6 +5086,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"buffer-crc32@npm:~0.2.3":
+  version: 0.2.13
+  resolution: "buffer-crc32@npm:0.2.13"
+  checksum: 06252347ae6daca3453b94e4b2f1d3754a3b146a111d81c68924c22d91889a40623264e95e67955b1cb4a68cbedf317abeabb5140a9766ed248973096db5ce1c
+  languageName: node
+  linkType: hard
+
 "buffer-from@npm:^1.0.0":
   version: 1.1.2
   resolution: "buffer-from@npm:1.1.2"
@@ -3956,6 +5106,13 @@ __metadata:
   dependencies:
     run-applescript: ^7.0.0
   checksum: 1d966c8d2dbf4d9d394e53b724ac756c2414c45c01340b37743621f59cc565a435024b394ddcb62b9b335d1c9a31f4640eb648c3fec7f97ee74dc0694c9beb6c
+  languageName: node
+  linkType: hard
+
+"bytes@npm:3.1.0":
+  version: 3.1.0
+  resolution: "bytes@npm:3.1.0"
+  checksum: 7c3b21c5d9d44ed455460d5d36a31abc6fa2ce3807964ba60a4b03fd44454c8cf07bb0585af83bfde1c5cc2ea4bbe5897bc3d18cd15e0acf25a3615a35aba2df
   languageName: node
   linkType: hard
 
@@ -4076,10 +5233,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"chokidar@npm:4.0.0":
+  version: 4.0.0
+  resolution: "chokidar@npm:4.0.0"
+  dependencies:
+    readdirp: ^4.0.1
+  checksum: f528f5cf22135fcdbe2ee44a89de3ebff4f94db7e101c55e5d92169bd4b52ce5b97d3ee0b74fe4fb57a065d2f2efce82f8bc687751e56b0a1870e9fe201b1c99
+  languageName: node
+  linkType: hard
+
 "chownr@npm:^3.0.0":
   version: 3.0.0
   resolution: "chownr@npm:3.0.0"
   checksum: fd73a4bab48b79e66903fe1cafbdc208956f41ea4f856df883d0c7277b7ab29fd33ee65f93b2ec9192fc0169238f2f8307b7735d27c155821d886b84aa97aa8d
+  languageName: node
+  linkType: hard
+
+"cjs-module-lexer@npm:1.2.3":
+  version: 1.2.3
+  resolution: "cjs-module-lexer@npm:1.2.3"
+  checksum: 5ea3cb867a9bb609b6d476cd86590d105f3cfd6514db38ff71f63992ab40939c2feb68967faa15a6d2b1f90daa6416b79ea2de486e9e2485a6f8b66a21b4fb0a
   languageName: node
   linkType: hard
 
@@ -4155,6 +5328,13 @@ __metadata:
   version: 2.1.1
   resolution: "clsx@npm:2.1.1"
   checksum: acd3e1ab9d8a433ecb3cc2f6a05ab95fe50b4a3cfc5ba47abb6cbf3754585fcb87b84e90c822a1f256c4198e3b41c7f6c391577ffc8678ad587fc0976b24fd57
+  languageName: node
+  linkType: hard
+
+"code-block-writer@npm:^10.1.1":
+  version: 10.1.1
+  resolution: "code-block-writer@npm:10.1.1"
+  checksum: e048037acbcbda19fca62a3a63e4a64226ea6b5dc0fad7632d34a88c1165b29a357e5e19f0497811e9911472e824ab85f68176f40e439da87e051908956eb47c
   languageName: node
   linkType: hard
 
@@ -4267,6 +5447,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"consola@npm:^3.2.3":
+  version: 3.4.2
+  resolution: "consola@npm:3.4.2"
+  checksum: 32d1339e0505842f033ca34cb4572a841281caa367f438b785d3b284ab2a06134f009e605908480402c5f57f56c1e3210090c37e6417923416f76ce730d39361
+  languageName: node
+  linkType: hard
+
 "console.table@npm:^0.10.0":
   version: 0.10.0
   resolution: "console.table@npm:0.10.0"
@@ -4280,6 +5467,13 @@ __metadata:
   version: 1.0.1
   resolution: "content-disposition@npm:1.0.1"
   checksum: f1ee5363968e7e4c491fcd9796d3c489ab29c4ea0bfa5dcc3379a9833d6044838367cf8a11c90b179cb2a8d471279ab259119c52e0d3e4ed30934ccd56b6d694
+  languageName: node
+  linkType: hard
+
+"content-type@npm:1.0.4":
+  version: 1.0.4
+  resolution: "content-type@npm:1.0.4"
+  checksum: 3d93585fda985d1554eca5ebd251994327608d2e200978fdbfba21c0c679914d5faf266d17027de44b34a72c7b0745b18584ecccaa7e1fdfb6a68ac7114f12e0
   languageName: node
   linkType: hard
 
@@ -4364,10 +5558,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"convert-hrtime@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "convert-hrtime@npm:3.0.0"
+  checksum: d022c950e99753ccb948583cacbc77353e7686982219d046da34957dc2924f8d6f198f55fef233d017b73d1afeb18541e7f7cd0ea5934bd8ca272edace83a7b9
+  languageName: node
+  linkType: hard
+
 "convert-source-map@npm:^2.0.0":
   version: 2.0.0
   resolution: "convert-source-map@npm:2.0.0"
   checksum: 63ae9933be5a2b8d4509daca5124e20c14d023c820258e484e32dc324d34c2754e71297c94a05784064ad27615037ef677e3f0c00469fb55f409d2bb21261035
+  languageName: node
+  linkType: hard
+
+"cookie-es@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "cookie-es@npm:2.0.1"
+  checksum: 365c5d2b1efc80c8c19c127cac48d615effdf296e7314e39a33b925468fb332ca2f83950492ba8131cdd0c9c17cd9b9e8848e526ba8375c6663c6ac75c7906eb
   languageName: node
   linkType: hard
 
@@ -4462,7 +5670,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cross-spawn@npm:^7.0.3, cross-spawn@npm:^7.0.5, cross-spawn@npm:^7.0.6":
+"cross-spawn@npm:^7.0.0, cross-spawn@npm:^7.0.3, cross-spawn@npm:^7.0.5, cross-spawn@npm:^7.0.6":
   version: 7.0.6
   resolution: "cross-spawn@npm:7.0.6"
   dependencies:
@@ -4500,6 +5708,13 @@ __metadata:
   version: 4.0.1
   resolution: "data-uri-to-buffer@npm:4.0.1"
   checksum: 0d0790b67ffec5302f204c2ccca4494f70b4e2d940fea3d36b09f0bb2b8539c2e86690429eb1f1dc4bcc9e4df0644193073e63d9ee48ac9fce79ec1506e4aa4c
+  languageName: node
+  linkType: hard
+
+"data-uri-to-buffer@npm:^6.0.2":
+  version: 6.0.2
+  resolution: "data-uri-to-buffer@npm:6.0.2"
+  checksum: 8b6927c33f9b54037f442856be0aa20e5fd49fa6c9c8ceece408dc306445d593ad72d207d57037c529ce65f413b421da800c6827b1dbefb607b8056f17123a61
   languageName: node
   linkType: hard
 
@@ -4543,7 +5758,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:4, debug@npm:^4.1.0, debug@npm:^4.1.1, debug@npm:^4.3.1, debug@npm:^4.3.4, debug@npm:^4.4.0, debug@npm:^4.4.3":
+"debug@npm:4, debug@npm:^4.1.0, debug@npm:^4.1.1, debug@npm:^4.3.1, debug@npm:^4.3.4, debug@npm:^4.4.0, debug@npm:^4.4.1, debug@npm:^4.4.3":
   version: 4.4.3
   resolution: "debug@npm:4.4.3"
   dependencies:
@@ -4552,6 +5767,18 @@ __metadata:
     supports-color:
       optional: true
   checksum: 4805abd570e601acdca85b6aa3757186084a45cff9b2fa6eee1f3b173caa776b45f478b2a71a572d616d2010cea9211d0ac4a02a610e4c18ac4324bde3760834
+  languageName: node
+  linkType: hard
+
+"debug@npm:4.3.4":
+  version: 4.3.4
+  resolution: "debug@npm:4.3.4"
+  dependencies:
+    ms: 2.1.2
+  peerDependenciesMeta:
+    supports-color:
+      optional: true
+  checksum: 3dbad3f94ea64f34431a9cbf0bafb61853eda57bff2880036153438f50fb5a84f27683ba0d8e5426bf41a8c6ff03879488120cf5b3a761e77953169c0600a708
   languageName: node
   linkType: hard
 
@@ -4667,6 +5894,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"degenerator@npm:^5.0.0":
+  version: 5.0.1
+  resolution: "degenerator@npm:5.0.1"
+  dependencies:
+    ast-types: ^0.13.4
+    escodegen: ^2.1.0
+    esprima: ^4.0.1
+  checksum: a64fa39cdf6c2edd75188157d32338ee9de7193d7dbb2aeb4acb1eb30fa4a15ed80ba8dae9bd4d7b085472cf174a5baf81adb761aaa8e326771392c922084152
+  languageName: node
+  linkType: hard
+
 "delayed-stream@npm:~1.0.0":
   version: 1.0.0
   resolution: "delayed-stream@npm:1.0.0"
@@ -4681,6 +5919,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"depd@npm:~1.1.2":
+  version: 1.1.2
+  resolution: "depd@npm:1.1.2"
+  checksum: 6b406620d269619852885ce15965272b829df6f409724415e0002c8632ab6a8c0a08ec1f0bd2add05dc7bd7507606f7e2cc034fa24224ab829580040b835ecd9
+  languageName: node
+  linkType: hard
+
 "deprecation@npm:^2.0.0, deprecation@npm:^2.3.1":
   version: 2.3.1
   resolution: "deprecation@npm:2.3.1"
@@ -4688,7 +5933,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"detect-libc@npm:^2.0.3, detect-libc@npm:^2.1.2":
+"detect-libc@npm:^2.0.0, detect-libc@npm:^2.0.3, detect-libc@npm:^2.1.2":
   version: 2.1.2
   resolution: "detect-libc@npm:2.1.2"
   checksum: 471740d52365084c4b2ae359e507b863f2b1d79b08a92835ebdf701918e08fc9cfba175b3db28483ca33b155e1311a91d69dc42c6d192b476f41a9e1f094ce6a
@@ -4876,6 +6121,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"edge-runtime@npm:2.5.9":
+  version: 2.5.9
+  resolution: "edge-runtime@npm:2.5.9"
+  dependencies:
+    "@edge-runtime/format": 2.2.1
+    "@edge-runtime/ponyfill": 2.4.2
+    "@edge-runtime/vm": 3.2.0
+    async-listen: 3.0.1
+    mri: 1.2.0
+    picocolors: 1.0.0
+    pretty-ms: 7.0.1
+    signal-exit: 4.0.2
+    time-span: 4.0.0
+  bin:
+    edge-runtime: dist/cli/index.js
+  checksum: 12108c47ceccc9722dfe154731ef22649a2d4612188ab0e79fda8dbd84e9e9979f772161e387a2ff083835188cd6e326eede1a74db0afe3d1de3c827f2668132
+  languageName: node
+  linkType: hard
+
 "ee-first@npm:1.1.1":
   version: 1.1.1
   resolution: "ee-first@npm:1.1.1"
@@ -4908,6 +6172,24 @@ __metadata:
   version: 2.0.0
   resolution: "encodeurl@npm:2.0.0"
   checksum: abf5cd51b78082cf8af7be6785813c33b6df2068ce5191a40ca8b1afe6a86f9230af9a9ce694a5ce4665955e5c1120871826df9c128a642e09c58d592e2807fe
+  languageName: node
+  linkType: hard
+
+"end-of-stream@npm:^1.1.0":
+  version: 1.4.5
+  resolution: "end-of-stream@npm:1.4.5"
+  dependencies:
+    once: ^1.4.0
+  checksum: 1e0cfa6e7f49887544e03314f9dfc56a8cb6dde910cbb445983ecc2ff426fc05946df9d75d8a21a3a64f2cecfe1bf88f773952029f46756b2ed64a24e95b1fb8
+  languageName: node
+  linkType: hard
+
+"end-of-stream@npm:~1.1.0":
+  version: 1.1.0
+  resolution: "end-of-stream@npm:1.1.0"
+  dependencies:
+    once: ~1.3.0
+  checksum: 9fa637e259e50e5e3634e8e14064a183bd0d407733594631362f9df596409739bef5f7064840e6725212a9edc8b4a70a5a3088ac423e8564f9dc183dd098c719
   languageName: node
   linkType: hard
 
@@ -5045,6 +6327,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"es-module-lexer@npm:1.4.1":
+  version: 1.4.1
+  resolution: "es-module-lexer@npm:1.4.1"
+  checksum: a11b5a256d4e8e9c7d94c2fd87415ccd1591617b6edd847e064503f8eaece2d25e2e9078a02c5ce3ed5e83bb748f5b4820efbe78072c8beb07ac619c2edec35d
+  languageName: node
+  linkType: hard
+
+"es-module-lexer@npm:1.5.0":
+  version: 1.5.0
+  resolution: "es-module-lexer@npm:1.5.0"
+  checksum: adbe0772701e226b4b853f758fd89c0bbfe8357ab93babde7b1cdb4f88c3a31460c908cbe578817e241d116cc4fcf569f7c6f29c4fbfa0aadb0def90f1ad4dd2
+  languageName: node
+  linkType: hard
+
 "es-object-atoms@npm:^1.0.0, es-object-atoms@npm:^1.1.1":
   version: 1.1.1
   resolution: "es-object-atoms@npm:1.1.1"
@@ -5090,6 +6386,95 @@ __metadata:
   version: 4.2.8
   resolution: "es6-promise@npm:4.2.8"
   checksum: 95614a88873611cb9165a85d36afa7268af5c03a378b35ca7bda9508e1d4f1f6f19a788d4bc755b3fd37c8ebba40782018e02034564ff24c9d6fa37e959ad57d
+  languageName: node
+  linkType: hard
+
+"esbuild@npm:0.27.0":
+  version: 0.27.0
+  resolution: "esbuild@npm:0.27.0"
+  dependencies:
+    "@esbuild/aix-ppc64": 0.27.0
+    "@esbuild/android-arm": 0.27.0
+    "@esbuild/android-arm64": 0.27.0
+    "@esbuild/android-x64": 0.27.0
+    "@esbuild/darwin-arm64": 0.27.0
+    "@esbuild/darwin-x64": 0.27.0
+    "@esbuild/freebsd-arm64": 0.27.0
+    "@esbuild/freebsd-x64": 0.27.0
+    "@esbuild/linux-arm": 0.27.0
+    "@esbuild/linux-arm64": 0.27.0
+    "@esbuild/linux-ia32": 0.27.0
+    "@esbuild/linux-loong64": 0.27.0
+    "@esbuild/linux-mips64el": 0.27.0
+    "@esbuild/linux-ppc64": 0.27.0
+    "@esbuild/linux-riscv64": 0.27.0
+    "@esbuild/linux-s390x": 0.27.0
+    "@esbuild/linux-x64": 0.27.0
+    "@esbuild/netbsd-arm64": 0.27.0
+    "@esbuild/netbsd-x64": 0.27.0
+    "@esbuild/openbsd-arm64": 0.27.0
+    "@esbuild/openbsd-x64": 0.27.0
+    "@esbuild/openharmony-arm64": 0.27.0
+    "@esbuild/sunos-x64": 0.27.0
+    "@esbuild/win32-arm64": 0.27.0
+    "@esbuild/win32-ia32": 0.27.0
+    "@esbuild/win32-x64": 0.27.0
+  dependenciesMeta:
+    "@esbuild/aix-ppc64":
+      optional: true
+    "@esbuild/android-arm":
+      optional: true
+    "@esbuild/android-arm64":
+      optional: true
+    "@esbuild/android-x64":
+      optional: true
+    "@esbuild/darwin-arm64":
+      optional: true
+    "@esbuild/darwin-x64":
+      optional: true
+    "@esbuild/freebsd-arm64":
+      optional: true
+    "@esbuild/freebsd-x64":
+      optional: true
+    "@esbuild/linux-arm":
+      optional: true
+    "@esbuild/linux-arm64":
+      optional: true
+    "@esbuild/linux-ia32":
+      optional: true
+    "@esbuild/linux-loong64":
+      optional: true
+    "@esbuild/linux-mips64el":
+      optional: true
+    "@esbuild/linux-ppc64":
+      optional: true
+    "@esbuild/linux-riscv64":
+      optional: true
+    "@esbuild/linux-s390x":
+      optional: true
+    "@esbuild/linux-x64":
+      optional: true
+    "@esbuild/netbsd-arm64":
+      optional: true
+    "@esbuild/netbsd-x64":
+      optional: true
+    "@esbuild/openbsd-arm64":
+      optional: true
+    "@esbuild/openbsd-x64":
+      optional: true
+    "@esbuild/openharmony-arm64":
+      optional: true
+    "@esbuild/sunos-x64":
+      optional: true
+    "@esbuild/win32-arm64":
+      optional: true
+    "@esbuild/win32-ia32":
+      optional: true
+    "@esbuild/win32-x64":
+      optional: true
+  bin:
+    esbuild: bin/esbuild
+  checksum: db33b01d8f9234843e411c87527587f646b5ac082e3759fe796a71878dcb1180da0d4f8b33525c492d918c0262befe0e724c2d5d8a2c4b611c2c75549a3dbf91
   languageName: node
   linkType: hard
 
@@ -5369,7 +6754,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esprima@npm:~4.0.0":
+"escodegen@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "escodegen@npm:2.1.0"
+  dependencies:
+    esprima: ^4.0.1
+    estraverse: ^5.2.0
+    esutils: ^2.0.2
+    source-map: ~0.6.1
+  dependenciesMeta:
+    source-map:
+      optional: true
+  bin:
+    escodegen: bin/escodegen.js
+    esgenerate: bin/esgenerate.js
+  checksum: 096696407e161305cd05aebb95134ad176708bc5cb13d0dcc89a5fcbb959b8ed757e7f2591a5f8036f8f4952d4a724de0df14cd419e29212729fa6df5ce16bf6
+  languageName: node
+  linkType: hard
+
+"esprima@npm:^4.0.0, esprima@npm:^4.0.1, esprima@npm:~4.0.0":
   version: 4.0.1
   resolution: "esprima@npm:4.0.1"
   bin:
@@ -5379,10 +6782,47 @@ __metadata:
   languageName: node
   linkType: hard
 
-"etag@npm:^1.8.1":
+"estraverse@npm:^5.2.0":
+  version: 5.3.0
+  resolution: "estraverse@npm:5.3.0"
+  checksum: 072780882dc8416ad144f8fe199628d2b3e7bbc9989d9ed43795d2c90309a2047e6bc5979d7e2322a341163d22cfad9e21f4110597fe487519697389497e4e2b
+  languageName: node
+  linkType: hard
+
+"estree-walker@npm:2.0.2, estree-walker@npm:^2.0.2":
+  version: 2.0.2
+  resolution: "estree-walker@npm:2.0.2"
+  checksum: 6151e6f9828abe2259e57f5fd3761335bb0d2ebd76dc1a01048ccee22fabcfef3c0859300f6d83ff0d1927849368775ec5a6d265dde2f6de5a1be1721cd94efc
+  languageName: node
+  linkType: hard
+
+"esutils@npm:^2.0.2":
+  version: 2.0.3
+  resolution: "esutils@npm:2.0.3"
+  checksum: 22b5b08f74737379a840b8ed2036a5fb35826c709ab000683b092d9054e5c2a82c27818f12604bfc2a9a76b90b6834ef081edbc1c7ae30d1627012e067c6ec87
+  languageName: node
+  linkType: hard
+
+"etag@npm:1.8.1, etag@npm:^1.8.1":
   version: 1.8.1
   resolution: "etag@npm:1.8.1"
   checksum: 571aeb3dbe0f2bbd4e4fadbdb44f325fc75335cd5f6f6b6a091e6a06a9f25ed5392f0863c5442acb0646787446e816f13cbfc6edce5b07658541dff573cab1ff
+  languageName: node
+  linkType: hard
+
+"events-intercept@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "events-intercept@npm:2.0.0"
+  checksum: 1aa3447249584abb15d046ce847476e57772a98ec856d3093cea33c90bdd60428125834668c624f9f0e54203d6efd0b35550547082ddcc374e029d85664eddb0
+  languageName: node
+  linkType: hard
+
+"events-universal@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "events-universal@npm:1.0.1"
+  dependencies:
+    bare-events: ^2.7.0
+  checksum: fb8451c98535bde30585004303a368d55c38e5bc3ed6aa9b5d29fecaabaf8ec276a33ff77dcc1d1c05eecf83b8161f184cabc9a03b76a06c10e9a4ce827a6abc
   languageName: node
   linkType: hard
 
@@ -5402,7 +6842,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"execa@npm:^5.0.0, execa@npm:^5.1.1":
+"execa@npm:3.2.0":
+  version: 3.2.0
+  resolution: "execa@npm:3.2.0"
+  dependencies:
+    cross-spawn: ^7.0.0
+    get-stream: ^5.0.0
+    human-signals: ^1.1.1
+    is-stream: ^2.0.0
+    merge-stream: ^2.0.0
+    npm-run-path: ^4.0.0
+    onetime: ^5.1.0
+    p-finally: ^2.0.0
+    signal-exit: ^3.0.2
+    strip-final-newline: ^2.0.0
+  checksum: 1c5e4629d5e40151ee6b3902740b0fee1e1fe519483472d020e0ec1bc6a4f12903ba02c569868c81416f6ad122da9d96f273164bc641648bada42cce9c56f907
+  languageName: node
+  linkType: hard
+
+"execa@npm:5, execa@npm:^5.0.0, execa@npm:^5.1.1":
   version: 5.1.1
   resolution: "execa@npm:5.1.1"
   dependencies:
@@ -5493,14 +6951,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-deep-equal@npm:^3.1.3":
+"fast-deep-equal@npm:^3.1.1, fast-deep-equal@npm:^3.1.3":
   version: 3.1.3
   resolution: "fast-deep-equal@npm:3.1.3"
   checksum: e21a9d8d84f53493b6aa15efc9cfd53dd5b714a1f23f67fb5dc8f574af80df889b3bce25dc081887c6d25457cce704e636395333abad896ccdec03abaf1f3f9d
   languageName: node
   linkType: hard
 
-"fast-glob@npm:^3.1.1, fast-glob@npm:^3.3.3":
+"fast-fifo@npm:^1.2.0, fast-fifo@npm:^1.3.2":
+  version: 1.3.2
+  resolution: "fast-fifo@npm:1.3.2"
+  checksum: 6bfcba3e4df5af7be3332703b69a7898a8ed7020837ec4395bb341bd96cc3a6d86c3f6071dd98da289618cf2234c70d84b2a6f09a33dd6f988b1ff60d8e54275
+  languageName: node
+  linkType: hard
+
+"fast-glob@npm:^3.1.1, fast-glob@npm:^3.2.7, fast-glob@npm:^3.3.3":
   version: 3.3.3
   resolution: "fast-glob@npm:3.3.3"
   dependencies:
@@ -5540,6 +7005,15 @@ __metadata:
   dependencies:
     reusify: ^1.0.4
   checksum: 49128edbf05e682bee3c1db3d2dfc7da195469065ef014d8368c555d829932313ae2ddf584bb03146409b0d5d9fdb387c471075483a7319b52f777ad91128ed8
+  languageName: node
+  linkType: hard
+
+"fd-slicer@npm:~1.1.0":
+  version: 1.1.0
+  resolution: "fd-slicer@npm:1.1.0"
+  dependencies:
+    pend: ~1.2.0
+  checksum: c8585fd5713f4476eb8261150900d2cb7f6ff2d87f8feb306ccc8a1122efd152f1783bdb2b8dc891395744583436bfd8081d8e63ece0ec8687eeefea394d4ff2
   languageName: node
   linkType: hard
 
@@ -5594,6 +7068,13 @@ __metadata:
   dependencies:
     is-unicode-supported: ^2.0.0
   checksum: 35c81239d4fa40b75c2c7c010833b0bc8861c27187e4c9388fca1d9731103ec9989b70ee3b664ef426ddd9abe02ec5f4fd973424aa8c6fd3ea5d3bf57a2d01b4
+  languageName: node
+  linkType: hard
+
+"file-uri-to-path@npm:1.0.0":
+  version: 1.0.0
+  resolution: "file-uri-to-path@npm:1.0.0"
+  checksum: b648580bdd893a008c92c7ecc96c3ee57a5e7b6c4c18a9a09b44fb5d36d79146f8e442578bc0e173dc027adf3987e254ba1dfd6e3ec998b7c282873010502144
   languageName: node
   linkType: hard
 
@@ -5667,7 +7148,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"form-data@npm:^4.0.4, form-data@npm:^4.0.5":
+"form-data@npm:^4.0.0, form-data@npm:^4.0.4, form-data@npm:^4.0.5":
   version: 4.0.5
   resolution: "form-data@npm:4.0.5"
   dependencies:
@@ -5758,6 +7239,28 @@ __metadata:
   version: 1.3.2
   resolution: "fromentries@npm:1.3.2"
   checksum: 33729c529ce19f5494f846f0dd4945078f4e37f4e8955f4ae8cc7385c218f600e9d93a7d225d17636c20d1889106fd87061f911550861b7072f53bf891e6b341
+  languageName: node
+  linkType: hard
+
+"fs-extra@npm:11.1.0":
+  version: 11.1.0
+  resolution: "fs-extra@npm:11.1.0"
+  dependencies:
+    graceful-fs: ^4.2.0
+    jsonfile: ^6.0.1
+    universalify: ^2.0.0
+  checksum: 5ca476103fa1f5ff4a9b3c4f331548f8a3c1881edaae323a4415d3153b5dc11dc6a981c8d1dd93eec8367ceee27b53f8bd27eecbbf66ffcdd04927510c171e7f
+  languageName: node
+  linkType: hard
+
+"fs-extra@npm:11.1.1":
+  version: 11.1.1
+  resolution: "fs-extra@npm:11.1.1"
+  dependencies:
+    graceful-fs: ^4.2.0
+    jsonfile: ^6.0.1
+    universalify: ^2.0.0
+  checksum: fb883c68245b2d777fbc1f2082c9efb084eaa2bbf9fddaa366130d196c03608eebef7fb490541276429ee1ca99f317e2d73e96f5ca0999eefedf5a624ae1edfd
   languageName: node
   linkType: hard
 
@@ -5868,6 +7371,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"generic-pool@npm:3.4.2":
+  version: 3.4.2
+  resolution: "generic-pool@npm:3.4.2"
+  checksum: 174a787d8d7dc6b6426efa61e5111a29c32a34c64246837fbda0eb874e943fa5fbbff31535abbd11d6288fb2c4207589e1ec1b60eb9a4025fd774e3acb5bf769
+  languageName: node
+  linkType: hard
+
 "gensync@npm:^1.0.0-beta.2":
   version: 1.0.0-beta.2
   resolution: "gensync@npm:1.0.0-beta.2"
@@ -5948,6 +7458,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"get-stream@npm:^5.0.0":
+  version: 5.2.0
+  resolution: "get-stream@npm:5.2.0"
+  dependencies:
+    pump: ^3.0.0
+  checksum: 8bc1a23174a06b2b4ce600df38d6c98d2ef6d84e020c1ddad632ad75bac4e092eeb40e4c09e0761c35fc2dbc5e7fff5dab5e763a383582c4a167dd69a905bd12
+  languageName: node
+  linkType: hard
+
 "get-stream@npm:^6.0.0":
   version: 6.0.1
   resolution: "get-stream@npm:6.0.1"
@@ -5982,6 +7501,17 @@ __metadata:
   dependencies:
     resolve-pkg-maps: ^1.0.0
   checksum: fa00f90cb0fddd1a4719576d933de416ff6285f6dcf331296dc76434b82bc90e639fdc2c256888771dee154cc128cb9eba9152c76145bd295c9735dd13261967
+  languageName: node
+  linkType: hard
+
+"get-uri@npm:^6.0.1":
+  version: 6.0.5
+  resolution: "get-uri@npm:6.0.5"
+  dependencies:
+    basic-ftp: ^5.0.2
+    data-uri-to-buffer: ^6.0.2
+    debug: ^4.3.4
+  checksum: aef94dbecde44bc9cd23f5c1b6af5bf772a3d16612c0fc37d3a4056ffd202f2cdd329746d4fdc2124813ea6c8b1c5279f3749d27226a2b161df43dbcb70082e3
   languageName: node
   linkType: hard
 
@@ -6117,7 +7647,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"graceful-fs@npm:^4.1.2, graceful-fs@npm:^4.1.6, graceful-fs@npm:^4.2.0, graceful-fs@npm:^4.2.4, graceful-fs@npm:^4.2.6":
+"graceful-fs@npm:^4.1.2, graceful-fs@npm:^4.1.6, graceful-fs@npm:^4.2.0, graceful-fs@npm:^4.2.4, graceful-fs@npm:^4.2.6, graceful-fs@npm:^4.2.9":
   version: 4.2.11
   resolution: "graceful-fs@npm:4.2.11"
   checksum: ac85f94da92d8eb6b7f5a8b20ce65e43d66761c55ce85ac96df6865308390da45a8d3f0296dd3a663de65d30ba497bd46c696cc1e248c72b13d6d567138a4fc7
@@ -6264,6 +7794,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"http-errors@npm:1.7.3":
+  version: 1.7.3
+  resolution: "http-errors@npm:1.7.3"
+  dependencies:
+    depd: ~1.1.2
+    inherits: 2.0.4
+    setprototypeof: 1.1.1
+    statuses: ">= 1.5.0 < 2"
+    toidentifier: 1.0.0
+  checksum: a59f359473f4b3ea78305beee90d186268d6075432622a46fb7483059068a2dd4c854a20ac8cd438883127e06afb78c1309168bde6cdfeed1e3700eb42487d99
+  languageName: node
+  linkType: hard
+
 "http-errors@npm:^2.0.0, http-errors@npm:^2.0.1, http-errors@npm:~2.0.1":
   version: 2.0.1
   resolution: "http-errors@npm:2.0.1"
@@ -6277,7 +7820,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"http-proxy-agent@npm:^7.0.0":
+"http-proxy-agent@npm:^7.0.0, http-proxy-agent@npm:^7.0.1":
   version: 7.0.2
   resolution: "http-proxy-agent@npm:7.0.2"
   dependencies:
@@ -6297,13 +7840,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"https-proxy-agent@npm:^7.0.1, https-proxy-agent@npm:^7.0.6":
+"https-proxy-agent@npm:^7.0.1, https-proxy-agent@npm:^7.0.3, https-proxy-agent@npm:^7.0.5, https-proxy-agent@npm:^7.0.6":
   version: 7.0.6
   resolution: "https-proxy-agent@npm:7.0.6"
   dependencies:
     agent-base: ^7.1.2
     debug: 4
   checksum: b882377a120aa0544846172e5db021fa8afbf83fea2a897d397bd2ddd8095ab268c24bc462f40a15f2a8c600bf4aa05ce52927f70038d4014e68aefecfa94e8d
+  languageName: node
+  linkType: hard
+
+"human-signals@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "human-signals@npm:1.1.1"
+  checksum: d587647c9e8ec24e02821b6be7de5a0fc37f591f6c4e319b3054b43fd4c35a70a94c46fc74d8c1a43c47fde157d23acd7421f375e1c1365b09a16835b8300205
   languageName: node
   linkType: hard
 
@@ -6327,6 +7877,15 @@ __metadata:
   bin:
     husky: bin.js
   checksum: c2412753f15695db369634ba70f50f5c0b7e5cb13b673d0826c411ec1bd9ddef08c1dad89ea154f57da2521d2605bd64308af748749b27d08c5f563bcd89975f
+  languageName: node
+  linkType: hard
+
+"iconv-lite@npm:0.4.24":
+  version: 0.4.24
+  resolution: "iconv-lite@npm:0.4.24"
+  dependencies:
+    safer-buffer: ">= 2.1.2 < 3"
+  checksum: bd9f120f5a5b306f0bc0b9ae1edeb1577161503f5f8252a20f1a9e56ef8775c9959fd01c55f2d3a39d9a8abaf3e30c1abeb1895f367dcbbe0a8fd1c9ca01c4f6
   languageName: node
   linkType: hard
 
@@ -6398,7 +7957,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"inherits@npm:2, inherits@npm:^2.0.3, inherits@npm:~2.0.3, inherits@npm:~2.0.4":
+"inherits@npm:2, inherits@npm:2.0.4, inherits@npm:^2.0.3, inherits@npm:~2.0.3, inherits@npm:~2.0.4":
   version: 2.0.4
   resolution: "inherits@npm:2.0.4"
   checksum: 4a48a733847879d6cf6691860a6b1e3f0f4754176e4d71494c41f3475553768b10f84b5ce1d40fbd0e34e6bfbb864ee35858ad4dd2cf31e02fc4a154b724d7f1
@@ -6503,6 +8062,13 @@ __metadata:
     call-bound: ^1.0.3
     has-tostringtag: ^1.0.2
   checksum: 0415b181e8f1bfd5d3f8a20f8108e64d372a72131674eea9c2923f39d065b6ad08d654765553bdbffbd92c3746f1007986c34087db1bd89a31f71be8359ccdaa
+  languageName: node
+  linkType: hard
+
+"is-buffer@npm:^2.0.5":
+  version: 2.0.5
+  resolution: "is-buffer@npm:2.0.5"
+  checksum: 764c9ad8b523a9f5a32af29bdf772b08eb48c04d2ad0a7240916ac2688c983bf5f8504bf25b35e66240edeb9d9085461f9b5dae1f3d2861c6b06a65fe983de42
   languageName: node
   linkType: hard
 
@@ -6945,6 +8511,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jose@npm:5.9.6":
+  version: 5.9.6
+  resolution: "jose@npm:5.9.6"
+  checksum: 4b536da0201858ed4c4582e8bb479081f11e0c63dd0f5e473adde16fc539785e1f2f0409bc1fc7cbbb5b68026776c960b4952da3a06f6fdfff0b9764c9127ae0
+  languageName: node
+  linkType: hard
+
 "jose@npm:^6.1.3":
   version: 6.2.2
   resolution: "jose@npm:6.2.2"
@@ -6959,7 +8532,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-yaml@npm:^4.1.0":
+"js-yaml@npm:4.1.1, js-yaml@npm:^4.1.0":
   version: 4.1.1
   resolution: "js-yaml@npm:4.1.1"
   dependencies:
@@ -6967,6 +8540,18 @@ __metadata:
   bin:
     js-yaml: bin/js-yaml.js
   checksum: ea2339c6930fe048ec31b007b3c90be2714ab3e7defcc2c27ebf30c74fd940358f29070b4345af0019ef151875bf3bc3f8644bea1bab0372652b5044813ac02d
+  languageName: node
+  linkType: hard
+
+"js-yaml@npm:^3.10.0, js-yaml@npm:^3.13.1":
+  version: 3.14.2
+  resolution: "js-yaml@npm:3.14.2"
+  dependencies:
+    argparse: ^1.0.7
+    esprima: ^4.0.0
+  bin:
+    js-yaml: bin/js-yaml.js
+  checksum: 626fc207734a3452d6ba84e1c8c226240e6d431426ed94d0ab043c50926d97c509629c08b1d636f5d27815833b7cfd225865631da9fb33cb957374490bf3e90b
   languageName: node
   linkType: hard
 
@@ -6990,6 +8575,16 @@ __metadata:
   version: 2.3.1
   resolution: "json-parse-even-better-errors@npm:2.3.1"
   checksum: 798ed4cf3354a2d9ccd78e86d2169515a0097a5c133337807cdf7f1fc32e1391d207ccfc276518cc1d7d8d4db93288b8a50ba4293d212ad1336e52a8ec0a941f
+  languageName: node
+  linkType: hard
+
+"json-schema-to-ts@npm:1.6.4":
+  version: 1.6.4
+  resolution: "json-schema-to-ts@npm:1.6.4"
+  dependencies:
+    "@types/json-schema": ^7.0.6
+    ts-toolbelt: ^6.15.5
+  checksum: 35399baff3167abafb44c926bf10755fcaa46fa52a52c5c4e467ae18add779c39ad7a998f624d96cb265c6c0f6ba45ff81bc85c8cdb58bb47ba8c4e8f79835df
   languageName: node
   linkType: hard
 
@@ -7043,6 +8638,13 @@ __metadata:
     graceful-fs:
       optional: true
   checksum: c3028ec5c770bb41290c9bb9ca04bdd0a1b698ddbdf6517c9453d3f90fc9e000c9675959fb46891d317690a93c62de03ff1735d8dbe02be83e51168ce85815d3
+  languageName: node
+  linkType: hard
+
+"jsonlines@npm:0.1.1":
+  version: 0.1.1
+  resolution: "jsonlines@npm:0.1.1"
+  checksum: 5408cbdbd396f1c418bc95023a8b3303ad0fac98e73cad9bacf0a73b52739dbaee962c095475618da2c236eeb2532130fd49b3b5fe6320a69d954144062cedbf
   languageName: node
   linkType: hard
 
@@ -7333,12 +8935,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lru-cache@npm:^7.14.1":
+  version: 7.18.3
+  resolution: "lru-cache@npm:7.18.3"
+  checksum: e550d772384709deea3f141af34b6d4fa392e2e418c1498c078de0ee63670f1f46f5eee746e8ef7e69e1c895af0d4224e62ee33e66a543a14763b0f2e74c1356
+  languageName: node
+  linkType: hard
+
 "lucide-react@npm:0.563.0":
   version: 0.563.0
   resolution: "lucide-react@npm:0.563.0"
   peerDependencies:
     react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
   checksum: 842fec302a57ae1e70eafe8b8b5020aef69c0f7969c3bd9af85cf3080f41c68ebedd6bf8bf041d83beb367b4e4febd5689f1e181560a602d0593c5bbfbe804bb
+  languageName: node
+  linkType: hard
+
+"luxon@npm:^3.4.0":
+  version: 3.7.2
+  resolution: "luxon@npm:3.7.2"
+  checksum: fc115fd6a7acc2adb7df3476d20c672beb2985d2a034294282f2c31de8c07f29a15460f5a2b7dd0107797be0dab545ddbc64862662b059fb18c1931a726064f4
   languageName: node
   linkType: hard
 
@@ -7469,6 +9085,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"micro@npm:9.3.5-canary.3":
+  version: 9.3.5-canary.3
+  resolution: "micro@npm:9.3.5-canary.3"
+  dependencies:
+    arg: 4.1.0
+    content-type: 1.0.4
+    raw-body: 2.4.1
+  bin:
+    micro: ./bin/micro.js
+  checksum: 6eed7314460602b073c57fa1c2399354e3186c8a9d692185bd7f2f01ab45d5528054e37add2dc5ce6dff039d16bc728e492616f5451380c492ce78f84c2e4b88
+  languageName: node
+  linkType: hard
+
 "micromatch@npm:^4.0.8":
   version: 4.0.8
   resolution: "micromatch@npm:4.0.8"
@@ -7493,7 +9122,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mime-types@npm:^2.1.12":
+"mime-types@npm:2.1.35, mime-types@npm:^2.1.12":
   version: 2.1.35
   resolution: "mime-types@npm:2.1.35"
   dependencies:
@@ -7532,6 +9161,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"minimatch@npm:10.1.1":
+  version: 10.1.1
+  resolution: "minimatch@npm:10.1.1"
+  dependencies:
+    "@isaacs/brace-expansion": ^5.0.0
+  checksum: 8820c0be92994f57281f0a7a2cc4268dcc4b610f9a1ab666685716b4efe4b5898b43c835a8f22298875b31c7a278a5e3b7e253eee7c886546bb0b61fb94bca6b
+  languageName: node
+  linkType: hard
+
 "minimatch@npm:^10.0.1, minimatch@npm:^10.2.2":
   version: 10.2.4
   resolution: "minimatch@npm:10.2.4"
@@ -7550,7 +9188,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:^3.1.1":
+"minimatch@npm:^3.0.4, minimatch@npm:^3.1.1":
   version: 3.1.5
   resolution: "minimatch@npm:3.1.5"
   dependencies:
@@ -7660,6 +9298,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"mkdirp@npm:^1.0.4":
+  version: 1.0.4
+  resolution: "mkdirp@npm:1.0.4"
+  bin:
+    mkdirp: bin/cmd.js
+  checksum: a96865108c6c3b1b8e1d5e9f11843de1e077e57737602de1b82030815f311be11f96f09cce59bd5b903d0b29834733e5313f9301e3ed6d6f6fba2eae0df4298f
+  languageName: node
+  linkType: hard
+
 "modify-values@npm:^1.0.0":
   version: 1.0.1
   resolution: "modify-values@npm:1.0.1"
@@ -7711,7 +9358,28 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ms@npm:^2.1.3":
+"mri@npm:1.2.0":
+  version: 1.2.0
+  resolution: "mri@npm:1.2.0"
+  checksum: 83f515abbcff60150873e424894a2f65d68037e5a7fcde8a9e2b285ee9c13ac581b63cfc1e6826c4732de3aeb84902f7c1e16b7aff46cd3f897a0f757a894e85
+  languageName: node
+  linkType: hard
+
+"ms@npm:2.1.1":
+  version: 2.1.1
+  resolution: "ms@npm:2.1.1"
+  checksum: 0078a23cd916a9a7435c413caa14c57d4b4f6e2470e0ab554b6964163c8a4436448ac7ae020e883685475da6b6796cc396b670f579cb275db288a21e3e57721e
+  languageName: node
+  linkType: hard
+
+"ms@npm:2.1.2":
+  version: 2.1.2
+  resolution: "ms@npm:2.1.2"
+  checksum: 673cdb2c3133eb050c745908d8ce632ed2c02d85640e2edb3ace856a2266a813b30c613569bf3354fdf4ea7d1a1494add3bfa95e2713baa27d0c2c71fc44f58f
+  languageName: node
+  linkType: hard
+
+"ms@npm:2.1.3, ms@npm:^2.1.3":
   version: 2.1.3
   resolution: "ms@npm:2.1.3"
   checksum: aa92de608021b242401676e35cfa5aa42dd70cbdc082b916da7fb925c542173e36bce97ea3e804923fe92c0ad991434e4a38327e15a1b5b5f945d66df615ae6d
@@ -7792,6 +9460,13 @@ __metadata:
   version: 2.0.1
   resolution: "nested-error-stacks@npm:2.0.1"
   checksum: 8430d7d80ad69b1add2992ee2992a363db6c1a26a54740963bc99a004c5acb1d2a67049397062eab2caa3a312b4da89a0b85de3bdf82d7d472a6baa166311fe6
+  languageName: node
+  linkType: hard
+
+"netmask@npm:^2.0.2":
+  version: 2.1.1
+  resolution: "netmask@npm:2.1.1"
+  checksum: a733e8873a457138518ac0ac9d7c92147b79886c336300ffd2403e067790338eb48939dd0cbbb94251ff070859e7b6dca43410057c99edb8e1982d34a4145a5b
   languageName: node
   linkType: hard
 
@@ -7886,6 +9561,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"node-fetch@npm:2.6.9":
+  version: 2.6.9
+  resolution: "node-fetch@npm:2.6.9"
+  dependencies:
+    whatwg-url: ^5.0.0
+  peerDependencies:
+    encoding: ^0.1.0
+  peerDependenciesMeta:
+    encoding:
+      optional: true
+  checksum: acb04f9ce7224965b2b59e71b33c639794d8991efd73855b0b250921382b38331ffc9d61bce502571f6cc6e11a8905ca9b1b6d4aeb586ab093e2756a1fd190d0
+  languageName: node
+  linkType: hard
+
 "node-fetch@npm:^2.6.0, node-fetch@npm:^2.6.7":
   version: 2.7.0
   resolution: "node-fetch@npm:2.7.0"
@@ -7908,6 +9597,17 @@ __metadata:
     fetch-blob: ^3.1.4
     formdata-polyfill: ^4.0.10
   checksum: 06a04095a2ddf05b0830a0d5302699704d59bda3102894ea64c7b9d4c865ecdff2d90fd042df7f5bc40337266961cb6183dcc808ea4f3000d024f422b462da92
+  languageName: node
+  linkType: hard
+
+"node-gyp-build@npm:^4.2.2":
+  version: 4.8.4
+  resolution: "node-gyp-build@npm:4.8.4"
+  bin:
+    node-gyp-build: bin.js
+    node-gyp-build-optional: optional.js
+    node-gyp-build-test: build-test.js
+  checksum: 8b81ca8ffd5fa257ad8d067896d07908a36918bc84fb04647af09d92f58310def2d2b8614d8606d129d9cd9b48890a5d2bec18abe7fcff54818f72bedd3a7d74
   languageName: node
   linkType: hard
 
@@ -7935,6 +9635,17 @@ __metadata:
   version: 2.0.36
   resolution: "node-releases@npm:2.0.36"
   checksum: c0ca6aec957149cb2c053b077c15a7fb274741a78bac0b6cb921f8bcbace1044388d86a5db860d21bd2e49d8f060cf93367dce89f475225b5d7ca31df60a951a
+  languageName: node
+  linkType: hard
+
+"nopt@npm:^8.0.0":
+  version: 8.1.0
+  resolution: "nopt@npm:8.1.0"
+  dependencies:
+    abbrev: ^3.0.0
+  bin:
+    nopt: bin/nopt.js
+  checksum: 49cfd3eb6f565e292bf61f2ff1373a457238804d5a5a63a8d786c923007498cba89f3648e3b952bc10203e3e7285752abf5b14eaf012edb821e84f24e881a92a
   languageName: node
   linkType: hard
 
@@ -7973,7 +9684,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"npm-run-path@npm:^4.0.1":
+"npm-run-path@npm:^4.0.0, npm-run-path@npm:^4.0.1":
   version: 4.0.1
   resolution: "npm-run-path@npm:4.0.1"
   dependencies:
@@ -8050,7 +9761,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"once@npm:^1.3.0, once@npm:^1.4.0":
+"once@npm:^1.3.0, once@npm:^1.3.1, once@npm:^1.4.0":
   version: 1.4.0
   resolution: "once@npm:1.4.0"
   dependencies:
@@ -8059,7 +9770,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"onetime@npm:^5.1.2":
+"once@npm:~1.3.0":
+  version: 1.3.3
+  resolution: "once@npm:1.3.3"
+  dependencies:
+    wrappy: 1
+  checksum: 8e832de08b1d73b470e01690c211cb4fcefccab1fd1bd19e706d572d74d3e9b7e38a8bfcdabdd364f9f868757d9e8e5812a59817dc473eaf698ff3bfae2219f2
+  languageName: node
+  linkType: hard
+
+"onetime@npm:^5.1.0, onetime@npm:^5.1.2":
   version: 5.1.2
   resolution: "onetime@npm:5.1.2"
   dependencies:
@@ -8115,6 +9835,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"os-paths@npm:^4.0.1":
+  version: 4.4.0
+  resolution: "os-paths@npm:4.4.0"
+  checksum: 4861e9262ca9fa7693a9e5801b0bb50a38a251158b222396102ebe7b04b56b5f716d3c5b81be3410a594e4673004fb247f01fe6a9a89e9616a2a21966f678d49
+  languageName: node
+  linkType: hard
+
 "outvariant@npm:^1.4.0, outvariant@npm:^1.4.3":
   version: 1.4.3
   resolution: "outvariant@npm:1.4.3"
@@ -8130,6 +9857,82 @@ __metadata:
     object-keys: ^1.1.1
     safe-push-apply: ^1.0.0
   checksum: cc9dd7d85c4ccfbe8109fce307d581ac7ede7b26de892b537873fbce2dc6a206d89aea0630dbb98e47ce0873517cefeaa7be15fcf94aaf4764a3b34b474a5b61
+  languageName: node
+  linkType: hard
+
+"oxc-transform@npm:0.111.0":
+  version: 0.111.0
+  resolution: "oxc-transform@npm:0.111.0"
+  dependencies:
+    "@oxc-transform/binding-android-arm-eabi": 0.111.0
+    "@oxc-transform/binding-android-arm64": 0.111.0
+    "@oxc-transform/binding-darwin-arm64": 0.111.0
+    "@oxc-transform/binding-darwin-x64": 0.111.0
+    "@oxc-transform/binding-freebsd-x64": 0.111.0
+    "@oxc-transform/binding-linux-arm-gnueabihf": 0.111.0
+    "@oxc-transform/binding-linux-arm-musleabihf": 0.111.0
+    "@oxc-transform/binding-linux-arm64-gnu": 0.111.0
+    "@oxc-transform/binding-linux-arm64-musl": 0.111.0
+    "@oxc-transform/binding-linux-ppc64-gnu": 0.111.0
+    "@oxc-transform/binding-linux-riscv64-gnu": 0.111.0
+    "@oxc-transform/binding-linux-riscv64-musl": 0.111.0
+    "@oxc-transform/binding-linux-s390x-gnu": 0.111.0
+    "@oxc-transform/binding-linux-x64-gnu": 0.111.0
+    "@oxc-transform/binding-linux-x64-musl": 0.111.0
+    "@oxc-transform/binding-openharmony-arm64": 0.111.0
+    "@oxc-transform/binding-wasm32-wasi": 0.111.0
+    "@oxc-transform/binding-win32-arm64-msvc": 0.111.0
+    "@oxc-transform/binding-win32-ia32-msvc": 0.111.0
+    "@oxc-transform/binding-win32-x64-msvc": 0.111.0
+  dependenciesMeta:
+    "@oxc-transform/binding-android-arm-eabi":
+      optional: true
+    "@oxc-transform/binding-android-arm64":
+      optional: true
+    "@oxc-transform/binding-darwin-arm64":
+      optional: true
+    "@oxc-transform/binding-darwin-x64":
+      optional: true
+    "@oxc-transform/binding-freebsd-x64":
+      optional: true
+    "@oxc-transform/binding-linux-arm-gnueabihf":
+      optional: true
+    "@oxc-transform/binding-linux-arm-musleabihf":
+      optional: true
+    "@oxc-transform/binding-linux-arm64-gnu":
+      optional: true
+    "@oxc-transform/binding-linux-arm64-musl":
+      optional: true
+    "@oxc-transform/binding-linux-ppc64-gnu":
+      optional: true
+    "@oxc-transform/binding-linux-riscv64-gnu":
+      optional: true
+    "@oxc-transform/binding-linux-riscv64-musl":
+      optional: true
+    "@oxc-transform/binding-linux-s390x-gnu":
+      optional: true
+    "@oxc-transform/binding-linux-x64-gnu":
+      optional: true
+    "@oxc-transform/binding-linux-x64-musl":
+      optional: true
+    "@oxc-transform/binding-openharmony-arm64":
+      optional: true
+    "@oxc-transform/binding-wasm32-wasi":
+      optional: true
+    "@oxc-transform/binding-win32-arm64-msvc":
+      optional: true
+    "@oxc-transform/binding-win32-ia32-msvc":
+      optional: true
+    "@oxc-transform/binding-win32-x64-msvc":
+      optional: true
+  checksum: 157e67603e57f5b1099d6f4100290a76eebf1f02c82ba5316ad0fff928b939718948844f004986364cc736650d5e89b47434491d2caf8247c5d5fb99128060e0
+  languageName: node
+  linkType: hard
+
+"p-finally@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "p-finally@npm:2.0.1"
+  checksum: 6306a2851c3b28f8b603624f395ae84dce76970498fed8aa6aae2d930595053746edf1e4ee0c4b78a97410d84aa4504d63179f5310d555511ecd226f53ed1e8e
   languageName: node
   linkType: hard
 
@@ -8187,6 +9990,32 @@ __metadata:
   version: 2.2.0
   resolution: "p-try@npm:2.2.0"
   checksum: f8a8e9a7693659383f06aec604ad5ead237c7a261c18048a6e1b5b85a5f8a067e469aa24f5bc009b991ea3b058a87f5065ef4176793a200d4917349881216cae
+  languageName: node
+  linkType: hard
+
+"pac-proxy-agent@npm:^7.0.1":
+  version: 7.2.0
+  resolution: "pac-proxy-agent@npm:7.2.0"
+  dependencies:
+    "@tootallnate/quickjs-emscripten": ^0.23.0
+    agent-base: ^7.1.2
+    debug: ^4.3.4
+    get-uri: ^6.0.1
+    http-proxy-agent: ^7.0.0
+    https-proxy-agent: ^7.0.6
+    pac-resolver: ^7.0.1
+    socks-proxy-agent: ^8.0.5
+  checksum: 099c1bc8944da6a98e8b7de1fbf23e4014bc3063f66a7c29478bd852c1162e1d086a4f80f874f40961ebd5c516e736aed25852db97b79360cbdcc9db38086981
+  languageName: node
+  linkType: hard
+
+"pac-resolver@npm:^7.0.1":
+  version: 7.0.1
+  resolution: "pac-resolver@npm:7.0.1"
+  dependencies:
+    degenerator: ^5.0.0
+    netmask: ^2.0.2
+  checksum: 839134328781b80d49f9684eae1f5c74f50a1d4482076d44c84fc2f3ca93da66fa11245a4725a057231e06b311c20c989fd0681e662a0792d17f644d8fe62a5e
   languageName: node
   linkType: hard
 
@@ -8343,10 +10172,31 @@ __metadata:
   languageName: node
   linkType: hard
 
-"path-to-regexp@npm:^6.3.0":
+"path-to-regexp-updated@npm:path-to-regexp@6.3.0, path-to-regexp@npm:^6.3.0":
   version: 6.3.0
   resolution: "path-to-regexp@npm:6.3.0"
   checksum: eca78602e6434a1b6799d511d375ec044e8d7e28f5a48aa5c28d57d8152fb52f3fc62fb1cfc5dfa2198e1f041c2a82ed14043d75740a2fe60e91b5089a153250
+  languageName: node
+  linkType: hard
+
+"path-to-regexp@npm:6.1.0":
+  version: 6.1.0
+  resolution: "path-to-regexp@npm:6.1.0"
+  checksum: dd5c6915c38683cf5bd2908a6b6af0801703fc6e78fce8d23d89b5a1510e1f5b75e3e44fe635e1fad2dc1ae71d34bc0d7cf00f098e890cc26e3570b10bc96c00
+  languageName: node
+  linkType: hard
+
+"path-to-regexp@npm:8.2.0":
+  version: 8.2.0
+  resolution: "path-to-regexp@npm:8.2.0"
+  checksum: 56e13e45962e776e9e7cd72e87a441cfe41f33fd539d097237ceb16adc922281136ca12f5a742962e33d8dda9569f630ba594de56d8b7b6e49adf31803c5e771
+  languageName: node
+  linkType: hard
+
+"path-to-regexp@npm:8.3.0":
+  version: 8.3.0
+  resolution: "path-to-regexp@npm:8.3.0"
+  checksum: 73e0d3db449f9899692b10be8480bbcfa294fd575be2d09bce3e63f2f708d1fccd3aaa8591709f8b82062c528df116e118ff9df8f5c52ccc4c2443a90be73e10
   languageName: node
   linkType: hard
 
@@ -8370,6 +10220,13 @@ __metadata:
   version: 4.0.0
   resolution: "path-type@npm:4.0.0"
   checksum: 5b1e2daa247062061325b8fdbfd1fb56dde0a448fb1455453276ea18c60685bdad23a445dc148cf87bc216be1573357509b7d4060494a6fd768c7efad833ee45
+  languageName: node
+  linkType: hard
+
+"pend@npm:~1.2.0":
+  version: 1.2.0
+  resolution: "pend@npm:1.2.0"
+  checksum: 6c72f5243303d9c60bd98e6446ba7d30ae29e3d56fdb6fae8767e8ba6386f33ee284c97efe3230a0d0217e2b1723b8ab490b1bbf34fcbb2180dbc8a9de47850d
   languageName: node
   linkType: hard
 
@@ -8397,6 +10254,13 @@ __metadata:
     postgres-date: ~1.0.4
     postgres-interval: ^1.1.0
   checksum: bf4ec3f594743442857fb3a8dfe5d2478a04c98f96a0a47365014557cbc0b4b0cee01462c79adca863b93befbf88f876299b75b72c665b5fb84a2c94fbd10316
+  languageName: node
+  linkType: hard
+
+"picocolors@npm:1.0.0":
+  version: 1.0.0
+  resolution: "picocolors@npm:1.0.0"
+  checksum: a2e8092dd86c8396bdba9f2b5481032848525b3dc295ce9b57896f931e63fc16f79805144321f72976383fc249584672a75cc18d6777c6b757603f372f745981
   languageName: node
   linkType: hard
 
@@ -8615,7 +10479,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pretty-ms@npm:^7.0.0":
+"pretty-ms@npm:7.0.1, pretty-ms@npm:^7.0.0":
   version: 7.0.1
   resolution: "pretty-ms@npm:7.0.1"
   dependencies:
@@ -8647,6 +10511,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"promisepipe@npm:3.0.0":
+  version: 3.0.0
+  resolution: "promisepipe@npm:3.0.0"
+  checksum: b35e4102bc540f655777329ddb39d0d7e767946cafd144c537915f98b21ca7ee7ef9aecd14784ed0e6c2c6f6eb9fe5e66b60c56cdaa4a6050b2cfa98e342278d
+  languageName: node
+  linkType: hard
+
 "prompts@npm:^2.4.2":
   version: 2.4.2
   resolution: "prompts@npm:2.4.2"
@@ -8667,10 +10538,50 @@ __metadata:
   languageName: node
   linkType: hard
 
+"proxy-agent@npm:6.4.0":
+  version: 6.4.0
+  resolution: "proxy-agent@npm:6.4.0"
+  dependencies:
+    agent-base: ^7.0.2
+    debug: ^4.3.4
+    http-proxy-agent: ^7.0.1
+    https-proxy-agent: ^7.0.3
+    lru-cache: ^7.14.1
+    pac-proxy-agent: ^7.0.1
+    proxy-from-env: ^1.1.0
+    socks-proxy-agent: ^8.0.2
+  checksum: 4d3794ad5e07486298902f0a7f250d0f869fa0e92d790767ca3f793a81374ce0ab6c605f8ab8e791c4d754da96656b48d1c24cb7094bfd310a15867e4a0841d7
+  languageName: node
+  linkType: hard
+
+"proxy-from-env@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "proxy-from-env@npm:1.1.0"
+  checksum: ed7fcc2ba0a33404958e34d95d18638249a68c430e30fcb6c478497d72739ba64ce9810a24f53a7d921d0c065e5b78e3822759800698167256b04659366ca4d4
+  languageName: node
+  linkType: hard
+
 "proxy-from-env@npm:^2.1.0":
   version: 2.1.0
   resolution: "proxy-from-env@npm:2.1.0"
   checksum: b106ad790f26d47ba4791af3fe8cba5c8d35d85020119c82c05b413eb11b3ab97d2393ecaed51bca97c2788fa256408283dfeb4d970b2ebcae6702310f064e7e
+  languageName: node
+  linkType: hard
+
+"pump@npm:^3.0.0":
+  version: 3.0.4
+  resolution: "pump@npm:3.0.4"
+  dependencies:
+    end-of-stream: ^1.1.0
+    once: ^1.3.1
+  checksum: d043c3e710c56ffd280711e98a94e863ab334f79ea43cee0fb70e1349b2355ffd2ff287c7522e4c960a247699d5b7825f00fa090b85d6179c973be13f78a6c49
+  languageName: node
+  linkType: hard
+
+"punycode@npm:^2.1.0":
+  version: 2.3.1
+  resolution: "punycode@npm:2.3.1"
+  checksum: bb0a0ceedca4c3c57a9b981b90601579058903c62be23c5e8e843d2c2d4148a3ecf029d5133486fb0e1822b098ba8bba09e89d6b21742d02fa26bda6441a6fb2
   languageName: node
   linkType: hard
 
@@ -8708,6 +10619,18 @@ __metadata:
   version: 1.2.1
   resolution: "range-parser@npm:1.2.1"
   checksum: 0a268d4fea508661cf5743dfe3d5f47ce214fd6b7dec1de0da4d669dd4ef3d2144468ebe4179049eff253d9d27e719c88dae55be64f954e80135a0cada804ec9
+  languageName: node
+  linkType: hard
+
+"raw-body@npm:2.4.1":
+  version: 2.4.1
+  resolution: "raw-body@npm:2.4.1"
+  dependencies:
+    bytes: 3.1.0
+    http-errors: 1.7.3
+    iconv-lite: 0.4.24
+    unpipe: 1.0.0
+  checksum: d5e9179d2f1f0a652cd107c080f25d165c724f546124d620c8df7fb80322df42bff547a8b310e55e1f7952556d013716a21b30162192eb0b3332d7efcba75883
   languageName: node
   linkType: hard
 
@@ -8856,6 +10779,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"readdirp@npm:^4.0.1":
+  version: 4.1.2
+  resolution: "readdirp@npm:4.1.2"
+  checksum: 3242ee125422cb7c0e12d51452e993f507e6ed3d8c490bc8bf3366c5cdd09167562224e429b13e9cb2b98d4b8b2b11dc100d3c73883aa92d657ade5a21ded004
+  languageName: node
+  linkType: hard
+
 "recast@npm:^0.23.11":
   version: 0.23.11
   resolution: "recast@npm:0.23.11"
@@ -9000,6 +10930,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"resolve.exports@npm:2.0.3":
+  version: 2.0.3
+  resolution: "resolve.exports@npm:2.0.3"
+  checksum: abfb9f98278dcd0c19b8a49bb486abfafa23df4636d49128ea270dc982053c3ef230a530aecda1fae1322873fdfa6c97674fc539651ddfdb375ac58e0b8ef6df
+  languageName: node
+  linkType: hard
+
 "resolve@npm:^1.10.0":
   version: 1.22.11
   resolution: "resolve@npm:1.22.11"
@@ -9054,6 +10991,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"retry@npm:0.13.1":
+  version: 0.13.1
+  resolution: "retry@npm:0.13.1"
+  checksum: 47c4d5be674f7c13eee4cfe927345023972197dbbdfba5d3af7e461d13b44de1bfd663bfc80d2f601f8ef3fc8164c16dd99655a221921954a65d044a2fc1233b
+  languageName: node
+  linkType: hard
+
 "rettime@npm:^0.10.1":
   version: 0.10.1
   resolution: "rettime@npm:0.10.1"
@@ -9077,6 +11021,58 @@ __metadata:
   bin:
     rimraf: dist/esm/bin.mjs
   checksum: 797dabd9b03a154a863c20e0bd0066214a3a7165d30a358852b63b96f9463d360f59d56db6ccbaebac6fe2ff5c93dea2cddd547855bba1a1e1d5361c31e7456a
+  languageName: node
+  linkType: hard
+
+"rolldown@npm:1.0.0-rc.1":
+  version: 1.0.0-rc.1
+  resolution: "rolldown@npm:1.0.0-rc.1"
+  dependencies:
+    "@oxc-project/types": =0.110.0
+    "@rolldown/binding-android-arm64": 1.0.0-rc.1
+    "@rolldown/binding-darwin-arm64": 1.0.0-rc.1
+    "@rolldown/binding-darwin-x64": 1.0.0-rc.1
+    "@rolldown/binding-freebsd-x64": 1.0.0-rc.1
+    "@rolldown/binding-linux-arm-gnueabihf": 1.0.0-rc.1
+    "@rolldown/binding-linux-arm64-gnu": 1.0.0-rc.1
+    "@rolldown/binding-linux-arm64-musl": 1.0.0-rc.1
+    "@rolldown/binding-linux-x64-gnu": 1.0.0-rc.1
+    "@rolldown/binding-linux-x64-musl": 1.0.0-rc.1
+    "@rolldown/binding-openharmony-arm64": 1.0.0-rc.1
+    "@rolldown/binding-wasm32-wasi": 1.0.0-rc.1
+    "@rolldown/binding-win32-arm64-msvc": 1.0.0-rc.1
+    "@rolldown/binding-win32-x64-msvc": 1.0.0-rc.1
+    "@rolldown/pluginutils": 1.0.0-rc.1
+  dependenciesMeta:
+    "@rolldown/binding-android-arm64":
+      optional: true
+    "@rolldown/binding-darwin-arm64":
+      optional: true
+    "@rolldown/binding-darwin-x64":
+      optional: true
+    "@rolldown/binding-freebsd-x64":
+      optional: true
+    "@rolldown/binding-linux-arm-gnueabihf":
+      optional: true
+    "@rolldown/binding-linux-arm64-gnu":
+      optional: true
+    "@rolldown/binding-linux-arm64-musl":
+      optional: true
+    "@rolldown/binding-linux-x64-gnu":
+      optional: true
+    "@rolldown/binding-linux-x64-musl":
+      optional: true
+    "@rolldown/binding-openharmony-arm64":
+      optional: true
+    "@rolldown/binding-wasm32-wasi":
+      optional: true
+    "@rolldown/binding-win32-arm64-msvc":
+      optional: true
+    "@rolldown/binding-win32-x64-msvc":
+      optional: true
+  bin:
+    rolldown: bin/cli.mjs
+  checksum: cce07a38fc7410fb540973402c2979a60c632e72d816f419bf9991909c23667699586f660dac35cbc48f2c0ca6827513319efb3723bde7ef37076a5357c4be24
   languageName: node
   linkType: hard
 
@@ -9171,10 +11167,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"safer-buffer@npm:>= 2.1.2 < 3.0.0":
+"safer-buffer@npm:>= 2.1.2 < 3, safer-buffer@npm:>= 2.1.2 < 3.0.0":
   version: 2.1.2
   resolution: "safer-buffer@npm:2.1.2"
   checksum: cab8f25ae6f1434abee8d80023d7e72b598cf1327164ddab31003c51215526801e40b66c5e65d658a0af1e9d6478cadcb4c745f4bd6751f97d8644786c0978b0
+  languageName: node
+  linkType: hard
+
+"sandbox@npm:2.5.6":
+  version: 2.5.6
+  resolution: "sandbox@npm:2.5.6"
+  dependencies:
+    "@vercel/sandbox": 1.9.0
+    debug: ^4.4.1
+    zod: ^4.1.1
+  bin:
+    sandbox: bin/sandbox.mjs
+    sbx: bin/sandbox.mjs
+  checksum: c2b2fe64c8cab0e705005debf8e1ce6a327243c87417022c5f29eb6eead1683f3296ed9a54f2629ee3a746ba7b3a48e8f201e423d357ba87609708a0a8d2e3d9
   languageName: node
   linkType: hard
 
@@ -9194,12 +11204,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:^6.0.0, semver@npm:^6.3.1":
+"semver@npm:6.3.1, semver@npm:^6.0.0, semver@npm:^6.3.1":
   version: 6.3.1
   resolution: "semver@npm:6.3.1"
   bin:
     semver: bin/semver.js
   checksum: ae47d06de28836adb9d3e25f22a92943477371292d9b665fb023fae278d345d508ca1958232af086d85e0155aee22e313e100971898bbb8d5d89b8b1d4054ca2
+  languageName: node
+  linkType: hard
+
+"semver@npm:7.5.4":
+  version: 7.5.4
+  resolution: "semver@npm:7.5.4"
+  dependencies:
+    lru-cache: ^6.0.0
+  bin:
+    semver: bin/semver.js
+  checksum: 12d8ad952fa353b0995bf180cdac205a4068b759a140e5d3c608317098b3575ac2f1e09182206bf2eb26120e1c0ed8fb92c48c592f6099680de56bb071423ca3
   languageName: node
   linkType: hard
 
@@ -9291,6 +11312,13 @@ __metadata:
     es-errors: ^1.3.0
     es-object-atoms: ^1.0.0
   checksum: ec27cbbe334598547e99024403e96da32aca3e530583e4dba7f5db1c43cbc4affa9adfbd77c7b2c210b9b8b2e7b2e600bad2a6c44fd62e804d8233f96bbb62f4
+  languageName: node
+  linkType: hard
+
+"setprototypeof@npm:1.1.1":
+  version: 1.1.1
+  resolution: "setprototypeof@npm:1.1.1"
+  checksum: a8bee29c1c64c245d460ce53f7460af8cbd0aceac68d66e5215153992cc8b3a7a123416353e0c642060e85cc5fd4241c92d1190eec97eda0dcb97436e8fcca3b
   languageName: node
   linkType: hard
 
@@ -9493,7 +11521,14 @@ shadcn@latest:
   languageName: node
   linkType: hard
 
-"signal-exit@npm:^3.0.3":
+"signal-exit@npm:4.0.2":
+  version: 4.0.2
+  resolution: "signal-exit@npm:4.0.2"
+  checksum: 41f5928431cc6e91087bf0343db786a6313dd7c6fd7e551dbc141c95bb5fb26663444fd9df8ea47c5d7fc202f60aa7468c3162a9365cbb0615fc5e1b1328fe31
+  languageName: node
+  linkType: hard
+
+"signal-exit@npm:^3.0.2, signal-exit@npm:^3.0.3":
   version: 3.0.7
   resolution: "signal-exit@npm:3.0.7"
   checksum: a2f098f247adc367dffc27845853e9959b9e88b01cb301658cfe4194352d8d2bb32e18467c786a7fe15f1d44b233ea35633d076d5e737870b7139949d1ab6318
@@ -9539,7 +11574,14 @@ shadcn@latest:
   languageName: node
   linkType: hard
 
-"socks-proxy-agent@npm:^8.0.3":
+"smol-toml@npm:1.5.2":
+  version: 1.5.2
+  resolution: "smol-toml@npm:1.5.2"
+  checksum: 75b7e8482151cbe48be094de205631502d5694c2a7d968446799e8b988b4105bd6efd3b6a986baa40d9e9b47cbb2daada21a302901a618793aabd35a670f195e
+  languageName: node
+  linkType: hard
+
+"socks-proxy-agent@npm:^8.0.2, socks-proxy-agent@npm:^8.0.3, socks-proxy-agent@npm:^8.0.5":
   version: 8.0.5
   resolution: "socks-proxy-agent@npm:8.0.5"
   dependencies:
@@ -9636,6 +11678,24 @@ shadcn@latest:
   languageName: node
   linkType: hard
 
+"sprintf-js@npm:~1.0.2":
+  version: 1.0.3
+  resolution: "sprintf-js@npm:1.0.3"
+  checksum: 19d79aec211f09b99ec3099b5b2ae2f6e9cdefe50bc91ac4c69144b6d3928a640bb6ae5b3def70c2e85a2c3d9f5ec2719921e3a59d3ca3ef4b2fd1a4656a0df3
+  languageName: node
+  linkType: hard
+
+"srvx@npm:0.8.9":
+  version: 0.8.9
+  resolution: "srvx@npm:0.8.9"
+  dependencies:
+    cookie-es: ^2.0.0
+  bin:
+    srvx: bin/srvx.mjs
+  checksum: e2976db34d16dc6658614cf04d9432b1c8142efe496cc286141d3d55df8bba1a7150fa22adcf6cd394fe6468621a675e7e1ec597dedc301ff8e27addaa0d9470
+  languageName: node
+  linkType: hard
+
 "ssri@npm:^13.0.0":
   version: 13.0.1
   resolution: "ssri@npm:13.0.1"
@@ -9652,6 +11712,20 @@ shadcn@latest:
     "@stablelib/base64": ^1.0.0
     fast-sha256: ^1.3.0
   checksum: 02b74a3e4cd131affe8bf18945360747a5a0bf81c1d62a7bbbea3d40976b4fef4bb37de71a35cdc0fdc4d6f0d951a3b6031052e78bd086dc9b09b629b82d3919
+  languageName: node
+  linkType: hard
+
+"stat-mode@npm:0.3.0":
+  version: 0.3.0
+  resolution: "stat-mode@npm:0.3.0"
+  checksum: d52680a4e81c5afc184913fe8f26e082e0cbbc87dfd53302de7edbf5c01eb2ee5b8212dcf171983e4e5140ca3039841cd34ca6959f9db745394c8b26670d5195
+  languageName: node
+  linkType: hard
+
+"statuses@npm:>= 1.5.0 < 2":
+  version: 1.5.0
+  resolution: "statuses@npm:1.5.0"
+  checksum: c469b9519de16a4bb19600205cffb39ee471a5f17b82589757ca7bd40a8d92ebb6ed9f98b5a540c5d302ccbc78f15dc03cc0280dd6e00df1335568a5d5758a5c
   languageName: node
   linkType: hard
 
@@ -9676,6 +11750,37 @@ shadcn@latest:
     es-errors: ^1.3.0
     internal-slot: ^1.1.0
   checksum: be944489d8829fb3bdec1a1cc4a2142c6b6eb317305eeace1ece978d286d6997778afa1ae8cb3bd70e2b274b9aa8c69f93febb1e15b94b1359b11058f9d3c3a1
+  languageName: node
+  linkType: hard
+
+"stream-to-array@npm:~2.3.0":
+  version: 2.3.0
+  resolution: "stream-to-array@npm:2.3.0"
+  dependencies:
+    any-promise: ^1.1.0
+  checksum: 7feaf63b38399b850615e6ffcaa951e96e4c8f46745dbce4b553a94c5dc43966933813747014935a3ff97793e7f30a65270bde19f82b2932871a1879229a77cf
+  languageName: node
+  linkType: hard
+
+"stream-to-promise@npm:2.2.0":
+  version: 2.2.0
+  resolution: "stream-to-promise@npm:2.2.0"
+  dependencies:
+    any-promise: ~1.3.0
+    end-of-stream: ~1.1.0
+    stream-to-array: ~2.3.0
+  checksum: 2c9ddb69c34d10ad27eb06197abc93fd1b1cd5f9597ead28ade4d6c57f4110d948a2ef14530f2f7b3b967f74f3554b57c38a4501b72a13b27fc8745bd7190d1d
+  languageName: node
+  linkType: hard
+
+"streamx@npm:^2.15.0":
+  version: 2.25.0
+  resolution: "streamx@npm:2.25.0"
+  dependencies:
+    events-universal: ^1.0.0
+    fast-fifo: ^1.3.2
+    text-decoder: ^1.1.0
+  checksum: eb38bcf6724cc65ba953e03199055be42d2eb2c1695aca613c46b5ef8a2e9dcfb7ef2ff2ea5eeceae26db9896ce6e29918967211a6ad4311577554fb14db99f8
   languageName: node
   linkType: hard
 
@@ -9961,7 +12066,31 @@ shadcn@latest:
   languageName: node
   linkType: hard
 
-"tar@npm:^7.5.4":
+"tar-stream@npm:3.1.7":
+  version: 3.1.7
+  resolution: "tar-stream@npm:3.1.7"
+  dependencies:
+    b4a: ^1.6.4
+    fast-fifo: ^1.2.0
+    streamx: ^2.15.0
+  checksum: 6393a6c19082b17b8dcc8e7fd349352bb29b4b8bfe1075912b91b01743ba6bb4298f5ff0b499a3bbaf82121830e96a1a59d4f21a43c0df339e54b01789cb8cc6
+  languageName: node
+  linkType: hard
+
+"tar@npm:7.5.7":
+  version: 7.5.7
+  resolution: "tar@npm:7.5.7"
+  dependencies:
+    "@isaacs/fs-minipass": ^4.0.0
+    chownr: ^3.0.0
+    minipass: ^7.1.2
+    minizlib: ^3.1.0
+    yallist: ^5.0.0
+  checksum: 82fa04804b6cae4c0b46b84e97a08c39e1c17bb959350baa32d139bcf5e1fc7ebc3ceb72465dd3e2e311992386ecc13599a257d5672158490ceb9464146d5573
+  languageName: node
+  linkType: hard
+
+"tar@npm:^7.4.0, tar@npm:^7.5.4":
   version: 7.5.13
   resolution: "tar@npm:7.5.13"
   dependencies:
@@ -9984,10 +12113,26 @@ shadcn@latest:
   languageName: node
   linkType: hard
 
+"text-decoder@npm:^1.1.0":
+  version: 1.2.7
+  resolution: "text-decoder@npm:1.2.7"
+  dependencies:
+    b4a: ^1.6.4
+  checksum: a544f8490806675986e9703cda2d0809d7bd010adf0cc19ac9975791912ea9e6998cd4696d7d7e9392c5648e660111a865c983e8adfeb29699fab471548f82a3
+  languageName: node
+  linkType: hard
+
 "text-extensions@npm:^1.0.0":
   version: 1.9.0
   resolution: "text-extensions@npm:1.9.0"
   checksum: 56a9962c1b62d39b2bcb369b7558ca85c1b55e554b38dfd725edcc0a1babe5815782a60c17ff6b839093b163dfebb92b804208aaaea616ec7571c8059ae0cf44
+  languageName: node
+  linkType: hard
+
+"throttleit@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "throttleit@npm:2.1.0"
+  checksum: a2003947aafc721c4a17e6f07db72dc88a64fa9bba0f9c659f7997d30f9590b3af22dadd6a41851e0e8497d539c33b2935c2c7919cf4255922509af6913c619b
   languageName: node
   linkType: hard
 
@@ -10017,6 +12162,15 @@ shadcn@latest:
   languageName: node
   linkType: hard
 
+"time-span@npm:4.0.0":
+  version: 4.0.0
+  resolution: "time-span@npm:4.0.0"
+  dependencies:
+    convert-hrtime: ^3.0.0
+  checksum: 8bcecbda97142e804ba03acf52117cc771c2933277b299bdf2e8a949960fda3e70d8159b3ba5f49495d662c4b8cc15e30dbb1a703b1a735eecce11682b98e8f9
+  languageName: node
+  linkType: hard
+
 "tiny-invariant@npm:^1.3.3":
   version: 1.3.3
   resolution: "tiny-invariant@npm:1.3.3"
@@ -10028,6 +12182,13 @@ shadcn@latest:
   version: 1.6.0
   resolution: "tinycolor2@npm:1.6.0"
   checksum: 6df4d07fceeedc0a878d7bac47e2cd47c1ceeb1078340a9eb8a295bc0651e17c750f73d47b3028d829f30b85c15e0572c0fd4142083e4c21a30a597e47f47230
+  languageName: node
+  linkType: hard
+
+"tinyexec@npm:0.3.2":
+  version: 0.3.2
+  resolution: "tinyexec@npm:0.3.2"
+  checksum: bd491923020610bdeadb0d8cf5d70e7cbad5a3201620fd01048c9bf3b31ffaa75c33254e1540e13b993ce4e8187852b0b5a93057bb598e7a57afa2ca2048a35c
   languageName: node
   linkType: hard
 
@@ -10075,6 +12236,13 @@ shadcn@latest:
   languageName: node
   linkType: hard
 
+"toidentifier@npm:1.0.0":
+  version: 1.0.0
+  resolution: "toidentifier@npm:1.0.0"
+  checksum: 199e6bfca1531d49b3506cff02353d53ec987c9ee10ee272ca6484ed97f1fc10fb77c6c009079ca16d5c5be4a10378178c3cacdb41ce9ec954c3297c74c6053e
+  languageName: node
+  linkType: hard
+
 "toidentifier@npm:~1.0.1":
   version: 1.0.1
   resolution: "toidentifier@npm:1.0.1"
@@ -10098,6 +12266,15 @@ shadcn@latest:
   languageName: node
   linkType: hard
 
+"tree-kill@npm:1.2.2":
+  version: 1.2.2
+  resolution: "tree-kill@npm:1.2.2"
+  bin:
+    tree-kill: cli.js
+  checksum: 49117f5f410d19c84b0464d29afb9642c863bc5ba40fcb9a245d474c6d5cc64d1b177a6e6713129eb346b40aebb9d4631d967517f9fbe8251c35b21b13cd96c7
+  languageName: node
+  linkType: hard
+
 "trim-newlines@npm:^3.0.0":
   version: 3.0.1
   resolution: "trim-newlines@npm:3.0.1"
@@ -10109,6 +12286,16 @@ shadcn@latest:
   version: 2.0.0
   resolution: "ts-algebra@npm:2.0.0"
   checksum: 970b0e7db49cf8c1a8ff2a816eb047fac8add47511f5e4995e4998c56c6f7b226399284412de88f3e137ab55c857a4262c0d8f02f0765730e7d3a021de2ea7ef
+  languageName: node
+  linkType: hard
+
+"ts-morph@npm:12.0.0":
+  version: 12.0.0
+  resolution: "ts-morph@npm:12.0.0"
+  dependencies:
+    "@ts-morph/common": ~0.11.0
+    code-block-writer: ^10.1.1
+  checksum: c033708c76448625380daa3b8c2eeea1306300fa4367804029635f0d911a3723e4315a6e0824e6dfb256df0b99aac0ea0478cb3f14ed6fae2339d43ec882a427
   languageName: node
   linkType: hard
 
@@ -10181,6 +12368,13 @@ shadcn@latest:
   languageName: node
   linkType: hard
 
+"ts-toolbelt@npm:^6.15.5":
+  version: 6.15.5
+  resolution: "ts-toolbelt@npm:6.15.5"
+  checksum: 24ad00cfd9ce735c76c873a9b1347eac475b94e39ebbdf100c9019dce88dd5f4babed52884cf82bb456a38c28edd0099ab6f704b84b2e5e034852b618472c1f3
+  languageName: node
+  linkType: hard
+
 "tsconfig-paths@npm:^4.2.0":
   version: 4.2.0
   resolution: "tsconfig-paths@npm:4.2.0"
@@ -10213,7 +12407,7 @@ shadcn@latest:
   languageName: node
   linkType: hard
 
-"tsx@npm:^4.21.0":
+"tsx@npm:4.21.0, tsx@npm:^4.21.0":
   version: 4.21.0
   resolution: "tsx@npm:4.21.0"
   dependencies:
@@ -10351,7 +12545,7 @@ shadcn@latest:
   languageName: node
   linkType: hard
 
-"typescript@npm:^5.8.2":
+"typescript@npm:^5.8.2, typescript@npm:typescript@5.9.3":
   version: 5.9.3
   resolution: "typescript@npm:5.9.3"
   bin:
@@ -10361,7 +12555,7 @@ shadcn@latest:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@^5.8.2#~builtin<compat/typescript>":
+"typescript@patch:typescript@^5.8.2#~builtin<compat/typescript>, typescript@patch:typescript@npm%3Atypescript@5.9.3#~builtin<compat/typescript>":
   version: 5.9.3
   resolution: "typescript@patch:typescript@npm%3A5.9.3#~builtin<compat/typescript>::version=5.9.3&hash=5786d5"
   bin:
@@ -10394,6 +12588,13 @@ shadcn@latest:
   languageName: node
   linkType: hard
 
+"uid-promise@npm:1.0.0":
+  version: 1.0.0
+  resolution: "uid-promise@npm:1.0.0"
+  checksum: 8769e9581a4ae88b2b43225a3f31730d1075935359df44bfd47618e0f7c8a83cd49c127916fa73f62bfaabcc800d2b3f334af9a02615123d4349372326792ede
+  languageName: node
+  linkType: hard
+
 "unbox-primitive@npm:^1.1.0":
   version: 1.1.0
   resolution: "unbox-primitive@npm:1.1.0"
@@ -10403,6 +12604,13 @@ shadcn@latest:
     has-symbols: ^1.1.0
     which-boxed-primitive: ^1.1.1
   checksum: 729f13b84a5bfa3fead1d8139cee5c38514e63a8d6a437819a473e241ba87eeb593646568621c7fc7f133db300ef18d65d1a5a60dc9c7beb9000364d93c581df
+  languageName: node
+  linkType: hard
+
+"undici-types@npm:~5.26.4":
+  version: 5.26.5
+  resolution: "undici-types@npm:5.26.5"
+  checksum: 3192ef6f3fd5df652f2dc1cd782b49d6ff14dc98e5dced492aa8a8c65425227da5da6aafe22523c67f035a272c599bb89cfe803c1db6311e44bed3042fc25487
   languageName: node
   linkType: hard
 
@@ -10417,6 +12625,29 @@ shadcn@latest:
   version: 7.18.2
   resolution: "undici-types@npm:7.18.2"
   checksum: 23da306c8366574adec305b06a8519ab5c7d09e3f5d16c1a98709a34fae17da09ec95198f30f86c00055e02efa8bfcc843e84e8aebeb9b8d6bb3e06afccae07a
+  languageName: node
+  linkType: hard
+
+"undici@npm:5.28.4":
+  version: 5.28.4
+  resolution: "undici@npm:5.28.4"
+  dependencies:
+    "@fastify/busboy": ^2.0.0
+  checksum: a8193132d84540e4dc1895ecc8dbaa176e8a49d26084d6fbe48a292e28397cd19ec5d13bc13e604484e76f94f6e334b2bdc740d5f06a6e50c44072818d0c19f9
+  languageName: node
+  linkType: hard
+
+"undici@npm:^6.23.0":
+  version: 6.25.0
+  resolution: "undici@npm:6.25.0"
+  checksum: aed372e1b0f16045696c878e46b03e97dfd1c6dd650fb2355d48adeecc730c990ab15ab2de5a5855dbfe04c9af403a3d4f702234d3e25e72c475d1fb3a72fcfe
+  languageName: node
+  linkType: hard
+
+"undici@npm:^7.16.0":
+  version: 7.25.0
+  resolution: "undici@npm:7.25.0"
+  checksum: 502f855d69dd0f343a4b4999b995b99eab8764639983776bb5afd09b50671863244defe093e7fb97df767c948d6548c0c3d97f8dbb35fec16c1c8c1c15843f17
   languageName: node
   linkType: hard
 
@@ -10441,7 +12672,7 @@ shadcn@latest:
   languageName: node
   linkType: hard
 
-"unpipe@npm:~1.0.0":
+"unpipe@npm:1.0.0, unpipe@npm:~1.0.0":
   version: 1.0.0
   resolution: "unpipe@npm:1.0.0"
   checksum: 4fa18d8d8d977c55cb09715385c203197105e10a6d220087ec819f50cb68870f02942244f1017565484237f1f8c5d3cd413631b1ae104d3096f24fdfde1b4aa2
@@ -10466,6 +12697,15 @@ shadcn@latest:
   bin:
     update-browserslist-db: cli.js
   checksum: 6f209a97ae8eacdd3a1ef2eb365adf49d1e2a757e5b2dd4ac87dc8c99236cbe3e572d3e605a87dd7b538a11751b71d9f93edc47c7405262a293a493d155316cd
+  languageName: node
+  linkType: hard
+
+"uri-js@npm:^4.2.2":
+  version: 4.4.1
+  resolution: "uri-js@npm:4.4.1"
+  dependencies:
+    punycode: ^2.1.0
+  checksum: 7167432de6817fe8e9e0c9684f1d2de2bb688c94388f7569f7dbdb1587c9f4ca2a77962f134ec90be0cc4d004c939ff0d05acc9f34a0db39a3c797dada262633
   languageName: node
   linkType: hard
 
@@ -10541,6 +12781,48 @@ shadcn@latest:
   languageName: node
   linkType: hard
 
+"vercel@npm:^51.8.0":
+  version: 51.8.0
+  resolution: "vercel@npm:51.8.0"
+  dependencies:
+    "@vercel/backends": 0.1.2
+    "@vercel/blob": 2.3.0
+    "@vercel/build-utils": 13.19.1
+    "@vercel/detect-agent": 1.2.3
+    "@vercel/elysia": 0.1.70
+    "@vercel/express": 0.1.80
+    "@vercel/fastify": 0.1.73
+    "@vercel/fun": 1.3.0
+    "@vercel/go": 3.5.0
+    "@vercel/h3": 0.1.79
+    "@vercel/hono": 0.2.73
+    "@vercel/hydrogen": 1.3.6
+    "@vercel/koa": 0.1.53
+    "@vercel/nestjs": 0.2.74
+    "@vercel/next": 4.16.8
+    "@vercel/node": 5.7.12
+    "@vercel/prepare-flags-definitions": 0.2.1
+    "@vercel/python": 6.35.0
+    "@vercel/redwood": 2.4.12
+    "@vercel/remix-builder": 5.7.2
+    "@vercel/ruby": 2.3.2
+    "@vercel/rust": 1.1.1
+    "@vercel/static-build": 2.9.20
+    chokidar: 4.0.0
+    esbuild: 0.27.0
+    form-data: ^4.0.0
+    jose: 5.9.6
+    luxon: ^3.4.0
+    proxy-agent: 6.4.0
+    sandbox: 2.5.6
+    smol-toml: 1.5.2
+  bin:
+    vc: dist/vc.js
+    vercel: dist/vc.js
+  checksum: 37829baaeb042f9dc491af92611183e2ed068d5171a134078e6bc99f2ce1fcb904a0378600a7490b1d0c1fefb7c18c40433df6544db8184d87fa609eff5ef151
+  languageName: node
+  linkType: hard
+
 "wcwidth@npm:>=1.0.1":
   version: 1.0.1
   resolution: "wcwidth@npm:1.0.1"
@@ -10554,6 +12836,13 @@ shadcn@latest:
   version: 3.3.3
   resolution: "web-streams-polyfill@npm:3.3.3"
   checksum: 21ab5ea08a730a2ef8023736afe16713b4f2023ec1c7085c16c8e293ee17ed085dff63a0ad8722da30c99c4ccbd4ccd1b2e79c861829f7ef2963d7de7004c2cb
+  languageName: node
+  linkType: hard
+
+"web-vitals@npm:0.2.4":
+  version: 0.2.4
+  resolution: "web-vitals@npm:0.2.4"
+  checksum: 128a4e87730b0a02fb6af3eef7d31f9a79b4646e83cfe4465aa8ce6054fe16f7b1f4125a384f1b4f039091bd9513cb54b4e559c0b10ae953c01900786a16b1c2
   languageName: node
   linkType: hard
 
@@ -10799,9 +13088,28 @@ shadcn@latest:
     tsx: ^4.21.0
     tw-animate-css: ^1.4.0
     typescript: ^5.8.2
+    vercel: ^51.8.0
     zod: 4.0.0
   languageName: unknown
   linkType: soft
+
+"xdg-app-paths@npm:5.1.0":
+  version: 5.1.0
+  resolution: "xdg-app-paths@npm:5.1.0"
+  dependencies:
+    xdg-portable: ^7.0.0
+  checksum: 722917cfcd072a75b4330c4dba969cff287d624880d6a5406adabfa69bdf54be33f4a6773bf7d2d49adc5a3ddc1867a346056591869267dc485f8d3aca16480f
+  languageName: node
+  linkType: hard
+
+"xdg-portable@npm:^7.0.0":
+  version: 7.3.0
+  resolution: "xdg-portable@npm:7.3.0"
+  dependencies:
+    os-paths: ^4.0.1
+  checksum: e228ec6486e143d58d2e151bbb5899107bddbd57f92841e52598ba9515373fc095a570d4e974b009afd9b94bd9b98d4a4e5ebac66736cc02d30d178c7182bf6b
+  languageName: node
+  linkType: hard
 
 "xtend@npm:^4.0.0, xtend@npm:~4.0.1":
   version: 4.0.2
@@ -10889,6 +13197,35 @@ shadcn@latest:
   languageName: node
   linkType: hard
 
+"yauzl-clone@npm:^1.0.4":
+  version: 1.0.4
+  resolution: "yauzl-clone@npm:1.0.4"
+  dependencies:
+    events-intercept: ^2.0.0
+  checksum: 380342495e72ad1d5c32f38e1457eee141ede22027de22528509c0dd7b9be280cf768f716982045bfa08b7d685bef1209441f28c12eb379b4a7e0475ef68d68f
+  languageName: node
+  linkType: hard
+
+"yauzl-promise@npm:2.1.3":
+  version: 2.1.3
+  resolution: "yauzl-promise@npm:2.1.3"
+  dependencies:
+    yauzl: ^2.9.1
+    yauzl-clone: ^1.0.4
+  checksum: 757c46afc0ab92d0dcf338518112323d7a6cb8f2c1b45f8abf503122d663276ade951683b0b9558408adca00df7d3a63018f7fa76dac5b9b400a3153834d67ec
+  languageName: node
+  linkType: hard
+
+"yauzl@npm:^2.9.1":
+  version: 2.10.0
+  resolution: "yauzl@npm:2.10.0"
+  dependencies:
+    buffer-crc32: ~0.2.3
+    fd-slicer: ~1.1.0
+  checksum: 7f21fe0bbad6e2cb130044a5d1d0d5a0e5bf3d8d4f8c4e6ee12163ce798fee3de7388d22a7a0907f563ac5f9d40f8699a223d3d5c1718da90b0156da6904022b
+  languageName: node
+  linkType: hard
+
 "yn@npm:3.1.1":
   version: 3.1.1
   resolution: "yn@npm:3.1.1"
@@ -10919,6 +13256,20 @@ shadcn@latest:
   languageName: node
   linkType: hard
 
+"zod@npm:3.22.4":
+  version: 3.22.4
+  resolution: "zod@npm:3.22.4"
+  checksum: 80bfd7f8039b24fddeb0718a2ec7c02aa9856e4838d6aa4864335a047b6b37a3273b191ef335bf0b2002e5c514ef261ffcda5a589fb084a48c336ffc4cdbab7f
+  languageName: node
+  linkType: hard
+
+"zod@npm:3.24.4":
+  version: 3.24.4
+  resolution: "zod@npm:3.24.4"
+  checksum: 62829789765a9187bd72bed3972a7c1a39fdfe6c59bc752eedabec5f99af701658471b8577d22e0fee2081e6e35d4efc93c02c90e13350755a36feadbf72bbbc
+  languageName: node
+  linkType: hard
+
 "zod@npm:4.0.0":
   version: 4.0.0
   resolution: "zod@npm:4.0.0"
@@ -10933,7 +13284,7 @@ shadcn@latest:
   languageName: node
   linkType: hard
 
-"zod@npm:^3.25 || ^4.0, zod@npm:^4.3.6":
+"zod@npm:^3.25 || ^4.0, zod@npm:^4.1.1, zod@npm:^4.3.6":
   version: 4.3.6
   resolution: "zod@npm:4.3.6"
   checksum: 19cec761b46bae4b6e7e861ea740f3f248e50a6671825afc8a5758e27b35d6f20ccde9942422fd5cf6f8b697f18bd05ef8bb33f5f2db112ab25cc628de2fae47


### PR DESCRIPTION
## Context/Motivation

Without a nurture scheduler, the action queue only fills when consultants manually create or edit leads. This PR keeps the queue populated week-over-week by auto-starting sequences on lead create/re-score and running a Vercel Cron job once daily to draft messages for due sequences.

## Acceptance Criteria (from #132)

- [x] New leads get a stage-appropriate nurture sequence automatically (`unqualified` → discovery/3d, `nurture` → nurture/14d, `warm` → warm_progression/7d)
- [x] Scheduler drafts messages on cadence and inserts them into `message_queue` as `pending`
- [x] Drafts appear in the action queue (#128) — verified by E2E spec (`nurture-scheduler.spec.ts` Test 3)
- [x] Pausing a sequence stops further drafts
- [x] Resuming recomputes `nextStepAt` from now
- [x] Hot leads complete their sequence; the scheduler skips them
- [x] Manual: age a sequence forward via `POST /api/dev/nurture/advance`, run the cron, confirm a draft appears in the action queue — verified by E2E spec (Tests 2–3; uses direct DB seed with past `nextStepAt` instead of the production-gated advance route)

## Changes

- **Scheduler** (`src/server/nurture/scheduler.ts`) — `runSchedulerTick` queries due sequences, drafts sequentially (amortises Claude cache), inserts pending `message_queue` rows, advances `nextStepAt`. Errors log and advance anyway to prevent poison rows.
- **Router** (`nurture.ts`) — replaces the 7-line stub with `listActive`, `startSequence`, `pauseSequence`, `resumeSequence`.
- **Auto-start** (`leads.ts`) — wires `startOrUpdateSequence` into `leadsRouter.create` and `.update` (non-blocking; failure never blocks lead ops).
- **Cron route** (`GET /api/cron/nurture-scheduler`) — bearer-authenticated, scheduled daily at 00:00 UTC in `vercel.json` (Hobby plan limit).
- **Dev helper** (`POST /api/dev/nurture/advance`) — backdates `nextStepAt` by 1 minute; returns 404 in production.
- **Migration** — partial unique index `nurture_active_one_per_lead_uidx ON (lead_id) WHERE status = 'active'` prevents duplicate active sequences at the DB level.
- **Env** — adds `CRON_SECRET` (Vercel Cron sets this automatically).

## Testing

- [x] `make build` passes
- [x] `make check` passes
- [x] `make test` passes (new suites: schemas, scheduler, nurture router, cron route, leads auto-start)
- [x] `make test_e2e` — E2E spec added (`e2e/features/nurture-scheduler.spec.ts`); runs in post-deploy CI with `CRON_SECRET` now passed through

**Manual (required before merge):**
- [ ] Run `yarn db:migrate`; confirm partial index via `\d nurture_sequences`
- [x] Create a lead → confirm one `nurture_sequences` row with correct `sequenceType` and `nextStepAt` — covered by E2E Test 1
- [ ] Update lead to `warm` → confirm row updates in place (no duplicate)
- [ ] Update lead to `hot` → confirm row `status='completed'`
- [x] `POST /api/dev/nurture/advance` → `GET /api/cron/nurture-scheduler` → confirm pending draft in action queue — covered by E2E Tests 2–3
- [ ] Pause → re-run cron → no new draft
- [ ] Resume → re-run cron → new draft with correct `nextStepAt`

## Relevant Links

- Closes #132
- Part of #87 (Epic 3: HITL Message Queue + Nurture Sequences)

## Breaking Changes

None — additive only. Auto-start failures are non-blocking.