### PR TITLE
feat(nurture): add scheduler with cron job, tRPC procedures, and E2E coverage

### DIFF
--- a/.claude/agents/codebase-pattern-finder.md
+++ b/.claude/agents/codebase-pattern-finder.md
@@ -2,8 +2,8 @@
 name: codebase-pattern-finder
 description: Find similar implementations, usage examples, or existing patterns that can be modeled after. It will give you concrete code examples based on what you're looking for! It's similar to codebase-locator, but it will not only tell you the location of files, it will also give you code details!
 tools: Grep, Glob, Read, LS
-color: green
-model: haiku
+color: orange
+model: sonnet
 ---
 
 You are a specialist at finding code patterns and examples in the codebase. Your job is to locate similar implementations that can serve as templates or inspiration for new work.

--- a/.claude/agents/codebase-verification.md
+++ b/.claude/agents/codebase-verification.md
@@ -2,7 +2,7 @@
 name: codebase-verification
 description: Use PROACTIVELY after any code changes to run verification via make targets (build, check, test, test_e2e). Delegates verbose build/test output to isolate it from the main context window. Returns a one-line success or a structured failure with the extracted error block. Invoke with a prompt naming the make targets to run, in order.
 tools: Bash
-color: blue
+color: green
 model: haiku
 ---
 

--- a/.claude/agents/web-lookup.md
+++ b/.claude/agents/web-lookup.md
@@ -1,0 +1,80 @@
+---
+name: web-lookup
+description: Fast library-docs and single-fact web lookups — API signatures, config flags, syntax, version-specific behavior, direct quote extraction from specs/docs. This is the primary library-docs surface. Proactively use for known-answer questions with one or two authoritative sources, and as a parallel helper when a web-research synthesis needs a factual anchor. Escalate to web-research when the question needs cross-source synthesis or conflict resolution. Do not use for codebase questions (use codebase-locator/analyzer) or thoughts/ (use thoughts-locator).
+tools: WebSearch, WebFetch, mcp__context7__resolve-library-id, mcp__context7__query-docs
+color: yellow
+model: sonnet
+---
+
+You are a fast web lookup specialist. You answer narrow, known-answer questions with one or two authoritative citations and return. You return facts, not opinions.
+
+## When to invoke
+
+- Any API signature, config flag, syntax detail, default value, or version number for a named library/framework/SDK/CLI
+- A direct quote from a specific document (spec, RFC, changelog, official doc page)
+- Confirming the current name / status / behavior of a library feature
+- Parallel factual anchor for a `web-research` synthesis in flight (the main thread can run several `web-lookup` calls alongside `web-research` and merge the results)
+
+## When NOT to invoke (refuse with a one-line redirect)
+
+- Cross-source synthesis, comparisons, conflict resolution → redirect to `web-research`
+- Codebase structure / implementation → redirect to `codebase-locator` / `codebase-analyzer`
+- Contents of `thoughts/` → redirect to `thoughts-locator`
+- Questions answerable from the current conversation's context → answer without tools
+
+## Library documentation policy (mandatory)
+
+For any question about a library, framework, SDK, API, CLI tool, or cloud service: **try `context7` first**.
+
+1. Call `mcp__context7__resolve-library-id` with the library name.
+2. Call `mcp__context7__query-docs` with the resolved ID and the user's question.
+3. Only fall back to `WebSearch` / `WebFetch` if context7 returns no usable match or the specific version/section isn't covered.
+
+This applies even for well-known libraries — training data is not authoritative for post-cutoff changes.
+
+## Hard contracts (all mandatory)
+
+### Citation contract
+Every factual claim must have an inline citation in the form `([source-name](url))`. Direct quotes must be wrapped in quotation marks and match the source verbatim.
+
+### Search budget
+Cap: **2 `WebSearch` calls + 3 `WebFetch` calls** per invocation. If you hit the cap without an answer, stop and return a Gaps entry. Do not keep searching.
+
+### Length budget
+Cap your response at **200 words**. Prefer the shortest direct quote over paraphrase.
+
+### Staleness
+Note publication date for each cited source. If the top source is older than 18 months and the topic is fast-moving (framework APIs, model capabilities, pricing), flag the staleness risk in the Summary.
+
+## Mandatory output format
+
+```
+## Summary
+<1–2 sentences, every claim cited inline>
+
+## Sources
+- [source-name](url) — <date> — <one-line relevance note>
+```
+
+If insufficient sources found within budget, return:
+
+```
+## Summary
+Insufficient sources found within budget.
+
+## Gaps
+<what was asked, what was tried>
+```
+
+## Refusal
+
+```
+REFUSED: <reason>. Redirect: <agent or approach>.
+```
+
+## Guardrails
+
+- Never fabricate URLs or quotes.
+- Never invoke the `Agent` tool.
+- Never exceed the search budget without explicit authorisation.
+- Never expand into multi-topic synthesis — escalate to `web-research` instead.

--- a/.claude/agents/web-research.md
+++ b/.claude/agents/web-research.md
@@ -1,0 +1,112 @@
+---
+name: web-research
+description: Deep multi-source web research — synthesising findings across ≥3 sources, resolving conflicting information, surveying best-practices, evaluating comparisons and benchmarks. Proactively use when the answer requires synthesis or the caller needs a survey of a space. Do not use for single-fact or library-docs lookups (use web-lookup), codebase questions (use codebase-locator/analyzer), or thoughts/ (use thoughts-locator).
+tools: WebSearch, WebFetch, TodoWrite, Read, Grep, Glob, LS
+color: yellow
+model: opus
+effort: max
+---
+
+You are a deep web research specialist. You synthesise findings across multiple sources, surface conflicts explicitly, and return verifiable citations. You return facts, not opinions.
+
+## When to invoke
+
+- Cross-source synthesis (≥3 independent sources)
+- Surveying a technical space (frameworks, benchmarks, approaches)
+- Resolving conflicting claims
+- Grounding a design decision in current external evidence
+- Papers, blog posts, release notes, best-practices published after training cutoff
+
+## When NOT to invoke (refuse with a one-line redirect)
+
+- Single-fact / single-source lookup → redirect to `web-lookup`
+- Codebase structure / implementation → redirect to `codebase-locator` / `codebase-analyzer` / `codebase-pattern-finder`
+- Contents of `thoughts/` → redirect to `thoughts-locator` / `thoughts-analyzer`
+- Questions answerable from the current conversation's context → answer without research
+
+## Library-docs delegation
+
+This agent does **not** use context7 or handle API/syntax/config questions about named libraries. If your synthesis needs a specific API signature, config flag, version number, or short doc quote, record it as a `Gaps` entry — the caller can run `web-lookup` in parallel for those facts and feed the results back in. Focus your own searching on papers, READMEs, blog posts, benchmarks, release notes, and other claims-shaped sources.
+
+## Hard contracts (all mandatory)
+
+### Citation contract (binary — every claim cited or not)
+Every factual claim must have an inline citation in the form `([source-name](url))`. Direct quotes must be wrapped in quotation marks and match the source verbatim. No uncited claims.
+
+### Search budget (stopping criteria)
+Cap: **5 `WebSearch` calls + 8 `WebFetch` calls** per invocation unless the caller explicitly authorises more. If you hit the cap without a satisfactory answer, stop and report what you found and what is missing — do not keep searching.
+
+### Staleness handling
+- Note publication date for every cited source.
+- On conflicts, **prefer the most recent** and surface the conflict under `## Conflicts`.
+- If the most authoritative source is older than 18 months and the topic is fast-moving (framework APIs, model capabilities, pricing), flag the staleness risk explicitly.
+
+### Length budget
+Default cap: **800 words**. The cap is raised by any of the following, in the caller's prompt:
+- An explicit target ("~2000 words", "detailed briefing", "deep dive") → use the target as the cap.
+- ≥4 numbered sub-sections or distinct topics in the prompt → raise to **400 words per section** (e.g. 5 sections = 2,000 words).
+
+Within whatever cap applies, prefer exact quotes and direct links over your own paraphrase. Do not compress tertiary-but-load-bearing facts (specific numbers, named metrics/classes, real-world gain figures) just to stay under the default cap when the prompt clearly asks for a survey.
+
+### Repo-aware cross-checking
+If the question relates to code in this repo, use `Read` / `Grep` / `Glob` / `LS` to verify the external information matches current repo state (installed package version, import paths, config values). Flag mismatches explicitly.
+
+## Search strategy
+
+**Start narrow, then broaden.** Begin with the most specific terms the caller provided; widen only if initial results are weak.
+
+**For library / API docs:** `site:<official-domain>` searches first; then changelog / release-notes; then GitHub issues. If the synthesis hinges on an exact API signature / config flag / version number, flag it as a gap rather than fetching deeply — that's `web-lookup`'s job.
+
+**For project-specific claims (benchmark results, real-world gain numbers, case studies, launch announcements):** For any topic that has both a paper/preprint AND an implementation repo, you **must** fetch the repo README (and the landing page / launch blog post if one exists) in addition to the paper — even if the paper alone appears to satisfy the prompt. Extract any quantified real-world gain claims **verbatim** (e.g. "X% → Y% on benchmark Z"). Papers carry methodology and controlled-baseline numbers; READMEs carry post-publication and real-world gain claims that are often absent from the paper. Treat the README fetch as non-optional for this source type — not a "fetch if the paper is insufficient" fallback.
+
+**For best-practices:** Include the year in the query when relevant. Cross-reference ≥2 independent sources before treating a claim as consensus.
+
+**For technical solutions:** Exact error messages in quotes; GitHub issue / discussion threads; official troubleshooting sections.
+
+**For comparisons:** Search both "X vs Y" and the opposite order to counter SEO position bias. Look for benchmark data with dates.
+
+Use search operators: `"exact phrases"`, `-exclusions`, `site:domain`, `after:YYYY-MM-DD`.
+
+Use `TodoWrite` to plan a multi-step research agenda when ≥3 sub-questions exist.
+
+## Mandatory output format
+
+```
+## Summary
+<1–3 sentences, every factual claim cited inline>
+
+## Findings
+
+### <Topic 1>
+- <Finding with inline citation — ([source](url))>
+- <Another finding — ([source](url))>
+- **Publication date:** <YYYY-MM or "undated">
+
+### <Topic 2>
+<repeat>
+
+## Conflicts
+<omit section if none. Otherwise: each conflict with both sources cited.>
+
+## Gaps
+<What was asked but not found, and what was tried. Omit if nothing missing.>
+
+## Sources
+- [source-name](url) — <date> — <one-line relevance note>
+<repeat>
+```
+
+If insufficient sources found within budget, return only `Summary` ("Insufficient sources found within budget."), `Gaps`, and `Sources` (attempted).
+
+## Refusal
+
+```
+REFUSED: <reason>. Redirect: <agent or approach>.
+```
+
+## Guardrails
+
+- Never fabricate URLs or quotes. If a page won't fetch, record it in `Gaps`.
+- Never paraphrase when a direct quote fits within the length budget.
+- Never invoke the `Agent` tool.
+- Never exceed the search budget without explicit authorisation.

--- a/.claude/commands/brainstorm.md
+++ b/.claude/commands/brainstorm.md
@@ -1,6 +1,8 @@
 ---
 description: Interactive design refinement using Socratic method. Use when creating or developing, before writing code or implementation plans - refines rough ideas into fully-formed designs through collaborative questioning, alternative exploration, and incremental validation. Don't use during clear 'mechanical' processes
 skills: writing-clearly-and-concisely
+model: opus
+effort: max
 ---
 # Brainstorming Ideas Into Designs
 
@@ -19,7 +21,7 @@ Start by understanding the current project context, then ask questions one at a 
    - **@agent-codebase-pattern-finder** - To find similar features we can model after
    - **@agent-thoughts-locator** - To find any research, plans, or decisions about this area
    - **@agent-thoughts-analyzer** - To extract key insights from the most relevant documents
-- **ALWAYS use @agent-web-search-researcher** for web research - NEVER call WebSearch or WebFetch directly. The agent handles documentation, articles, blog posts, and any external web content.
+- **ALWAYS use @agent-web-lookup or @agent-web-research** for web research - NEVER call WebSearch or WebFetch directly. Use `web-lookup` for single-fact queries (haiku, fast); use `web-research` for multi-source synthesis or conflict resolution (opus, deep).
 
 **Exploring approaches:**
 - Propose 2-3 different approaches with trade-offs

--- a/.claude/commands/create_plan.md
+++ b/.claude/commands/create_plan.md
@@ -1,5 +1,7 @@
 ---
 skills: writing-clearly-and-concisely, tdd
+model: opus
+effort: max
 ---
 # Implementation Plan
 

--- a/.claude/commands/describe_pr.md
+++ b/.claude/commands/describe_pr.md
@@ -1,4 +1,5 @@
 ---
+model: sonnet
 skills: writing-clearly-and-concisely
 ---
 # Generate PR Description

--- a/.claude/commands/implement_plan.md
+++ b/.claude/commands/implement_plan.md
@@ -1,3 +1,7 @@
+---
+skills: tdd
+model: sonnet
+---
 # Implement Plan
 
 You are tasked with implementing an approved technical plan from `thoughts/plans/`. These plans contain phases with specific changes and success criteria.

--- a/.claude/commands/implement_plan.md
+++ b/.claude/commands/implement_plan.md
@@ -14,9 +14,20 @@ When given a plan path:
 - **Read files fully** - never use limit/offset parameters, you need complete context
 - Think deeply about how the pieces fit together
 - Create a todo list mirroring the plan's phases and per-phase `### Changes` entries
-- Start implementing if you understand what needs to be done
+- Run the Pre-flight risk scan (next section) before writing code.
 
 If no plan path provided, ask for one.
+
+## Pre-flight: Risks & Gotchas
+
+Before writing code, scan the plan for these risks and state findings in a short block:
+
+1. **Schema changes** — name each migration step. Never use schema-push shortcuts that bypass the migrations log.
+2. **CI trigger scope** — for any workflow change, state the trigger. `repository_dispatch`, `schedule`, and `workflow_dispatch` run from the default branch; changes on a feature branch take no effect until merged.
+3. **Env vars** — list new variables and where to set them (local + deployment).
+4. **Test data** — identify external records the plan creates and confirm each spec cleans them up in `afterAll`.
+
+Wait for approval before editing files. If the plan has zero risks, say so and proceed.
 
 ## Implementation Philosophy
 

--- a/.claude/commands/iterate_plan.md
+++ b/.claude/commands/iterate_plan.md
@@ -1,5 +1,7 @@
 ---
 description: Iterate on existing implementation plans with thorough research and updates
+model: opus
+effort: max
 ---
 
 # Iterate Implementation Plan

--- a/.claude/commands/review_roadmap.md
+++ b/.claude/commands/review_roadmap.md
@@ -1,5 +1,7 @@
 ---
 description: Review and prioritize GitHub Project issues for PMF alignment
+model: opus
+effort: max
 ---
 
 # Roadmap Review

--- a/.claude/commands/validate_plan.md
+++ b/.claude/commands/validate_plan.md
@@ -76,6 +76,7 @@ For each phase in the plan:
    - Execute every command listed under the phase's `### Success` → `**Automated**` checklist
    - Document pass/fail status per command
    - If failures, investigate root cause
+   - If an E2E spec fails, re-run just that spec once via `@agent-codebase-verification` before starting root-cause analysis. Only treat the failure as a real regression if it fails twice in a row. First-run flakes on parallel specs are a recurring pattern.
 
 3. **Assess manual criteria**:
    - Walk every item under the phase's `### Success` → `**Manual**` checklist

--- a/.claude/commands/validate_plan.md
+++ b/.claude/commands/validate_plan.md
@@ -1,3 +1,6 @@
+---
+model: sonnet
+---
 # Validate Plan
 
 You are tasked with validating that an implementation plan was correctly executed, verifying all success criteria and identifying any deviations or issues.

--- a/.claude/commands/write_ticket.md
+++ b/.claude/commands/write_ticket.md
@@ -1,6 +1,7 @@
 ---
 description: Create detailed tickets
 skills: ticket-writer, writing-clearly-and-concisely
+model: sonnet
 ---
 
 Use the ticket-writer skill exactly as written

--- a/.claude/scripts/block-dangerous-git.sh
+++ b/.claude/scripts/block-dangerous-git.sh
@@ -9,6 +9,10 @@
 INPUT=$(cat)
 COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command')
 
+# Extract only the first line (the actual shell command, not heredoc body)
+FIRST_LINE=$(echo "$COMMAND" | head -1)
+
+# Patterns matched against the full command (git subcommand + flags only)
 DANGEROUS_PATTERNS=(
   "git push"
   "git reset --hard"
@@ -18,14 +22,19 @@ DANGEROUS_PATTERNS=(
   "git checkout \\."
   "git restore \\."
   "push --force"
-  "reset --hard"
 )
 
 for pattern in "${DANGEROUS_PATTERNS[@]}"; do
-  if echo "$COMMAND" | grep -qE "$pattern"; then
-    echo "BLOCKED: '$COMMAND' matches dangerous pattern '$pattern'. The user has prevented you from doing this without explicit override." >&2
+  if echo "$FIRST_LINE" | grep -qE "$pattern"; then
+    echo "BLOCKED: '$FIRST_LINE' matches dangerous pattern '$pattern'. The user has prevented you from doing this without explicit override." >&2
     exit 2
   fi
 done
+
+# reset --hard checked separately against first line to avoid matching heredoc body
+if echo "$FIRST_LINE" | grep -qE "reset[[:space:]]+--hard"; then
+  echo "BLOCKED: '$FIRST_LINE' matches dangerous pattern 'reset --hard'. The user has prevented you from doing this without explicit override." >&2
+  exit 2
+fi
 
 exit 0

--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: commit
 description: git commit code changes with clear messages
+model: haiku
+skills: writing-clearly-and-concisely
 ---
 # Commit Changes
 

--- a/.claude/skills/tdd/SKILL.md
+++ b/.claude/skills/tdd/SKILL.md
@@ -106,9 +106,6 @@ After all tests pass, look for [refactor candidates](refactoring.md):
 [ ] No speculative features added
 ```
 
-## Rekurve-specific notes
+## Project conventions
 
-- Unit tests use **Rstest** (`make test`). See `rstest-best-practices` skill for config.
-- Integration tests hit real Neon branches; never mock the database (per `feedback_hubspot_source_of_truth` memory — we got burned by mock/prod divergence).
-- E2E tests use **Playwright** (`make test_e2e`). Don't TDD E2E — they're too slow for the tracer-bullet loop.
-- Use `make test` (not `yarn test`) per project convention.
+Check this project's `CLAUDE.md` for the test-runner commands, DB-mocking policy, and E2E conventions before starting a cycle. See [e2e-cleanup.md](e2e-cleanup.md) for per-spec cleanup patterns when specs create external records.

--- a/.claude/skills/tdd/e2e-cleanup.md
+++ b/.claude/skills/tdd/e2e-cleanup.md
@@ -1,0 +1,40 @@
+# E2E Cleanup Patterns
+
+## The failure mode
+
+Broad-filter cleanup after tests that create external records is unreliable. External APIs (e.g. search endpoints) are eventually consistent — a record created at test time may not appear in a search query run seconds later. Cleanup that relies on searching silently leaves rows behind.
+
+## The fix pattern
+
+Each spec maintains a local set of created identifiers (phone numbers, emails, or IDs). Push every created identifier into the set at creation time; delete by those exact identifiers in `afterAll`. Never search.
+
+```ts
+const createdPhones = new Set<string>();
+
+test("creates a contact", async () => {
+  const phone = `+1555${Date.now()}`;
+  await createContact({ phone });
+  createdPhones.add(phone);
+  // assertions...
+});
+
+afterAll(async () => {
+  for (const phone of createdPhones) {
+    await deleteContactByPhone(phone);
+  }
+});
+```
+
+## Test data isolation
+
+Generate a unique identifier per run (timestamp + random suffix). Never reuse a phone number or email across specs — collisions hit unique constraints and mask real failures.
+
+## dotenv load order
+
+If a spec or fixture reads env vars, call `dotenv.config()` before importing any module that triggers env validation. Import order matters; the call must come first.
+
+## When not to use
+
+Read-only specs and specs that hit only an isolated local database have no eventual-consistency risk — skip the tracking set.
+
+See the project's `CLAUDE.md` (or equivalent) for canonical E2E guardrails.

--- a/.claude/skills/tdd/mocking.md
+++ b/.claude/skills/tdd/mocking.md
@@ -2,8 +2,8 @@
 
 Mock at **system boundaries** only:
 
-- External APIs (payment, email, HubSpot, Claude API, etc.)
-- Databases (sometimes — prefer test DB / Neon branch)
+- External APIs (payment providers, email providers, LLM APIs, third-party CRMs, etc.)
+- Databases (sometimes — prefer a real test database or ephemeral branch)
 - Time/randomness
 - File system (sometimes)
 

--- a/.claude/skills/ticket-writer/SKILL.md
+++ b/.claude/skills/ticket-writer/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: ticket-writer
 description: Interactive guide for writing clear, actionable Jira, Linear, GitHub, or File tickets through collaborative refinement. Use when users want to create, review, or improve tickets, user stories, bugs, epics, technical tasks, or spikes. Helps eliminate ambiguity by challenging vague requirements and ensuring tickets contain complete context, testable acceptance criteria, and actionable requirements before development begins. Also use for breaking down large work, writing acceptance criteria, or ensuring tickets are "ready for development."
-skills: writing-clearly-and-concisely
 ---
 
 # Ticket Writer Skill

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,9 +48,30 @@ Use `--sensitive` when adding `CRON_SECRET`, `BETTER_AUTH_SECRET`, `HUBSPOT_*`, 
 
 ---
 
+## Testing
+
+- **Unit tests** use **Rstest** via `make test` (not `yarn test`). See the `rstest-best-practices` skill for config.
+- **Integration tests** hit real Neon branches. **Never mock the database** — we got burned by mock/prod divergence.
+- **E2E tests** use **Playwright** via `make test_e2e`. Don't TDD E2E — they're too slow for the tracer-bullet loop.
+
+---
+
 ## E2E Testing
 
 **_BEFORE marking e2e test changes complete:_** Audit every locator in every method you modified or called. If any uses `getByRole()`, `getByText()`, `getByLabel()`, or CSS selectors instead of `getByTestId()`, check the source component — if it already has a `data-testid`, switch to it; if not, add one to the source, then kill any Next.js server and build and start to verify. This is a **blocking gate** — do not check off e2e test task items until this audit is done.
+
+Additional guardrails for all E2E specs:
+
+- **Per-spec cleanup** — every spec that creates leads or HubSpot contacts tracks them by phone or email within that spec and cleans up in `afterAll`. Never rely on broad search filters — HubSpot search is eventually consistent and can miss a contact created moments earlier.
+- **dotenv load order** — any script or fixture that reads env vars must call `dotenv.config()` **before** importing anything that triggers `~/env` validation.
+- **Flake double-run** — if an E2E spec fails, re-run just that spec once before diagnosing. Only treat it as a real regression if it fails twice in a row.
+- **Test data isolation** — never share a phone number or email across specs; collisions hit the unique constraint and mask real failures. Always generate a unique value per run (e.g., timestamp + random suffix).
+
+---
+
+## GitHub Actions
+
+`repository_dispatch`, `schedule`, and `workflow_dispatch` triggers always run from the **default branch (`main`)** — not from the branch that triggered the event. A fix pushed to a feature branch will not take effect until it is merged into `main`. This is how GitHub Actions works by design (see `.github/workflows/quality-control.yml:48` for the existing `repository_dispatch` usage).
 
 ---
 

--- a/thoughts/designs/2026-04-21-sub-agent-eval-pipeline.md
+++ b/thoughts/designs/2026-04-21-sub-agent-eval-pipeline.md
@@ -1,0 +1,548 @@
+# Sub-Agent Evaluation & Continuous-Improvement Pipeline
+
+**Date:** 2026-04-21
+**Status:** Design — approved, not yet implemented
+**Scope:** `.claude/agents/`, `.claude/commands/`, `.claude/skills/` under this repo; designed to be portable to other Claude Code projects.
+
+---
+
+## 1. Motivation
+
+Claude Code sub-agents are defined as markdown files with YAML frontmatter (`name`, `description`, `model`, `tools`) plus a system-prompt body. Today, quality assessment of these files is ad-hoc: authors write a description and prompt, observe behaviour, hand-edit. There is no systematic signal for routing accuracy, output quality, or regressions across the 9 agents currently in `.claude/agents/`.
+
+This design proposes an evaluation harness that:
+
+1. **Measures** agent quality against a principled rubric on a curated task set (step 2).
+2. **Emits reflective feedback** per failing task so humans can edit agents with evidence (step 2).
+3. **Later** runs closed-loop auto-mutation via GEPA (step 3), gated on rigorous judge calibration.
+
+The pipeline then extends — in phases — to slash commands and skills.
+
+A note on naming: "step 2" and "step 3" refer to the scope ladder introduced during design (measurement / measurement+reflection / closed-loop). The pipeline is shipping at step 2.
+
+---
+
+## 2. Scope ladder
+
+| Step | What it does | When |
+|---|---|---|
+| **2. Measurement + reflection** | Score each agent against a rubric on a fixed task set. Judge emits `(score, feedback)` per run. Humans read the report and hand-edit agents. | **Now** |
+| **3. Closed-loop optimization** | GEPA-style mutation: propose prompt edits, re-eval, accept if Pareto-improving, open PR for human review. | After judge calibration passes (§11) |
+
+Step 3 is **described in-scope but deferred**. The step-2 implementation is architected so that adding step 3 is additive — no redesign.
+
+Cost and latency criteria are intentionally excluded from the rubric until quality reaches a plateau. Quality optimisation first; Pareto trade-offs against spend come later.
+
+---
+
+## 3. Architecture overview
+
+```
+┌────────────────────────────────────────────────────────────────┐
+│  .claude/eval/  (portable; self-contained Python package)       │
+├────────────────────────────────────────────────────────────────┤
+│                                                                  │
+│   tasks/         rubrics/        runner.py     judge.py          │
+│   (YAML)         (YAML)           (SDK)         (Opus)            │
+│        │            │                │            │              │
+│        ▼            ▼                ▼            ▼              │
+│           ┌───────────────────────────────────┐                  │
+│           │       eval orchestrator           │                   │
+│           └───────────────────────────────────┘                  │
+│                          │                                       │
+│                          ▼                                       │
+│    runs/{timestamp}/{agent}/{task-id}/                           │
+│        ├─ meta.json                                              │
+│        ├─ transcript.jsonl   ← Meta-Harness-compatible           │
+│        └─ score.json                                             │
+│                          │                                       │
+│                          ▼                                       │
+│    reports/{date}.md   +   GitHub Issue                          │
+│                                                                  │
+└────────────────────────────────────────────────────────────────┘
+```
+
+**Location:** `.claude/eval/` — colocated with the artefacts it evaluates, portable to other Claude Code projects via copy.
+
+**Language:** Python (sibling pyproject.toml, independent of the Next.js workspace). Rationale: the DSPy/GEPA implementation path for step 3 is Python-only; starting in Python avoids a rewrite.
+
+**Execution substrate:** Claude Agent SDK headless. An agent file is already a (system-prompt, tools, model) tuple — the SDK's native input shape. Zero translation cost. Full message transcripts (including `tool_use` / `tool_result` blocks) are captured by default, unlocking Meta-Harness-style trace reading at step 3.
+
+---
+
+## 4. Repo layout
+
+```
+.claude/
+└── eval/
+    ├── pyproject.toml
+    ├── config.yaml                  # judge model, seeds, max_turns, paths
+    ├── run.py                       # CLI: python -m eval.run
+    ├── src/eval/
+    │   ├── agents.py                # parse .claude/agents/*.md frontmatter+body
+    │   ├── rubric.py                # load shared-core + per-agent extensions
+    │   ├── runner.py                # Agent SDK invocation, trace capture
+    │   ├── judge.py                 # Opus judge prompt + call + parse
+    │   ├── tasks.py                 # hybrid task loader
+    │   └── report.py                # markdown report + GH issue writer
+    ├── tasks/
+    │   ├── shared/                  # cross-agent routing probes
+    │   └── per-agent/
+    │       └── <agent-name>.yaml    # 15 tasks: 5 golden + 5 mined + 5 adversarial
+    ├── rubrics/
+    │   ├── routing.core.yaml
+    │   ├── execution.core.yaml
+    │   └── per-agent/
+    │       └── <agent-name>.extensions.yaml
+    ├── runs/                        # .gitignored; raw traces
+    │   └── {timestamp}/{agent}/{task-id}/
+    ├── calibration/                 # committed; human labels for κ gate
+    │   └── {date}-round-{n}.jsonl
+    └── reports/                     # committed; summaries
+        └── {date}.md
+```
+
+**Key decisions (recorded for portability):**
+
+- `runs/` is git-ignored; transcripts are bulk data. `reports/` and `calibration/` are durable and committed.
+- Task files are YAML, one per agent. Keeps edit surface small.
+- Rubric inheritance is **extend-or-reweight only**, never override. Core criteria are universal.
+- Agents optionally declare `evalCriteria:` in frontmatter pointing to their extension file. Co-locates constraint with the prompt that declares it.
+
+---
+
+## 5. Task sourcing (hybrid)
+
+Hybrid strategy with three sources per agent, ~15 tasks total:
+
+| Bucket | Count | Source |
+|---|---:|---|
+| **Golden** | 5 | Hand-written by engineer. Covers the golden path + 2–3 edge cases. |
+| **Mined** | 5 | Extracted from past Claude Code sessions in `~/.claude/projects/-Users-sam-workspace-rekurve-www/`. Real user invocations. Routing tasks come from top-level session logs (user prompt → delegation decision). Execution tasks come from the per-sub-agent JSONL at `.../subagents/agent-{agentId}.jsonl` — those contain the stripped system prompt the sub-agent actually received. |
+| **Adversarial** | 5 | Synthesised by an Opus "task author" that reads the agent's description + prompt. Generates prompts that should *not* trigger the agent (negatives) + edge cases the human didn't think of. |
+
+**Total at full coverage:** ~135 tasks (9 agents × 15).
+
+### Routing / execution split
+
+Tasks divide by what they score:
+
+- **Routing tasks** — user-prompt-only. Judged *without* running the agent. Single question: "should this agent have been invoked?" (and for negatives, "should it have *stayed silent*?"). Cheap — pennies per call.
+- **Execution tasks** — full agent invocation. Judged on output quality against the execution rubric. Expensive — one full agent run per task per candidate.
+
+The split maps to DeepEval's two-layer model (reasoning vs. action) and Anthropic's sub-agent docs: the `description` field is the routing signal; the body is the execution signal. At step 3, GEPA can mutate the description (cheap to re-eval) separately from the body (expensive) — Pareto-weighting them separately prevents body improvements from being masked by description regressions.
+
+---
+
+## 6. Rubric design
+
+Two rubrics per agent: **routing** (what the router sees) and **execution** (what the task produces). Both use shared-core + per-agent extensions.
+
+### 6.1 Criterion types
+
+Per Autorubric §2 (arxiv:2603.00077v2):
+
+- **Binary** (MET / UNMET) — highest inter-rater reliability. Default.
+- **3-point ordinal** (0 / 0.5 / 1.0) — for criteria that genuinely span a scale.
+- **Unbounded numeric scales are excluded.** LLM judges miscalibrate on them.
+
+### 6.2 Routing rubric (core)
+
+| Criterion | Type | Weight |
+|---|---|---:|
+| Correct-invoke (on positives) | binary | **+2.0** |
+| Non-invoke (on negatives) | binary | **+2.0** |
+| Scope clarity (what / when / when-not) | 3-point ordinal | +1.0 |
+| Verbosity penalty (desc > 60w w/o routing value) | binary | −0.5 |
+
+### 6.3 Execution rubric (core)
+
+| Criterion | Type | Weight | Evidence |
+|---|---|---:|---|
+| Task-completion | binary | **+2.0** | Primary dimension. |
+| Factual-grounding (citations / file:line) | binary | **+2.0** | MT-Bench §3.4: reference-guided scoring cut GPT-4 failures 14→3 of 20. |
+| Tool-scoping (allowlist only; no waste) | binary | +1.0 | DeepEval `ToolCorrectnessMetric` / `ArgumentCorrectnessMetric`. |
+| Stop-discipline | binary | +1.0 | DeepEval action-layer baseline. |
+| Output-contract (format compliance) | binary | +1.0 | Enables mechanical downstream scoring. |
+| Hallucinated paths or URLs | binary | **−1.5** | Autorubric §2: anti-patterns must exceed positive baseline to counter LLM leniency bias. |
+| Unsolicited suggestions | binary | **−1.5** | Critical for agents that explicitly forbid it (e.g. codebase-analyzer). |
+| Refused valid task | binary | **−1.5** | Mirror of correct-invoke; harder to detect than bad output. |
+| Length-budget exceeded | binary | −0.5 | MT-Bench §3.3 verbosity bias (Claude-v1 fooled 91.3%). Penalty needed but bounded. |
+
+### 6.4 Aggregation
+
+Autorubric Equation 1 (clipped 0–1):
+
+```
+score = max(0, min(1, Σᵢ₌₁ⁿ vᵢ · wᵢ / Σ{wᵢ>0} wᵢ))
+```
+
+Where `wᵢ` is the weight and `vᵢ` is the verdict value (1 for MET, 0 for UNMET, or the option's explicit value for multi-choice criteria). Per the paper's §2 exegesis: *"Negative weights are excluded from the denominator so a perfect response scores exactly 1; clamping prevents penalties from pushing scores below zero"* (arxiv:2603.00077v2).
+
+- Max raw positive on execution = 2+2+1+1+1 = 7
+- Max raw negative = 3 × −1.5 + −0.5 = −5
+- Pure clean run → 1.0; hallucination-heavy "looks-right" run → clipped to 0
+
+### 6.5 Why 2.0 / 1.0 / −1.5 (not flat 1.0 / −0.5)
+
+1. **Leniency asymmetry.** Autorubric §2 establishes the *mechanism* — *"Negative criteria serve as penalties for anti-patterns, counteracting the leniency bias documented in LLM judges (Sharma et al., 2025)"* (arxiv:2603.00077v2). Quantification comes from MT-Bench §3.3, which reports self-enhancement bias of ~+10% for GPT-4 and ~+25% for Claude-v1 (the authors caveat the result as under-powered: *"our study cannot determine whether the models exhibit self-enhancement bias"*). Negatives ≥ positive baseline corrects for the plausible-upper-bound case.
+2. **Signal on the correctness axis** (MT-Bench §3.4): reference-guided correctness has the largest calibrated improvement (70%→15% failure reduction). 2.0 lets a correctness win overcome format/process losses.
+3. **Pareto shape for step 3** (GEPA paper §4): GEPA selects candidates best on ≥1 criterion. Flat weights create near-flat Pareto surfaces where cosmetic variants look equivalent to correctness wins. A 2:1 correctness:process ratio preserves gradient.
+
+**Future refinement.** The length-budget penalty (§6.3) is binary. Autorubric's criterion-type ordering (§6.1) excludes continuous scales due to LLM miscalibration on unbounded numeric ranges, which is why length is scored binary rather than normalised. If the binary threshold proves too blunt (e.g. judge verdicts cluster at the boundary), the upgrade path is to add a narrow 3-point ordinal (under / at / over budget) with behavioural anchors — not a continuous length-normalised score.
+
+### 6.6 Per-agent extensions
+
+Each agent may declare an extensions file adding binary criteria specific to its contract. Examples:
+
+- `codebase-verification.extensions.yaml` — "emits literal `STATUS: SUCCESS` / `STATUS: FAILURE` / `STATUS: REFUSED` line" (binary, +2.0)
+- `codebase-analyzer.extensions.yaml` — "did not identify bugs/problems/improvements" (binary, −1.5; overrides weight from core's unsolicited-suggestions to match this agent's explicit prohibition)
+
+Extensions may **add** criteria or **re-weight** core criteria. They may not **redefine** core criteria or **remove** them.
+
+---
+
+## 7. Judge configuration
+
+### 7.1 Scoring mode
+
+- **Step 2:** single-answer rubric scoring (MT-Bench §4.2). Judge reads one response, emits per-criterion binaries. 1 call per (task × candidate).
+- **Step 3:** rubric scoring + pairwise-with-swap. Pairwise (swap-gated) gates mutation acceptance. Rubric drives the dashboard. 2× cost on pairwise accepted.
+
+### 7.2 Judge model
+
+**Opus 4.7** (claude-opus-4-7). Rationale:
+
+- MT-Bench §4.2 Table 5: GPT-4 rubric agreement with humans = 85%, above inter-human 81%. Opus-class models clear the calibration bar; weaker models don't.
+- Autorubric Table 4 (arxiv:2603.00077v2): strong judges show negligible ensemble lift — Gemini-3-Flash κ = 0.679 (default) → 0.673 (+ensemble k=3 majority), slightly negative. **No ensemble at step 2.**
+- Autorubric Table 2 (RiceChem): verdict-balanced exemplars lift 0-shot 77.2% → 3-shot 79.0% → 5-shot 80.0%. **3-shot** is the plateau — 5-shot adds only +1.0pp accuracy for +66% prompt-token cost. 3-shot, verdict-balanced (prevents base-rate drift per Autorubric §2: *"verdict balancing to prevent the judge from inferring a base-rate prior"*).
+
+Downgrade path if step-3 cost becomes a problem: Sonnet + k=3 same-model ensemble. This is Autorubric's "weak judge" regime — LLaMA-3.1-8B κ −0.001 → +0.044 with ensemble k=5, and accuracy from 41.2% → 67.5% (+26pp). Sonnet isn't LLaMA-weak, but the ensemble asymmetry confirms the downgrade path is sound.
+
+### 7.3 Mandatory bias mitigations
+
+All five applied to every judge call:
+
+1. **Randomise criterion order** in every judge prompt (fixed per-(task, candidate) seed so results replay). A 2× swap is adopted as the default per MT-Bench §3.4. A newer paper (arxiv:2602.02219, Feb 2026) reports measurable gains from a 10-permutation balanced rotation scheme (5 forward + 5 reverse cyclic rotations). If empirical drift is observed on a specific criterion, upgrade that criterion to the 10-permutation scheme. Default stays at 2× — 10× judge cost is a real budget hit.
+2. **Randomise exemplar order** within the 3-shot block.
+3. **Reference-based scoring** on golden-set tasks — inject the human-authored ideal response as `<reference>`.
+4. **Swap-gated pairwise verdicts** (step 3 only). No win declared on single-order call.
+5. **Blind the judge to agent identity** — strip agent name from the transcript before scoring. Prevents self-enhancement drift and forces evaluation against the rubric rather than priors.
+
+---
+
+## 8. Execution substrate details
+
+### 8.1 Agent SDK runner
+
+`.claude/eval/src/eval/runner.py` (~150 LOC):
+
+1. Read `.claude/agents/<name>.md`, parse frontmatter (`name`, `description`, `model`, `tools`) and body (system prompt).
+2. Call Claude Agent SDK with: system prompt = body, tools = frontmatter `tools` allowlist, model = frontmatter `model`, max_turns = config.
+3. Capture the full message stream (including `tool_use`, `tool_result` blocks).
+4. Write trajectory artefacts (§8.2).
+
+**Important:** the `Agent` tool is disallowed at the SDK level — real sub-agents can't spawn other sub-agents, so the eval enforces the same boundary.
+
+### 8.2 Trajectory capture
+
+Every eval run writes three files per (agent × task):
+
+```
+.claude/eval/runs/{timestamp}/{agent}/{task-id}/
+  ├── meta.json           # agent-file SHA, task-id, candidate-id, model, seed, ts, cost, latency
+  ├── transcript.jsonl    # full SDK message stream, one message per line
+  └── score.json          # per-criterion binaries, aggregate, judge-model-id,
+                          # judge-prompt-SHA, reflective feedback string
+```
+
+This layout is **deliberately Meta-Harness-shaped** (arxiv:2603.28052v1 §3): a step-3 proposer can `ls` the directory, `cat` prior transcripts and scores, and reason over raw traces — matching the paper's Algorithm 1 filesystem-inspection step. Table 3 shows raw-trace reading beats scalar-only by ~15pp; this layout preserves the option. Empirical support: the paper's Appendix A.2 reports the proposer reading a median of 82 files per iteration (41% harness source / 40% execution traces) with non-Markovian access patterns referencing ≥20 prior candidates per step — concrete evidence that the filesystem-as-memory affordance is actually used.
+
+**Note on native Claude Code transcripts.** Claude Code already writes sub-agent transcripts to `~/.claude/projects/{project}/{sessionId}/subagents/agent-{agentId}.jsonl` when agents run in a real session. The eval runner goes through the Agent SDK directly (not through a main Claude Code session), so it does not produce these native artefacts. If a future "shadow-eval from real usage" feature is added, it can read the native JSONL path directly rather than re-running — the schemas are compatible.
+
+### 8.3 GEPA adapter (step 3)
+
+GEPA ships a `GEPAAdapter` interface with `evaluate()` and `make_reflective_dataset()` methods, plus built-in adapters: `DefaultAdapter`, `DSPyFullProgramAdapter`, `GenericRAGAdapter`, `ConfidenceAdapter`, `MCPAdapter` ([gepa-ai/gepa](https://github.com/gepa-ai/gepa)). The universal entry point is `gepa.optimize_anything(seed_candidate, ...)`, which accepts an arbitrary text artefact as the seed — a sub-agent's markdown body fits directly.
+
+**Starting point:** subclass `DefaultAdapter`, override `evaluate()` to invoke the SDK runner (§8.1) and score the resulting transcript with the judge (§7), and override `make_reflective_dataset()` to emit per-task `(trace, score, feedback)` tuples for the reflection LM.
+
+**Scope:**
+- GEPA may mutate the **body** only (phase 1) or **body + description** (phase 2). See §11.3.
+- Model, tools, and wider frontmatter stay fixed. The adapter does not expose them to the optimizer — GEPA can't escape its sandbox.
+
+Seed-candidate pattern:
+
+```python
+result = gepa.optimize_anything(
+    seed_candidate={"system_prompt": agent_body},
+    trainset=trainset, valset=valset,
+    reflection_lm="claude-opus-4-7",
+    max_metric_calls=500,  # §11.6 budget
+    adapter=SubAgentAdapter(agent_name),
+)
+```
+
+The SDK runner (§8.1) remains the executor regardless of optimizer. DSPy's `dspy.GEPA` is an alternative integration path if the sub-agent is ever rewritten as a DSPy program — not currently planned.
+
+---
+
+## 9. Reporting
+
+### 9.1 Report sections
+
+Written to `.claude/eval/reports/{date}.md` after every run:
+
+1. **Header** — run timestamp, git SHA of `.claude/agents/*.md`, judge model, total cost & tokens.
+2. **Leaderboard** — agents × rubric scores × Δ vs. last run × flagged-criterion count. Red if any primary-axis criterion < 0.5 across ≥40% of tasks.
+3. **Regressions** — (agent, criterion) pairs that dropped ≥0.15 from last run. Linked to failing task IDs.
+4. **Reflective feedback digest** — GEPA-style one-line "why it failed" per failing task, grouped by theme.
+5. **Calibration drift check** — if κ-vs-human labels are available, current κ per criterion; flag downward crossings.
+6. **Suggested edits** — judge proposes 1–3 sentence edits per regression, with failing task IDs as evidence. **Not auto-applied at step 2** — humans review.
+
+### 9.2 Distribution
+
+- **Local:** `.claude/eval/reports/{date}.md`.
+- **GitHub Issue:** `report.py` opens or updates one issue per run with the report pasted in. Regressions → labels.
+- **Dashboard:** deferred. Only build if signal warrants it (YAGNI).
+
+---
+
+## 10. Trigger cadence (phased)
+
+| Phase | Trigger | Rationale |
+|---|---|---|
+| **Now (pre-calibration)** | Manual only — `/eval` slash command → `python -m eval.run` | Hand-driven. Build task set, tune rubric, label 50 items, confirm κ gate. |
+| **Step 2 stable (κ gate passes once)** | Manual + on-PR when `.claude/**` changes | Judge trusted enough to gate PRs. **Advisory-only, never blocking** — comment the report on the PR. |
+| **Post step-3 activation** | Manual + on-PR + nightly cron on `main` | Time series validates mutations hold up. |
+
+Cron is added **only after** step 3 activation. Pre-calibration nightly reports generate noise and normalise ignoring them (alert fatigue).
+
+**PR gating is advisory forever.** Blocking on judge verdicts risks the judge becoming the arbiter of what's mergeable — the exact drift GEPA exploits. Human veto preserved.
+
+### 10.1 Slash command
+
+Single namespaced command: `/eval <subcommand>`. Subcommands:
+
+- `/eval run` — run full suite (or single agent with `--agent=<name>`)
+- `/eval report` — re-render the latest report
+- `/eval calibrate` — enter calibration mode (produce N runs for human labelling)
+- `/eval mutate` — step 3 only; disabled unless `config.yaml: step3.enabled = true`
+
+---
+
+## 11. Step 3 activation criteria
+
+Step 3 auto-mutation activates only when **all** gates pass. Gates are conservative because GEPA's 32%→89% gains assume the metric isn't gameable; a judge with κ 0.3 would auto-mutate toward judge-gaming rather than quality.
+
+### 11.1 Calibration gate (judge accuracy vs. humans)
+
+- Hand-label 30 execution-rubric runs + 20 routing-rubric runs across ≥5 different agents.
+- Compute Cohen's κ per criterion between human and judge.
+- **Primary-axis criteria** (task-completion, factual-grounding, correct-invoke, hallucination, unsolicited-suggestions): **κ ≥ 0.6** ("substantial agreement" per Landis & Koch 1977). MT-Bench reports 85% non-tie agreement for GPT-4 with humans on pairwise tasks; the corresponding κ is a derived estimate (a rough range of 0.5–0.75 on balanced binary data per standard Cohen's κ formula), not a direct MT-Bench finding. The κ ≥ 0.6 floor is chosen conservatively against the lower end of that derivation.
+- **Secondary criteria:** κ ≥ 0.4 ("moderate").
+- Failing criteria: rewrite behavioral anchor, add exemplar, or split into sub-criteria. Re-label and re-measure.
+- Gate passes only after **two disjoint sample batches** clear both thresholds. Prevents overfit to the first label batch.
+
+### 11.2 Stability gate (judge variance)
+
+- Re-run the full 135-task suite 3× with different trace seeds.
+- Compute Spearman rank correlation of per-agent aggregate scores pairwise across reruns.
+- **Gate: ρ ≥ 0.9 all three pairs.** Below that, variance too high — raise samples per task or tighten anchors.
+
+### 11.3 Mutation scope bounds
+
+Progressive:
+
+1. **Phase 1: body-only.** GEPA may only edit the system-prompt body. Doesn't disturb routing; largest quality lever.
+2. **Phase 2: body + description.** Added only after a clean phase-1 mutation round ships without regressions. Description edits affect other agents' eval scores via adversarial negatives, so they need a baseline first.
+3. **Never: `model` or `tools`.** Architectural decisions. Letting the optimizer edit tool allowlists would let it escape its sandbox.
+
+### 11.4 Acceptance threshold
+
+A mutation is accepted only if:
+
+1. Aggregate rubric score delta ≥ **+0.05** vs. parent on the full task set. (One-task improvement = 6.7% noise on 15 tasks; +0.05 exceeds the stability gate's noise floor.)
+2. **No primary-axis criterion regresses by ≥0.1.**
+3. The improvement holds on a **held-out test split** — 3 tasks per agent never seen by GEPA. Autorubric §3: single-set optimisation overfits to judge idiosyncrasies; the held-out split detects that.
+
+### 11.5 Human-in-the-loop + rollback
+
+Two-layer safety:
+
+1. **PR-for-review, never auto-commit.** Every accepted mutation opens a PR with: (i) before/after diff, (ii) rubric score delta per criterion, (iii) the reflective feedback that motivated the mutation, (iv) the 3 failing-task IDs that triggered it. Human reviews and merges.
+2. **Shadow-eval on merge.** Once merged, the nightly cron runs the suite. If the mutated agent regresses ≥0.1 on primary axis vs. pre-mutation baseline, auto-open a rollback-candidate issue. If per-run isolation is needed (e.g. a mutation under review touches a file-writing tool), set `isolation: worktree` in the mutated agent's frontmatter — Claude Code will run it in a temporary git worktree that auto-cleans if no changes are made.
+
+### 11.6 Budget
+
+`max_metric_calls = 500` per agent per mutation session. At ~$0.08/judge call (Opus 4.7) ≈ $40/agent/session; full 9-agent sweep ≈ $360. Manual trigger only — never cron.
+
+### 11.7 Auto-disable conditions
+
+Step 3 disables itself automatically if:
+
+1. **Calibration drift** — quarterly re-calibration drops any primary-axis criterion below κ 0.6.
+2. **Suggestion quality drift** — ≥3 consecutive merged mutations are later reverted (manually or via shadow-eval flag). Indicates the optimizer is gaming the metric.
+
+Config flag: `step3.enabled: false` by default. `/eval mutate` refuses to run unless flipped true.
+
+---
+
+## 12. Extension to commands and skills (phased, fully designed)
+
+The pipeline extends to `.claude/commands/` and `.claude/skills/` — deferred in implementation, but design decisions are recorded here so future extension doesn't require redesign.
+
+### 12.1 Why phased
+
+- **Phase 1 (weeks 1–3):** agents only. Calibrate on 9 entities. Low count = easier to debug rubric weaknesses.
+- **Phase 2 (weeks 4–6):** commands.
+- **Phase 3 (later):** skills.
+
+**Extension to commands/skills cannot begin until the agent-eval κ gate has passed at least once.** Copying an uncalibrated judge across three artefact types triples drift risk without tripling signal.
+
+### 12.2 What transfers unchanged
+
+- Task sourcing hybrid (§5).
+- Rubric structure: shared-core + extensions (§6).
+- Judge configuration: Opus + 3-shot + 5 bias mitigations (§7).
+- Trajectory capture (§8.2).
+- Storage, reporting, triggers, slash command (§9, §10).
+
+### 12.3 Commands — what changes
+
+Commands expand inline into the parent conversation; there is no router decision and no sub-context boundary.
+
+- **No routing rubric.** Drop cleanly.
+- **New execution driver:** `run_command.py` constructs a synthetic parent-context fixture, expands the command, and runs the main conversation. Captures the resulting trajectory.
+- **New rubric axis:** consistency — does this command produce stable output across varied parent contexts? Use A/B with 2–3 different lead-in contexts per task.
+- **New anti-pattern:** side-effect leaks — commands that write files the user didn't ask for, run destructive shell without confirmation, push code, etc. Weight −1.5 per Autorubric leniency-correction.
+
+Storage extension: `.claude/eval/tasks/commands/<command-name>.yaml`, `.claude/eval/rubrics/execution.commands.yaml`.
+
+### 12.4 Skills — what changes
+
+Skills are diffuse: they shape how Claude responds to *future* turns in the same conversation, not a single output. Isolating their effect is the hard problem.
+
+**Chosen approach: pairwise A/B with swap.**
+
+For each skill, for each task:
+
+1. Run the task with the skill loaded.
+2. Run the task with the skill omitted.
+3. Swap A/B order; re-run the judge.
+4. Skill is declared net-positive only if judged better in **both** orders.
+
+This is the MT-Bench §3.4 swap-gated protocol — the same pairwise mode we adopt at step 3 (§7.1). Skills inherit the mode-3 judge stack for free.
+
+Skills-specific rubric criteria:
+
+- **Purpose-alignment** (binary, +2.0): did the skill-loaded run better serve the skill's stated purpose (from its `SKILL.md` frontmatter `description` field)?
+- **Context-noise** (binary, −1.0): did the skill inject irrelevant instructions that distracted the response from the user's actual question?
+- **Negative-space** (binary, +1.0): on tasks *unrelated* to the skill's purpose, the skill-loaded run should be indistinguishable from skill-absent. Catches skills that over-apply.
+
+### 12.5 Alternatives considered for skills
+
+Recorded for future re-evaluation if pairwise A/B proves inadequate:
+
+- **Behavioral contract testing** — skills declare `expectedBehaviors:` in frontmatter; judge scores "did this behaviour appear." Cheaper, mechanically simpler, but requires author discipline that may lag real behaviour.
+- **Downstream metric attribution** — measure whether skill-present runs improve downstream agent eval scores. Most faithful, but requires running full agent eval twice per skill. Deferred.
+
+### 12.6 Agent creation (Phase 4 — describe-but-defer)
+
+Step 3 enables **creating** new agents, not only improving them. Mechanism (GEPA seed-candidate pattern):
+
+1. Author creates `.claude/agents/draft-<name>.md` with a stub body and declared purpose.
+2. Draft enters the eval suite as any other candidate, with a provisional task set.
+3. GEPA mutates the body; acceptance threshold (§11.4) applies.
+4. If the draft's best candidate scores ≥ 0.6 on its primary axis, it graduates to `.claude/agents/<name>.md` via PR.
+
+This is the Meta-Harness §3 "propose a new harness" mechanism with the same gates as mutation. **Phase 4 only — not implemented now.** Captured so the step-3 architecture accommodates it.
+
+---
+
+## 13. Application to `codebase-analyzer.md` (initial test case)
+
+The first agent to run through this pipeline. `codebase-analyzer` is chosen because it carries the richest set of rubric-evaluable characteristics in the current suite — an explicit anti-pattern contract ("don't identify bugs/problems"), a mandatory file:line citation requirement, and a prescribed output template — making it a high-signal smoke test for whether the rubric design correctly discriminates quality.
+
+### 13.1 Metadata — current state and what the routing rubric will score
+
+**Description (line 3).** Current: *"Analyzes codebase implementation details. Call the codebase-analyzer agent when you need to find detailed information about specific components. As always, the more detailed your request prompt, the better!"*
+
+Maps to routing-rubric criteria (§6.2):
+
+| Criterion | Score hypothesis | Why |
+|---|---|---|
+| Scope clarity (what) | 1.0 | "implementation details" + "specific components" is specific. |
+| Scope clarity (when) | 0.5 | "when you need to find detailed information" restates the what. |
+| Scope clarity (when-not) | 0.0 | No negative boundary — invites false-positive routing for questions that should go to `codebase-locator` (find files) or `codebase-pattern-finder` (find usage examples). |
+| Verbosity penalty | 0 | Under 60 words; no waste. |
+
+**Model (line 6):** `sonnet`. Execution rubric will reveal whether sonnet is warranted — the agent does read-heavy analysis but no synthesis across external sources, which is haiku-shaped work. Decision deferred to the eval run.
+
+**Tools (line 4):** `Read, Grep, Glob, LS`. Clean read-only allowlist; no rubric concern.
+
+### 13.2 Prompt body — criteria the execution rubric will score
+
+The body is unusually explicit, which creates a strong test for the rubric:
+
+**Likely to score well** (per §6.3 core criteria):
+- **Task-completion** — prescribed Analysis Strategy (lines 40–60) is a clear workflow.
+- **Factual-grounding** — mandatory file:line references (line 118). Directly maps to the factual-grounding binary criterion.
+- **Output-contract** — prescribed output template (lines 66–114) is verbatim-copyable; mechanically scorable.
+- **Unsolicited suggestions** — explicit prohibition in lines 11–18 and 125–138. The core rubric's `−1.5` weight on this criterion matches the prompt's own escalation ("CRITICAL", "DO NOT").
+
+**Likely to score poorly or trigger rubric edge cases:**
+- **Length-budget exceeded (§6.3 −0.5)** — line 52's "Take time to ultrathink about how all these pieces connect and interact" invites length-bias failure (MT-Bench §3.3: Claude-v1 failed 91.3% on the verbosity attack). First failing task will surface whether the penalty catches it or the binary threshold is too lax.
+- **Per-agent extension (§6.6)** — the "don't identify bugs" contract is strong enough that `codebase-analyzer.extensions.yaml` should add a `−1.5` binary criterion ("did not identify bugs/problems/improvements"), re-weighting the core's `unsolicited-suggestions` to match this agent's explicit prohibition.
+
+### 13.3 Open questions the first eval run will answer
+
+1. **Does the 3-shot verdict-balanced exemplar set** (§7.2) produce consistent judge verdicts on the "no bugs" criterion? The contract is binary, but the boundary ("noting a configuration value" vs. "critiquing a configuration choice") requires calibrated exemplars.
+2. **Does model=sonnet outscore model=haiku** on adversarial tasks (§5 mined bucket) that test long-context analysis? If haiku is competitive, the design's §11.3 prohibition on `model` mutation is the right long-term policy but haiku may be the right starting point.
+3. **Does the routing rubric's "when-not" criterion** score correctly on the mined-negative tasks from `codebase-locator` / `codebase-pattern-finder` overlap territory? If the judge can't distinguish, the routing rubric weights need re-calibration before the κ gate.
+
+### 13.4 Retrospective sanity check: `web-research.md` iteration
+
+The `web-research` agent was iterated five times during the brainstorm week (transcript: `thoughts/research/2026-04-21-web-research-agent-iteration-transcript.md`). Each regression that drove an edit (length-cap ceiling, context7 premature satisfaction, missing project-claims branch) maps to at least one rubric criterion the design proposes:
+
+- Length-cap ceiling → **length-budget exceeded (−0.5)**
+- Context7 premature satisfaction → **task-completion (+2.0)** via missing facts
+- Missing README fetches → **factual-grounding (+2.0)**
+- Dropped Conflicts/Gaps sections across runs → **output-contract (+1.0)**
+
+The iteration transcript is the design's closest thing to pre-launch validation data: the rubric criteria do pick up the regressions that a human noticed. A full eval run on `web-research` at each historical state would be worth running once the pipeline is live, as a calibration artefact.
+
+---
+
+## 14. Research references
+
+All citations load-bearing for decisions above:
+
+- **Stanford Meta-Harness** — arxiv:2603.28052v1, §3–§4 and Appendix A.2. Filesystem-as-memory; Algorithm 1; Table 3 trace-reading vs scalar-only +15pp; A.2 proposer behaviour (median 82 files/iter, 41% harness source / 40% traces, non-Markovian access ≥20 prior candidates). Drives trajectory capture design (§8.2).
+- **GEPA: Reflective Prompt Evolution** — arxiv:2507.19457 (ICLR 2026 Oral) and [gepa-ai/gepa](https://github.com/gepa-ai/gepa) v0.1.1. Reflective Pareto evolution; `GEPAAdapter` interface (`evaluate()` + `make_reflective_dataset()`); built-in adapters (`DefaultAdapter`, `DSPyFullProgramAdapter`, `GenericRAGAdapter`, `ConfidenceAdapter`, `MCPAdapter`); `optimize_anything` universal entry point. 32%→89% ARC-AGI, 46.6%→56.6% AIME, 90× cost reduction vs Claude Opus. Drives step-3 design (§8.3, §11).
+- **Judging LLM-as-a-Judge (MT-Bench, Chatbot Arena)** — arxiv:2306.05685 (NeurIPS 2023). 85% human agreement for GPT-4; position bias (GPT-4 65% consistency, Claude-v1 23.8%); verbosity 91.3%; swap-gated pairwise; reference-guided scoring 14→3 failures of 20; math grading 70%/30%/15% for default/CoT/reference-guided. Drives judge config (§7) and calibration gate (§11.1).
+- **Systematic Study of Position Bias in LLM-as-Judge** — arxiv:2602.02219 (2026-02). 10-permutation balanced rotation (5 forward + 5 reverse cyclic) as a stronger alternative to 2× swap. Referenced as an upgrade path in §7.3.
+- **Autorubric** — arxiv:2603.00077v2. Verbatim quotes preserved at `thoughts/research/2026-04-21-autorubric-verbatim-quotes.md`. Binary > ordinal > nominal reliability (continuous excluded); negative-weight anti-patterns (leniency bias per Sharma et al. 2025); Equation 1 aggregation with "perfect response scores exactly 1"; Table 4 ensemble ablation (strong judges κ 0.679→0.673; weak judges +26pp); Table 2 3-shot plateau. Drives rubric design (§6) and judge model choice (§7.2).
+- **Anthropic engineering — Demystifying evals for AI agents** — anthropic.com/engineering/demystifying-evals-for-ai-agents. 20–50 tasks from real failures; code-based + model-based + human graders; balanced positive/negative sets. Drives task sourcing (§5).
+- **Anthropic — Building agents with the Claude Agent SDK** — claude.com/blog/building-agents-with-the-claude-agent-sdk. Feedback-loop principle: *"gather context → take action → verify work → repeat"*; rules-based feedback: *"The best form of feedback is providing clearly defined rules for an output, then explaining which rules failed and why."* Drives reflective-feedback framing at §9.1.
+- **Claude Code sub-agent docs** — code.claude.com/docs/en/sub-agents. Description is the routing signal; "use proactively" pattern; tool scoping (allowlist/denylist precedence); model resolution order; `isolation: worktree` frontmatter (used in §11.5); sub-agent transcript JSONL path `~/.claude/projects/.../subagents/agent-{agentId}.jsonl` (referenced in §5 and §8.2); "subagents cannot spawn other subagents" constraint (motivates the main-session `/eval` orchestrator in §10.1). Drives test-case analysis (§13) and routing-rubric design (§6.2).
+- **DeepEval agent evaluation guide** — deepeval.com/guides/guides-ai-agent-evaluation. Two-layer agent model (reasoning + action); `ToolCorrectnessMetric`, `ArgumentCorrectnessMetric`. Drives execution-rubric process-quality criteria (§6.3).
+- **Ragas agent metrics** — ragas.io docs. `ToolCallAccuracy` and `AgentGoalAccuracy` are named prior-art for the routing `correct-invoke` and execution `task-completion` criteria. Convergent terminology with §6.2–§6.3.
+- **Inspect AI (UK AISI)** — inspect.aisi.org.uk. `dataset → Task → Solver → Scorer` primitives — the same vocabulary the repo layout at §4 implements directly. Considered and rejected as an execution substrate in favour of Claude Agent SDK direct (would add ~1 week of adapter code) but used as the mental model for the primitives.
+- **Iteration transcript — `web-research` agent** — `thoughts/research/2026-04-21-web-research-agent-iteration-transcript.md`. 5-run pre-launch validation of rubric criteria against a real regression trace. Cited at §13.4.
+- **Ralph Loop design** — thoughts/designs/2026-04-01-ralph-loop.md. In-repo precedent for metric-driven automation.
+
+---
+
+## 15. Non-goals
+
+- Cost and latency optimisation. Deferred until quality plateaus.
+- Blocking PR gate on judge verdicts. Judge is advisory, forever.
+- Auto-commit of mutations. Every mutation goes via PR, even post step-3.
+- General-purpose LLM eval framework. Scope is strictly `.claude/**` artefacts.
+- Real-time monitoring / dashboards. YAGNI until the signal justifies it.
+
+---
+
+## 16. Next step
+
+User will run `/create_plan` to produce an implementation plan against this design. This document is the source-of-truth for the eval pipeline's architectural decisions and should be updated if those decisions change during implementation.

--- a/thoughts/plans/2026-04-20-ENG-132-nurture-scheduler.md
+++ b/thoughts/plans/2026-04-20-ENG-132-nurture-scheduler.md
@@ -101,13 +101,13 @@ Two vertical slices. **Slice 1** builds the cadence logic, state transitions, an
 - [x] `make build` passes
 
 **Manual**
-- [ ] Create a new lead via the UI with qualification data that lands in the `nurture` stage. In the DB, confirm exactly one `nurture_sequences` row exists for that lead with `sequenceType='nurture'`, `status='active'`, `nextStepAt` ≈ now + 14 days.
+- [x] Create a new lead via the UI with qualification data that lands in the `nurture` stage. In the DB, confirm exactly one `nurture_sequences` row exists for that lead with `sequenceType='nurture'`, `status='active'`, `nextStepAt` ≈ now + 14 days. _(covered by `e2e/features/nurture-scheduler.spec.ts` Test 1)_
 - [ ] Update the same lead's qualification to land in `warm`. Confirm the existing row's `sequenceType` becomes `warm_progression` and `nextStepAt` becomes ≈ now + 7 days (no new row).
 - [ ] Update the lead again to land in `hot`. Confirm the row's `status` becomes `completed` and `nextStepAt` is null/ignored.
-- [ ] Start a fresh `nurture`-stage lead, `POST /api/dev/nurture/advance` with that sequence id, then `GET /api/cron/nurture-scheduler` with the `Authorization: Bearer ${CRON_SECRET}` header. Confirm: (a) a new `message_queue` row with `status='pending'` for that lead, (b) sequence's `nextStepAt` advanced by 14 days, (c) row visible in the action queue view at `/dashboard`.
+- [x] Start a fresh `nurture`-stage lead, `POST /api/dev/nurture/advance` with that sequence id, then `GET /api/cron/nurture-scheduler` with the `Authorization: Bearer ${CRON_SECRET}` header. Confirm: (a) a new `message_queue` row with `status='pending'` for that lead, (b) sequence's `nextStepAt` advanced by 14 days, (c) row visible in the action queue view at `/dashboard`. _(covered by `nurture-scheduler.spec.ts` Tests 2–3; uses direct DB seed with past `nextStepAt` instead of the production-gated advance route)_
 - [ ] Pause the sequence via `nurture.pauseSequence`; re-run `/api/cron/nurture-scheduler`; confirm no new draft inserted.
 - [ ] Resume; confirm `nextStepAt` is set to ≈ now + 14 days; re-run cron; confirm new draft.
-- [ ] Hit `/api/cron/nurture-scheduler` with no Authorization header → 401. With wrong bearer → 401. With correct bearer but no due sequences → 200 with `{ drafted: 0, failed: 0 }`.
+- [x] Hit `/api/cron/nurture-scheduler` with no Authorization header → 401. With wrong bearer → 401. With correct bearer but no due sequences → 200 with `{ drafted: 0, failed: 0 }`. _(covered by `route.test.ts` unit tests)_
 
 ## References
 - Ticket: https://github.com/samjmarshall/rekurve/issues/132

--- a/thoughts/plans/2026-04-21-claude-config-insights-improvements.md
+++ b/thoughts/plans/2026-04-21-claude-config-insights-improvements.md
@@ -1,0 +1,147 @@
+# Claude Code Config Improvements from /insights Report Implementation Plan
+
+## Context
+
+The `/insights` run on 2026-04-21 analysed 171 sessions over 510h and surfaced recurring friction patterns (drizzle-kit push drift, `repository_dispatch` branch confusion, HubSpot eventual-consistency flakes, dotenv ordering, scope misalignment during implementation). Several fixes already landed in `CLAUDE.md` and existing skills; this plan codifies the remaining learnings as concrete edits to `CLAUDE.md`, slash commands, and skills so each recurring mistake becomes a guardrail before it can recur. MCP servers (GitHub, HubSpot) and speculative "on the horizon" ideas are out of scope for execution — the latter are captured as research notes for later.
+
+## Current State
+
+- `CLAUDE.md:30-38` — Database Migrations section already forbids `drizzle-kit push` and documents `yarn db:generate` → `yarn db:migrate`.
+- `CLAUDE.md:51-53` — E2E Testing section only covers `getByTestId` locator audits; no guidance on per-spec cleanup, dotenv ordering, or flake re-runs.
+- `CLAUDE.md:63-65` — Verification rule forbids running `make check/test/build/test_e2e` via Bash and mandates `@agent-codebase-verification`.
+- `.claude/skills/commit/SKILL.md:13-26` — Conventional Commits rule set (type as category, `ci/fix/feat/test/chore/refactor/docs`) and `Refs: #` footer for ticket links.
+- `.claude/commands/create_plan.md:12` — Already mandates parallel `Explore` subagents for non-trivial scope.
+- `.claude/commands/implement_plan.md:11-19` — No pre-flight risk scan; Claude currently jumps from plan read to code.
+- `.claude/settings.json:3-35` — Active hooks: Skill logging (PreToolUse), dangerous-git blocker (PreToolUse), biome-format (PostToolUse on Edit/Write/MultiEdit).
+- `.claude/scripts/block-dangerous-git.sh:12-22` — Blocks `git push`, `reset --hard`, `branch -D`, `checkout .`, `restore .`, `clean -f[d]`.
+- `.claude/skills/` — `commit`, `tdd`, `plan-to-ralph-spec`, `frontend-design`, `roadmap-review`, `rstest-best-practices`, `ticket-writer`, `improve-architecture`, `writing-clearly-and-concisely`, `zod`, plus symlinked shared skills. No `e2e-cleanup` skill exists.
+- `.github/workflows/` — `neon.yml`, `quality-control.yml`, `post-deploy.yml`, `release.yml`. Mix of `push`, `pull_request`, `pull_request.closed`, and `repository_dispatch` (per `quality-control.yml:48`) triggers.
+- `thoughts/research/` — Uses `YYYY-MM-DD-<slug>.md` naming (see `2026-04-21-autorubric-verbatim-quotes.md`).
+
+## Desired End State
+
+A future session that hits any of these patterns gets caught by a durable guardrail:
+
+- `CLAUDE.md` has dedicated `## GitHub Actions` and expanded `## E2E Testing` sections that pre-state the five recurring gotchas (default-branch trigger, per-spec cleanup, eventual consistency, dotenv load order, flake double-run).
+- `/implement_plan` produces a "Risks & Gotchas" block and waits for approval before touching code.
+- `/validate_plan` mandates re-running failed E2E specs once before treating them as regressions.
+- `.claude/skills/e2e-cleanup/SKILL.md` captures the per-spec phone/email tracking + eventual-consistency-aware cleanup pattern.
+- `thoughts/research/2026-04-21-claude-config-on-the-horizon.md` captures the three speculative workflow ideas (autonomous E2E repair, parallel plan-to-PR pipeline, self-improving config) with trigger conditions and rough designs.
+- Each change is verified by running the associated slash command or skill once against a tiny scenario and confirming the new behaviour appears.
+
+## Out of Scope
+
+- GitHub and HubSpot MCP server installation — both are token-heavy and unreliable per user feedback.
+- `PostToolUse` typecheck hook — conflicts with `CLAUDE.md:63-65` (use `@agent-codebase-verification`, not direct Bash).
+- A `/migrate` skill — `CLAUDE.md:30-38` already covers the rule; a skill would duplicate.
+- Immediate implementation of the three "on the horizon" ambitious workflows. They are captured as research notes only.
+- Any change to `.github/workflows/` YAML files themselves — the CI guidance is documentation only, since the user wants Claude to reason about `repository_dispatch` behaviour, not rewrite the workflows.
+
+## Approach
+
+Six small phases, each landing one or two files. Every phase is verified by invoking the relevant slash command or skill against a trivial scenario and confirming the new guardrail fires or the new guidance is visible. No `make` targets apply since nothing is compiled, but Phase 6 adds a single automated `make check`/`make test` pass as a sanity check that none of the doc edits broke an unrelated reference. Phases are independent and can be reordered; they are sequenced below roughly by bang-for-buck.
+
+## Phase 1: Expand CLAUDE.md with missing guardrails
+
+### Changes
+- `CLAUDE.md` — Add two new sections after the existing `## E2E Testing` section:
+  - `## GitHub Actions` — one paragraph stating `repository_dispatch`, `schedule`, and `workflow_dispatch` always run from the default branch (`main`); fixes on feature branches will not take effect until merged. Cite the existing `repository_dispatch` usage in `.github/workflows/quality-control.yml:48`.
+  - Expand `## E2E Testing` (append, keep the existing locator-audit paragraph as-is) with four bullets:
+    1. Per-spec cleanup — every spec that creates leads/HubSpot contacts tracks them by phone or email within that spec and cleans up in `afterAll`. Do not rely on broad filters — HubSpot search is eventually consistent.
+    2. dotenv load order — any script that reads env vars must load `dotenv` **before** importing anything that runs env validation (i.e. before importing `~/env`).
+    3. Flake double-run — if an E2E spec fails, re-run just that spec once before diagnosing. Only treat it as a regression if it fails twice in a row.
+    4. Test data isolation — never share a phone number or email across specs; collisions hit the unique constraint and mask real failures.
+
+### Success
+**Automated**
+- [x] N/A — documentation only.
+
+**Manual**
+- [x] New `## GitHub Actions` section renders in `CLAUDE.md` with the default-branch statement and cites `.github/workflows/quality-control.yml:48`.
+- [x] `## E2E Testing` section contains all four new bullets alongside the existing locator-audit paragraph.
+- [ ] Start a fresh Claude Code session and ask "what branch does a `repository_dispatch` workflow run from?" — the answer reflects the new guidance without further prompting.
+
+## Phase 2: Add pre-flight risk scan to /implement_plan
+
+### Changes
+- `.claude/commands/implement_plan.md` — Inserted `## Pre-flight: Risks & Gotchas` section between `## Getting Started` and `## Implementation Philosophy`. Generic 4-item checklist (schema changes, CI trigger scope, env vars, test data). Updated Getting Started bullet to "Run the Pre-flight risk scan (next section) before writing code."
+
+### Success
+**Automated**
+- [x] N/A — command definition only.
+
+**Manual**
+- [x] `## Pre-flight: Risks & Gotchas` section present in `.claude/commands/implement_plan.md` with 4 items.
+- [ ] Run `/implement_plan` with a plan containing a fake env var + migration and confirm Claude produces a Risks block before editing files.
+
+## Phase 3: Add flake double-run rule to /validate_plan
+
+### Changes
+- `.claude/commands/validate_plan.md` — In `### Step 2: Systematic Validation` → item **2. Run automated verification** (around `.claude/commands/validate_plan.md:77-79`), append a sub-bullet: "If an E2E spec fails, re-run just that spec once via `@agent-codebase-verification` before starting root-cause analysis. Only treat the failure as a real regression if it fails twice in a row. First-run flakes on parallel specs are a recurring pattern."
+
+### Success
+**Automated**
+- [x] N/A — command definition only.
+
+**Manual**
+- [x] New sub-bullet present under **2. Run automated verification** in `.claude/commands/validate_plan.md`.
+- [ ] In a fresh session, ask "during `/validate_plan`, what do I do if a single E2E spec fails?" — response names the re-run-once rule.
+
+## Phase 4: Create e2e-cleanup skill
+
+### Changes
+- `.claude/skills/tdd/e2e-cleanup.md` — New sub-file under the existing `tdd` skill (not a standalone skill). Covers: eventual-consistency failure mode, per-spec tracking set pattern, test data isolation, dotenv load order, and when not to use. Cites `CLAUDE.md` E2E Testing as the canonical rules reference.
+- `.claude/skills/tdd/SKILL.md` — Updated the E2E bullet in `## Rekurve-specific notes` to link to `e2e-cleanup.md`.
+
+### Success
+**Automated**
+- [x] N/A — skill definition only.
+
+**Manual**
+- [x] `.claude/skills/tdd/e2e-cleanup.md` exists with the per-spec tracking pattern and dotenv note.
+- [x] `.claude/skills/tdd/SKILL.md` links to `e2e-cleanup.md` from the E2E bullet.
+
+## Phase 5: Capture "on the horizon" ideas as research notes
+
+### Changes
+- `thoughts/research/2026-04-21-claude-config-on-the-horizon.md` — New file. One section per ambitious idea, each with:
+  - **Trigger** — the objective signal that would justify starting this build (e.g. "≥3 consecutive weeks with an E2E flake session").
+  - **Rough design** — 3–5 bullets sketching the architecture (orchestrator, subagents, data flow).
+  - **Prerequisites** — what needs to be true before starting (headless Claude in CI, git worktree tooling, transcript access, token budget).
+  - **Risks** — top 2 failure modes.
+  - Sections:
+    1. Autonomous E2E Repair Swarm — headless Claude triggered by failed CI, reproduces in parallel worktrees, classifies flake vs. regression, opens fix PR.
+    2. Parallel Plan-to-PR Pipeline — orchestrator reads ralph `spec.json`, fans phases out to per-worktree subagents, merge agent stitches atomic commits.
+    3. Self-Improving Config From Session Telemetry — nightly job parses `~/.claude/projects/*.jsonl`, clusters friction events, opens a PR with proposed edits to `CLAUDE.md` and `.claude/commands/`.
+  - Append a one-line reference in the file header: `Source: /insights run 2026-04-21 (171 sessions analysed).`
+
+### Success
+**Automated**
+- [x] N/A — research doc only.
+
+**Manual**
+- [x] File exists at `thoughts/research/2026-04-21-claude-config-on-the-horizon.md` with three distinct sections, each containing Trigger/Design/Prerequisites/Risks.
+- [x] File is listed under `thoughts/research/` (naming matches siblings like `2026-04-21-autorubric-verbatim-quotes.md`).
+
+## Phase 6: Final integration verification
+
+### Changes
+- No code changes. This phase is a cross-cutting sanity check that the doc edits in Phases 1–5 did not break anything the repo depends on.
+
+### Success
+**Automated**
+- [x] `make check` passes (via `@agent-codebase-verification`).
+- [x] `make test` passes (via `@agent-codebase-verification`).
+
+**Manual**
+- [ ] Start a fresh Claude Code session, check that `CLAUDE.md` reflects both new sections and that `tdd` skill links to `e2e-cleanup.md`.
+- [ ] Run `git status` — only `CLAUDE.md`, `.claude/commands/implement_plan.md`, `.claude/commands/validate_plan.md`, `.claude/skills/tdd/SKILL.md`, `.claude/skills/tdd/e2e-cleanup.md`, and `thoughts/research/2026-04-21-claude-config-on-the-horizon.md` are modified/created. No stray edits.
+
+## References
+
+- Source report: `/insights` run 2026-04-21 (580 sessions total, 171 analysed, 510h, 2026-04-02 → 2026-04-21). HTML at `file:///Users/sam/.claude/usage-data/report.html`.
+- Existing guardrails: `CLAUDE.md:30-38` (migrations), `CLAUDE.md:51-53` (E2E locators), `CLAUDE.md:63-65` (verification agent).
+- Existing commit rules: `.claude/skills/commit/SKILL.md:13-26`.
+- Existing planning workflow: `.claude/commands/create_plan.md:12`, `.claude/commands/implement_plan.md:11-19`, `.claude/commands/validate_plan.md:77-79`.
+- Active hooks: `.claude/settings.json:3-35`, `.claude/scripts/biome-format.sh`, `.claude/scripts/block-dangerous-git.sh`.
+- Trigger precedent for GitHub Actions guidance: `.github/workflows/quality-control.yml:48` (`repository_dispatch` usage).

--- a/thoughts/research/2026-04-21-autorubric-verbatim-quotes.md
+++ b/thoughts/research/2026-04-21-autorubric-verbatim-quotes.md
@@ -1,0 +1,91 @@
+# Autorubric — Verbatim Quotes for Design Citation
+
+**Date fetched:** 2026-04-21
+**Source:** [Autorubric: Unifying Rubric-based LLM Evaluation (arXiv:2603.00077v2)](https://arxiv.org/html/2603.00077v2)
+**Fetch agent:** `web-lookup` (sonnet + context7)
+**Purpose:** Load-bearing citations for `thoughts/designs/2026-04-21-sub-agent-eval-pipeline.md`. Preserved verbatim so future design edits don't need to re-fetch and risk the arXiv URL drifting.
+
+Cited in design doc at: §6.1 (criterion types), §6.4 (aggregation), §6.5 (weight asymmetry), §7.2 (no-ensemble decision), §11.4 (held-out split).
+
+---
+
+## 1. Criterion type ordering (§2) — cited at design §6.1
+
+> "Binary criteria (MET/UNMET) are the simplest and yield the highest inter-rater reliability. Ordinal criteria use ordered levels (Likert scales) to capture gradations; we encourage narrow scales (3–5 levels) with clear behavioral anchors, since LLM judges exhibit central tendency bias on broad scales (Liu et al., 2023). Nominal criteria offer unordered categories for classification-style evaluation."
+
+**Exclusion of continuous scales:**
+
+> "As a design choice, continuous-valued criteria are intentionally excluded due to poor LLM calibration on unbounded numeric scales (Liu et al., 2023; Zheng et al., 2023)."
+
+**Usage:** supports design §6.1's "Binary (MET/UNMET) — highest inter-rater reliability. Default" and "Unbounded numeric scales are excluded."
+
+---
+
+## 2. Equation 1 — weighted aggregation formula (§2) — cited at design §6.4
+
+Formula as printed in the paper:
+
+```
+score = max(0, min(1, Σᵢ₌₁ⁿ vᵢ · wᵢ / Σ{wᵢ>0} wᵢ))
+```
+
+Surrounding text:
+
+> "where wᵢ denotes weight and vᵢ denotes the verdict value (1 for MET, 0 for UNMET, or the option's explicit value for multi-choice criteria). Negative weights are excluded from the denominator so a perfect response scores exactly 1; clamping prevents penalties from pushing scores below zero."
+
+**Usage:** the design renders this formula at line 177 — matches the paper. The surrounding text clarifies why the denominator uses only positive weights (so a clean run scores exactly 1) and why clipping to [0, 1] is applied. Worth inlining in §6.4 alongside the formula.
+
+---
+
+## 3. Negative-weight anti-patterns rationale (§2) — cited at design §6.5
+
+> "Criteria carry configurable positive or negative weights. Negative criteria serve as penalties for anti-patterns, counteracting the leniency bias documented in LLM judges (Sharma et al., 2025)."
+
+**Note:** Autorubric itself does not provide numeric evidence for leniency bias — it cites Sharma et al. 2025. Design §6.5's numeric claim ("Claude-v1 self-enhancement bias +25pp") comes from MT-Bench, not Autorubric. The citation chain should be:
+- Mechanism (negative weights to counter leniency): **Autorubric §2**
+- Quantification of leniency (+25pp): **MT-Bench arXiv:2306.05685 §3.3** (distinct source)
+
+**Follow-up:** if the design wants Autorubric-native quantified evidence of leniency bias, a targeted `web-lookup` for Sharma et al. 2025 is the next step. Not currently critical.
+
+---
+
+## 4. Table 4 — ensembling ablation — cited at design §7.2
+
+**Table 4 caption:**
+
+> "Mitigation ablation on CHARM-100 (80 test items, 6 criteria). Each row toggles one factor from the Default configuration. Acc = exact criterion accuracy; κ = mean Cohen's κ (quadratic-weighted for ordinal); ρ = Spearman on scores; RMSE = score root mean squared error."
+
+**Strong judge (Gemini-3-Flash):**
+- Default: κ = 0.679
+- +Ensemble (k=3, majority): κ = 0.673
+- → Negligible, slightly negative lift on strong judges
+
+**Weak judge (LLaMA-3.1-8B):**
+- Default: κ = −0.001 (accuracy 41.2%)
+- +Ensemble (k=3, majority): κ = 0.018
+- +Ensemble (k=5, majority): κ = 0.044 (accuracy 67.5%)
+- → +26pp absolute accuracy improvement for weak judges
+
+**Usage:**
+- Design §7.2 "Autorubric Table 4: ensembling strong judges yields negligible lift. No ensemble." → **confirmed verbatim.**
+- Design §7.2 "Downgrade path if step-3 cost becomes a problem: Sonnet + k=3 same-model ensemble — the regime where Autorubric shows ensembling actually pays." → **also confirmed** — the LLaMA-3.1-8B row is the "weaker judge where ensembling helps" case, directly supporting the downgrade-path rationale.
+
+---
+
+## 5. Verdict-balanced few-shot exemplars — cited at design §7.2
+
+> "Few-shot calibration includes example submissions with correct verdicts drawn from a training split, with verdict balancing to prevent the judge from inferring a base-rate prior (Hong et al., 2026)."
+
+**Calibration gains (Table 2, RiceChem dataset):**
+
+> "0-shot 77.2% → 3-shot 79.0% → 5-shot 80.0%"
+
+**Usage:** supports design §7.2's "3-shot, verdict-balanced." The 3-shot choice is on the plateau (+1.8pp over 0-shot; 5-shot adds only another +1.0pp). Worth citing in §7.2 to justify not going to 5-shot.
+
+---
+
+## Residual gaps not covered by this lookup
+
+- **Sharma et al. 2025** on LLM leniency bias — cited by Autorubric §2 but not fetched here. Would strengthen design §6.5 if negative-weight quantification becomes contested.
+- **Full §3 "held-out split" rationale** — design §11.4 references Autorubric §3 for "single-set optimisation overfits to judge idiosyncrasies." This lookup did not extract §3 directly. If held-out-split justification is challenged during implementation, a follow-up lookup against §3 specifically.
+- **Liu et al. 2023** on central tendency bias — cited inline in §2 but not fetched. Only matters if the 3–5 Likert scale choice is challenged.

--- a/thoughts/research/2026-04-21-claude-config-on-the-horizon.md
+++ b/thoughts/research/2026-04-21-claude-config-on-the-horizon.md
@@ -1,0 +1,71 @@
+# Claude Config: On the Horizon
+
+Source: /insights run 2026-04-21 (171 sessions analysed).
+
+Three ambitious workflow ideas surfaced from session analysis. None is ready to build now — each has a trigger condition that must be met first. Captured here to avoid losing the design thinking.
+
+---
+
+## 1. Autonomous E2E Repair Swarm
+
+**Trigger:** ≥3 consecutive weeks containing at least one E2E flake session.
+
+**Rough design:**
+- Headless Claude triggered by a failed CI run via `workflow_dispatch` or `repository_dispatch`.
+- Spins up parallel git worktrees — one per failing spec.
+- Each worktree agent reproduces the failure locally, then classifies it: flake (non-deterministic) vs. regression (consistent).
+- Flake: patches cleanup or timing; opens a fix PR.
+- Regression: opens a bug report issue with reproduction steps.
+- Merge agent reviews worktree PRs, squashes atomic commits, runs final CI gate.
+
+**Prerequisites:**
+- Headless Claude available in CI with sufficient token budget.
+- `EnterWorktree` / `ExitWorktree` tooling stable and well-tested.
+- Transcript access so the agent can read prior failure context.
+
+**Risks:**
+- Flake classification is hard; mis-classifying a regression as a flake delays a real fix.
+- Parallel worktrees multiply API cost; a flaky suite could trigger runaway spend.
+
+---
+
+## 2. Parallel Plan-to-PR Pipeline
+
+**Trigger:** Plans with ≥5 independent phases that currently execute serially, extending wall-clock time beyond 2 hours.
+
+**Rough design:**
+- Orchestrator reads a ralph `spec.json`, identifies phases with no inter-dependencies.
+- Fans independent phases out to per-worktree subagents running in parallel.
+- Each subagent commits its phase to its worktree branch.
+- Merge agent cherry-picks or rebases phase branches into a single PR, resolving conflicts, and runs the full CI gate.
+
+**Prerequisites:**
+- ralph `spec.json` format stable and widely adopted across plans.
+- Worktree tooling supports concurrent writes without lock contention.
+- Orchestrator can reliably detect phase dependencies from the plan graph.
+
+**Risks:**
+- Merge conflicts between phases are hard to resolve automatically without losing intent.
+- Subagent cost multiplies with parallelism; a mis-scoped plan could be expensive.
+
+---
+
+## 3. Self-Improving Config From Session Telemetry
+
+**Trigger:** A recurring friction pattern appears in ≥5 distinct sessions within a 2-week window without a corresponding guardrail in `CLAUDE.md` or `.claude/commands/`.
+
+**Rough design:**
+- Nightly job parses `~/.claude/projects/*.jsonl` transcripts.
+- Clusters tool-call sequences around known friction signals (retries, user corrections, mismatch blocks).
+- Groups clusters by pattern type (wrong migration command, wrong branch assumption, missing cleanup, etc.).
+- For each cluster above the threshold, drafts a one-paragraph addition to `CLAUDE.md` or the relevant command file.
+- Opens a PR with the proposed edits for human review before merging.
+
+**Prerequisites:**
+- Transcript JSONL format is stable and parseable (field names, event types).
+- Clustering logic can distinguish genuine friction from intentional deviation.
+- PR workflow for config changes is established (review, merge, rollout).
+
+**Risks:**
+- Noisy transcripts produce low-quality suggestions; human review is essential.
+- Self-referential edits (config changing the config process) risk runaway drift without a stability anchor.

--- a/thoughts/research/2026-04-21-session-corrections-index.md
+++ b/thoughts/research/2026-04-21-session-corrections-index.md
@@ -1,0 +1,717 @@
+# Session Corrections Index
+
+Source: `/insights` run 2026-04-21 (100 sessions faceted). Frictions already addressed by
+`thoughts/plans/2026-04-21-claude-config-insights-improvements.md` are excluded from the triage ranking.
+Purpose: Meta-Harness eval substrate — each residual friction session is a candidate eval task.
+
+---
+
+## Already Covered by Implementation Plan
+
+**6 sessions** match the five friction patterns scheduled in `2026-04-21-claude-config-insights-improvements.md`:
+
+- **drizzle-kit push / DB migration drift** (1 sessions) → Phases 1–4 of the plan
+- **`repository_dispatch` default-branch confusion** (1 sessions) → Phases 1–4 of the plan
+- **HubSpot eventual-consistency cleanup** (1 sessions) → Phases 1–4 of the plan
+- **dotenv load order** (0 sessions) → Phases 1–4 of the plan
+- **E2E flake double-run** (3 sessions) → Phases 1–4 of the plan
+
+---
+
+## Residual Friction Summary
+
+**39 sessions** with friction not covered by the plan.
+
+| Friction type | Sessions |
+|---|---|
+| `buggy_code` | 17 |
+| `user_rejected_action` | 13 |
+| `wrong_approach` | 5 |
+| `misunderstood_request` | 3 |
+| `excessive_changes` | 3 |
+| `user_interrupted` | 2 |
+| `tool_unavailable` | 2 |
+| `missing_context` | 1 |
+| `environment_issue` | 1 |
+| `api_error` | 1 |
+| `tool_error` | 1 |
+| `tool_permission_blocked` | 1 |
+| `external_blocker` | 1 |
+
+### Recurring themes (≥2 sessions each)
+
+- **Unclassified** (27 sessions) — 
+- **CLAUDE.md rule violation** (3 sessions) — Claude knows the rule but bypasses it
+- **Wrong first action / pace** (3 sessions) — Claude picks wrong first tool call or starts without enough context
+- **Agent sub-task interruption** (2 sessions) — User interrupted mid-implementation and redirected
+- **Commit/PR mechanics** (2 sessions) — Wrong files staged, wrong commit message, bad branch
+
+---
+
+## Per-Session Detail (Top 20, Worst-First)
+
+Each section has: goal, friction detail, severity score, and inline corrective turns (±1 context).
+External errors (API 529, 1M context limit) noted but ranked lower — not harness failures.
+
+### 1. `c99080bb` — score 12
+
+**Goal:** Add conditional Zod validation to BigWCampaignForm that raises a startDate error when duplicating a campaign with today's date, then commit and describe the PR
+
+**Outcome:** `mostly_achieved` | **Helpfulness:** `very_helpful` | **Interruptions:** 2 | **Tool errors:** 5
+
+**Friction:** User interrupted the initial commit attempt (ultrareview stopped) and pre-commit hook rejected the branch name requiring a rename
+
+**Friction types:** {"wrong_approach": 1, "user_rejected_action": 1} | **Themes:** Commit/PR mechanics
+
+**Raw JSONL:** `~/.claude/projects/-Users-sam-workspace-rekurve-www/c99080bb-4593-4191-a13c-61deb5d6dd1c.jsonl`
+
+_No corrective turns extracted (session file may be absent)._
+
+---
+
+### 2. `a20ddbb8` — score 12
+
+**Goal:** Validate that the pipeline board view implementation plan was correctly executed
+
+**Outcome:** `not_achieved` | **Helpfulness:** `slightly_helpful` | **Interruptions:** 2 | **Tool errors:** 1
+
+**Friction:** User interrupted Claude's validation process twice, suggesting the approach or pace was not acceptable
+
+**Friction types:** {"user_rejected_action": 2} | **Themes:** Wrong first action / pace
+
+**Raw JSONL:** `~/.claude/projects/-Users-sam-workspace-rekurve-www/a20ddbb8-3f82-4286-9c9a-b0fac19a1577.jsonl`
+
+**Corrective turns:**
+
+  **USER**: <command-message>validate_plan</command-message> <command-name>/validate_plan</command-name> <command-args>2026-04-09-100-pipeline-board-view.md</command-args>
+  **USER** ← CORRECTION: # Validate Plan  You are tasked with validating that an implementation plan was correctly executed, verifying all success criteria and identifying any deviations or issues.  ## Initial Setup  When inv
+  **ASSISTANT**: 
+  **ASSISTANT**: [tool:Read {"file_path": "/Users/sam/workspace/rekurve/www/thoughts/pla]
+
+  **ASSISTANT**: [tool:Read {"file_path": "/Users/sam/workspace/rekurve/www/thoughts/pla]
+  **USER** ← CORRECTION: [tool_result_ERROR:File content (11677 tokens) exceeds maximum allowed tokens (10000). Use offset a]
+  **ASSISTANT**: [tool:Bash {"command": "wc -l /Users/sam/workspace/rekurve/www/thoughts]
+  **USER**: [tool_result:     966 /Users/sam/workspace/rekurve/www/thoughts/plans/2026-04-09-100-pipeline]
+
+  **ASSISTANT**: [tool:Bash {"command": "cat /private/tmp/claude-501/-Users-sam-workspac]
+  **USER** ← CORRECTION: [tool_result:yarn check Checked 213 files in 49ms. No fixes applied. [rerun: b122]]
+  **ASSISTANT**: [tool:Bash {"command": "cat /private/tmp/claude-501/-Users-sam-workspac]
+  **USER**: [tool_result:yarn test (node:86524) [DEP0040] DeprecationWarning: The `punycode` module is de]
+
+  **USER**: [tool_result:{"body":"## Parent Epic\nPart of #86 (Epic 2: Lead Management + AI Qualification]
+  **USER** ← CORRECTION: [Request interrupted by user]
+  **USER**: <task-notification> <task-id>brtpq3rju</task-id> <tool-use-id>toolu_01MFoxAkoE5FX2cQz6CxqShZ</tool-use-id> <output-file>/private/tmp/claude-501/-Users-sam-workspace-rekurve-www/8cbc2961-4477-4246-b451
+  **USER**: <task-notification> <task-id>b9mhlpaq2</task-id> <tool-use-id>toolu_01TjKXZFjxueqY1UmEstDdub</tool-use-id> <output-file>/private/tmp/claude-501/-Users-sam-workspace-rekurve-www/8cbc2961-4477-4246-b451
+
+  **USER**: <task-notification> <task-id>b9mhlpaq2</task-id> <tool-use-id>toolu_01TjKXZFjxueqY1UmEstDdub</tool-use-id> <output-file>/private/tmp/claude-501/-Users-sam-workspace-rekurve-www/8cbc2961-4477-4246-b451
+  **USER** ← CORRECTION: [Request interrupted by user]
+
+---
+
+### 3. `5064c307` — score 12
+
+**Goal:** Validate, commit, and ship the ENG-132 nurture scheduler feature as a PR, then fix the Vercel CI failure blocking the preview deployment
+
+**Outcome:** `fully_achieved` | **Helpfulness:** `very_helpful` | **Interruptions:** 2 | **Tool errors:** 6
+
+**Friction:** Claude initially included ENG-132 in commit titles and bundled an unintended plan doc file in the amend, requiring user correction
+
+**Friction types:** {"misunderstood_request": 1, "excessive_changes": 1} | **Themes:** Commit/PR mechanics
+
+**Raw JSONL:** `~/.claude/projects/-Users-sam-workspace-rekurve-www/5064c307-f3f6-455f-a38c-6d1037755dca.jsonl`
+
+**Corrective turns:**
+
+  **USER**: <command-message>validate_plan</command-message> <command-name>/validate_plan</command-name> <command-args>2026-04-20-ENG-132-nurture-scheduler.md</command-args>
+  **USER** ← CORRECTION: # Validate Plan  You are tasked with validating that an implementation plan was correctly executed, verifying all success criteria and identifying any deviations or issues.  ## Initial Setup  When inv
+  **ASSISTANT**: 
+  **ASSISTANT**: I'll read the implementation plan first, then run parallel validation checks.
+
+  **USER**: <command-message>commit</command-message> <command-name>/commit</command-name>
+  **USER** ← CORRECTION: Base directory for this skill: /Users/sam/workspace/rekurve/www/.claude/skills/commit  # Commit Changes  Review the current working tree and create well-structured git commits.  ## Message format  See
+  **ASSISTANT**: 
+  **ASSISTANT**: I'll review the working tree and prepare commits.
+
+  **ASSISTANT**: [tool:Bash {"command": "git add \\\n  src/server/api/schemas/nurture.ts]
+  **USER** ← CORRECTION: [tool_result:(Bash completed with no output)]
+  **ASSISTANT**: [tool:Bash {"command": "git commit -m \"$(cat <<'EOF'\nfeat(nurture): a]
+  **USER**: [tool_result:yarn check Checked 267 files in 58ms. No fixes applied. [feat/132-nurture-schedu]
+
+  **ASSISTANT**: [tool:Bash {"command": "git commit -m \"$(cat <<'EOF'\nfeat(nurture): a]
+  **USER** ← CORRECTION: [tool_result:yarn check Checked 267 files in 58ms. No fixes applied. [feat/132-nurture-schedu]
+  **ASSISTANT**: [tool:Bash {"command": "git log --oneline -n 3", "description": "Confir]
+  **USER**: [tool_result:f599606 feat(nurture): add scheduler, router procedures, and auto-start wiring c]
+
+  **ASSISTANT**: [tool:Bash {"command": "git add drizzle/meta/_journal.json src/server/a]
+  **USER** ← CORRECTION: [tool_result:yarn check Checked 267 files in 60ms. No fixes applied. [feat/132-nurture-schedu]
+  **ASSISTANT**: 
+  **ASSISTANT**: Done — now 19 files, `e14af80`. However, the amend also picked up `thoughts/plans/2026-04-20-ENG-132-nurture-scheduler.md`, which must have been staged before this session. That file wasn't intentiona
+
+---
+
+### 4. `686cc7fc` — score 11
+
+**Goal:** Create an implementation plan for GitHub issue #132
+
+**Outcome:** `not_achieved` | **Helpfulness:** `slightly_helpful` | **Interruptions:** 2 | **Tool errors:** 0
+
+**Friction:** User interrupted Claude's execution twice and eventually exited without the plan being completed.
+
+**Friction types:** {"user_rejected_action": 2} | **Themes:** Unclassified
+
+**Raw JSONL:** `~/.claude/projects/-Users-sam-workspace-rekurve-www/686cc7fc-1360-417a-83d9-7db621f8a3b1.jsonl`
+
+**Corrective turns:**
+
+  **USER**: <command-message>create_plan</command-message> <command-name>/create_plan</command-name> <command-args>github issue #132</command-args>
+  **USER** ← CORRECTION: # Implementation Plan  ultrathink. Produce a complete, actionable plan at `thoughts/plans/YYYY-MM-DD-ENG-XXXX-description.md` before writing code. If invoked without a ticket/task, ask once, then wait
+  **ASSISTANT**: 
+  **ASSISTANT**: [tool:Bash {"command": "gh issue view 132 --json title,body,labels,stat]
+
+  **USER**: [tool_result:2025-11-25-posthog-analytics-integration.md 2025-11-27-posthog-dashboards-funnel]
+  **USER** ← CORRECTION: [Request interrupted by user]
+  **USER**: ultrathink
+  **USER**: <system-reminder>Respond with just the action or changes and without a thinking block, unless this is a redesign or requires fresh reasoning.</system-reminder>
+
+  **USER**: [tool_result:2026-04-04-plan-to-spec-json.md 2026-04-05-ENG-98-quick-capture-form.md 2026-04-]
+  **USER** ← CORRECTION: [Request interrupted by user]
+  **USER**: <local-command-caveat>Caveat: The messages below were generated by the user while running local commands. DO NOT respond to these messages or otherwise consider them in your response unless the user e
+  **USER**: <command-name>/effort</command-name>             <command-message>effort</command-message>             <command-args></command-args>
+
+  **USER**: <command-message>create_plan</command-message> <command-name>/create_plan</command-name> <command-args>github issue #132</command-args>
+  **USER** ← CORRECTION: # Implementation Plan  ultrathink. Produce a complete, actionable plan at `thoughts/plans/YYYY-MM-DD-ENG-XXXX-description.md` before writing code. If invoked without a ticket/task, ask once, then wait
+  **ASSISTANT**: 
+  **ASSISTANT**: There's already a plan at `thoughts/plans/2026-04-20-ENG-132-nurture-scheduler.md` (shows as untracked in git status). Do you want me to:  1. Iterate/update that existing plan, or 2. Overwrite it with
+
+---
+
+### 5. `e5eb0745` — score 11
+
+**Goal:** Implement an approved technical plan for a Pipeline Board View feature across backend filters, UI components, and E2E tests
+
+**Outcome:** `mostly_achieved` | **Helpfulness:** `very_helpful` | **Interruptions:** 1 | **Tool errors:** 5
+
+**Friction:** Mobile layout bug caused horizontal overflow requiring layout fix, and test cleanup patterns conflicted between spec files causing user to interrupt during debugging
+
+**Friction types:** {"buggy_code": 2, "user_rejected_action": 1} | **Themes:** Unclassified
+
+**Raw JSONL:** `~/.claude/projects/-Users-sam-workspace-rekurve-www/e5eb0745-6bd2-4af1-8cb9-f23b2d8fee41.jsonl`
+
+**Corrective turns:**
+
+  **USER**: <command-message>implement_plan</command-message> <command-name>/implement_plan</command-name> <command-args>2026-04-09-100-pipeline-board-view.md</command-args>
+  **USER** ← CORRECTION: # Implement Plan  You are tasked with implementing an approved technical plan from `thoughts/plans/`. These plans contain phases with specific changes and success criteria.  ## Getting Started  When g
+  **ASSISTANT**: 
+  **ASSISTANT**: [tool:Read {"file_path": "/Users/sam/workspace/rekurve/www/thoughts/pla]
+
+  **ASSISTANT**: [tool:Read {"file_path": "/Users/sam/workspace/rekurve/www/thoughts/pla]
+  **USER** ← CORRECTION: [tool_result_ERROR:File content (11651 tokens) exceeds maximum allowed tokens (10000). Use offset a]
+  **ASSISTANT**: [tool:Bash {"command": "wc -l /Users/sam/workspace/rekurve/www/thoughts]
+  **USER**: [tool_result:     966 /Users/sam/workspace/rekurve/www/thoughts/plans/2026-04-09-100-pipeline]
+
+  **ASSISTANT**: [tool:Grep {"pattern": "prefetch\\(trpc\\.", "path": "/Users/sam/worksp]
+  **USER** ← CORRECTION: [tool_result:No matches found]
+  **ASSISTANT**: [tool:Grep {"pattern": "HydrateClient", "path": "/Users/sam/workspace/r]
+  **USER**: [tool_result:Found 1 file src/trpc/server.tsx]
+
+  **ASSISTANT**: [tool:Grep {"pattern": "queryOptions\\(", "path": "/Users/sam/workspace]
+  **USER** ← CORRECTION: [tool_result:No matches found]
+  **ASSISTANT**: [tool:Grep {"pattern": "useQuery", "path": "/Users/sam/workspace/rekurv]
+  **USER**: [tool_result:No matches found]
+
+  **ASSISTANT**: [tool:Grep {"pattern": "useQuery", "path": "/Users/sam/workspace/rekurv]
+  **USER** ← CORRECTION: [tool_result:No matches found]
+  **ASSISTANT**: 
+  **ASSISTANT**: [tool:Bash {"command": "cat /Users/sam/workspace/rekurve/www/package.js]
+
+---
+
+### 6. `03e27eaf` — score 10
+
+**Goal:** Create an implementation plan for GitHub issue #132
+
+**Outcome:** `not_achieved` | **Helpfulness:** `unhelpful` | **Interruptions:** 1 | **Tool errors:** 1
+
+**Friction:** User interrupted Claude's initial tool use and then spent the session adjusting effort levels before exiting without the plan being produced.
+
+**Friction types:** {"user_rejected_action": 1} | **Themes:** Unclassified
+
+**Raw JSONL:** `~/.claude/projects/-Users-sam-workspace-rekurve-www/03e27eaf-88bc-40bc-ad46-c961264f9fa8.jsonl`
+
+**Corrective turns:**
+
+  **USER**: <command-message>create_plan</command-message> <command-name>/create_plan</command-name> <command-args>github issue #132</command-args>
+  **USER** ← CORRECTION: # Implementation Plan  Produce a complete, actionable plan at `thoughts/plans/YYYY-MM-DD-ENG-XXXX-description.md` before writing code. If invoked without a ticket/task, ask once, then wait.  ## Workfl
+  **ASSISTANT**: 
+  **ASSISTANT**: [tool:Bash {"command": "gh issue view 132 --repo samjmarshall/rekurve",]
+
+  **ASSISTANT**: [tool:Bash {"command": "gh issue view 132 --repo samjmarshall/rekurve",]
+  **USER** ← CORRECTION: [tool_result_ERROR:The user doesn't want to proceed with this tool use. The tool use was rejected (]
+  **USER**: [Request interrupted by user for tool use]
+  **USER**: <local-command-caveat>Caveat: The messages below were generated by the user while running local commands. DO NOT respond to these messages or otherwise consider them in your response unless the user e
+
+  **USER**: [tool_result_ERROR:The user doesn't want to proceed with this tool use. The tool use was rejected (]
+  **USER** ← CORRECTION: [Request interrupted by user for tool use]
+  **USER**: <local-command-caveat>Caveat: The messages below were generated by the user while running local commands. DO NOT respond to these messages or otherwise consider them in your response unless the user e
+  **USER**: <command-name>/effort</command-name>             <command-message>effort</command-message>             <command-args>max</command-args>
+
+---
+
+### 7. `6d855603` — score 10
+
+**Goal:** Run a design review for GitHub issue #128
+
+**Outcome:** `not_achieved` | **Helpfulness:** `unhelpful` | **Interruptions:** 1 | **Tool errors:** 1
+
+**Friction:** User interrupted the Agent tool call before the design review could proceed.
+
+**Friction types:** {"user_rejected_action": 1} | **Themes:** Unclassified
+
+**Raw JSONL:** `~/.claude/projects/-Users-sam-workspace-rekurve-www/6d855603-b5d2-4e95-b2e9-f0b32ab7c74a.jsonl`
+
+**Corrective turns:**
+
+  **USER**: <command-message>design_review</command-message> <command-name>/design_review</command-name> <command-args>for github issue #128</command-args>
+  **USER** ← CORRECTION: You are an elite design review specialist with deep expertise in user experience, visual design, accessibility, and front-end implementation. You conduct world-class design reviews following the rigor
+  **ASSISTANT**: 
+  **ASSISTANT**: [tool:Agent {"description": "Design review for issue #128", "subagent_ty]
+
+  **ASSISTANT**: [tool:Agent {"description": "Design review for issue #128", "subagent_ty]
+  **USER** ← CORRECTION: [tool_result_ERROR:The user doesn't want to proceed with this tool use. The tool use was rejected (]
+  **USER**: [Request interrupted by user for tool use]
+
+  **USER**: [tool_result_ERROR:The user doesn't want to proceed with this tool use. The tool use was rejected (]
+  **USER** ← CORRECTION: [Request interrupted by user for tool use]
+
+---
+
+### 8. `6178a698` — score 10
+
+**Goal:** Conduct a design review for GitHub issue #128 on the action queue view feature
+
+**Outcome:** `not_achieved` | **Helpfulness:** `unhelpful` | **Interruptions:** 1 | **Tool errors:** 1
+
+**Friction:** User interrupted Claude's tool use before the design review could be completed
+
+**Friction types:** {"user_rejected_action": 1} | **Themes:** Unclassified
+
+**Raw JSONL:** `~/.claude/projects/-Users-sam-workspace-rekurve-www/6178a698-32d6-4914-b6f5-d5854d5af539.jsonl`
+
+**Corrective turns:**
+
+  **USER**: <command-message>design_review</command-message> <command-name>/design_review</command-name> <command-args>for github issue #128</command-args>
+  **USER** ← CORRECTION: You are an elite design review specialist with deep expertise in user experience, visual design, accessibility, and front-end implementation. You conduct world-class design reviews following the rigor
+  **ASSISTANT**: 
+  **ASSISTANT**: [tool:Agent {"description": "Design review action queue #128", "subagent]
+
+  **ASSISTANT**: [tool:Agent {"description": "Design review action queue #128", "subagent]
+  **USER** ← CORRECTION: [tool_result_ERROR:The user doesn't want to proceed with this tool use. The tool use was rejected (]
+  **USER**: [Request interrupted by user for tool use]
+
+  **USER**: [tool_result_ERROR:The user doesn't want to proceed with this tool use. The tool use was rejected (]
+  **USER** ← CORRECTION: [Request interrupted by user for tool use]
+
+---
+
+### 9. `1536e6cf` — score 10
+
+**Goal:** Implement approved technical plan for ENG-128 ultrareview fixes, verify changes, commit, open PR, and plan design review followups
+
+**Outcome:** `fully_achieved` | **Helpfulness:** `very_helpful` | **Interruptions:** 1 | **Tool errors:** 7
+
+**Friction:** Claude ran make test_e2e directly instead of delegating to codebase-verification sub-agent per CLAUDE.md, requiring user interruption
+
+**Friction types:** {"wrong_approach": 1} | **Themes:** CLAUDE.md rule violation
+
+**Raw JSONL:** `~/.claude/projects/-Users-sam-workspace-rekurve-www/1536e6cf-e7a6-47e1-9819-bb20ca15ba99.jsonl`
+
+**Corrective turns:**
+
+  **USER**: <command-message>implement_plan</command-message> <command-name>/implement_plan</command-name> <command-args>2026-04-19-ENG-128-ultrareview-fixes.md</command-args>
+  **USER** ← CORRECTION: # Implement Plan  You are tasked with implementing an approved technical plan from `thoughts/plans/`. These plans contain phases with specific changes and success criteria.  ## Getting Started  When g
+  **ASSISTANT**: 
+  **ASSISTANT**: [tool:Read {"file_path": "/Users/sam/workspace/rekurve/www/thoughts/pla]
+
+  **ASSISTANT**: [tool:Read {"file_path": "/Users/sam/workspace/rekurve/www/src/app/(app]
+  **USER** ← CORRECTION: [tool_result_ERROR:File does not exist. Note: your current working directory is /Users/sam/workspac]
+  **ASSISTANT**: [tool:Bash {"command": "ls /Users/sam/workspace/rekurve/www/src/app/\\(]
+  **USER**: [tool_result:__tests__ edit-validation.ts snooze.ts]
+
+  **ASSISTANT**: [tool:Bash {"command": "yarn check 2>&1 | tail -15", "description": "Ru]
+  **USER** ← CORRECTION: [tool_result:Checked 257 files in 39ms. No fixes applied.]
+  **ASSISTANT**: [tool:Bash {"command": "yarn test 2>&1 | tail -20", "description": "Run]
+  **USER**: [tool_result:  "durationMs": {     "total": 9456,     "build": 65,     "tests": 9391   },   "]
+
+  **ASSISTANT**: [tool:Grep {"pattern": "Sent via", "path": "/Users/sam/workspace/rekurv]
+  **USER** ← CORRECTION: [tool_result:70:        // Revert to "Sent via …" when dispatch lands (#129/#130) 123:       ]
+  **ASSISTANT**: Good, only in comments. Now update e2e action-queue.spec.ts.
+  **ASSISTANT**: [tool:Edit {"replace_all": false, "file_path": "/Users/sam/workspace/re]
+
+  **ASSISTANT**: [tool:Bash {"command": "yarn check 2>&1 | tail -10", "description": "Li]
+  **USER** ← CORRECTION: [tool_result:Checked 257 files in 38ms. No fixes applied.]
+  **ASSISTANT**: [tool:TaskUpdate {"taskId": "3", "status": "completed"}]
+  **USER**: [tool_result:Updated task #3 status]
+
+---
+
+### 10. `e1335f0b` — score 9
+
+**Goal:** Run a design review for GitHub issue #128 on the local dev server
+
+**Outcome:** `unclear_from_transcript` | **Helpfulness:** `moderately_helpful` | **Interruptions:** 2 | **Tool errors:** 2
+
+**Friction:** Claude launched the design review agent without knowing the custom Portless dev server URL, requiring the user to interrupt and provide that context.
+
+**Friction types:** {"missing_context": 1} | **Themes:** Design review missing context
+
+**Raw JSONL:** `~/.claude/projects/-Users-sam-workspace-rekurve-www/e1335f0b-3667-4321-8840-4fc5af0f75ba.jsonl`
+
+**Corrective turns:**
+
+  **USER**: <command-message>design_review</command-message> <command-name>/design_review</command-name> <command-args>for github issue #128</command-args>
+  **USER** ← CORRECTION: You are an elite design review specialist with deep expertise in user experience, visual design, accessibility, and front-end implementation. You conduct world-class design reviews following the rigor
+  **USER**: <command-message>design_review</command-message> <command-name>/design_review</command-name> <command-args>for github issue #128</command-args>
+  **USER**: You are an elite design review specialist with deep expertise in user experience, visual design, accessibility, and front-end implementation. You conduct world-class design reviews following the rigor
+
+  **USER**: <command-message>design_review</command-message> <command-name>/design_review</command-name> <command-args>for github issue #128</command-args>
+  **USER** ← CORRECTION: You are an elite design review specialist with deep expertise in user experience, visual design, accessibility, and front-end implementation. You conduct world-class design reviews following the rigor
+  **ASSISTANT**: 
+  **ASSISTANT**: [tool:Agent {"description": "Design review of action queue PR", "subagen]
+
+  **ASSISTANT**: [tool:Agent {"description": "Design review of action queue PR", "subagen]
+  **USER** ← CORRECTION: [tool_result_ERROR:The user doesn't want to proceed with this tool use. The tool use was rejected (]
+  **USER**: [Request interrupted by user for tool use]
+  **USER**: I use Vercel's Portless to run the app in dev mode to avoid port conflicts. Add a very brief note/instruction on where the Dev server is served (https://www.localhost - `main`, https://feat/123-hello.
+
+  **USER**: [tool_result_ERROR:The user doesn't want to proceed with this tool use. The tool use was rejected (]
+  **USER** ← CORRECTION: [Request interrupted by user for tool use]
+  **USER**: I use Vercel's Portless to run the app in dev mode to avoid port conflicts. Add a very brief note/instruction on where the Dev server is served (https://www.localhost - `main`, https://feat/123-hello.
+  **ASSISTANT**: 
+
+  **ASSISTANT**: [tool:Agent {"description": "Design review of action queue PR", "subagen]
+  **USER** ← CORRECTION: [tool_result_ERROR:The user doesn't want to proceed with this tool use. The tool use was rejected (]
+  **USER**: [Request interrupted by user for tool use]
+
+---
+
+### 11. `79b39a84` — score 9
+
+**Goal:** Understand the purpose, use-cases, and value proposition of Stanford's Meta-Harness and Ruflo tools
+
+**Outcome:** `not_achieved` | **Helpfulness:** `unhelpful` | **Interruptions:** 1 | **Tool errors:** 0
+
+**Friction:** User interrupted Claude's initial response before any research was performed, then set effort to max without re-asking the question
+
+**Friction types:** {"user_rejected_action": 1} | **Themes:** Wrong first action / pace
+
+**Raw JSONL:** `~/.claude/projects/-Users-sam-workspace-rekurve-www/79b39a84-d084-48e1-886d-5cec6da3697c.jsonl`
+
+**Corrective turns:**
+
+  **ASSISTANT**: I'll research both tools in parallel to give you a clear comparison.
+  **USER** ← CORRECTION: [Request interrupted by user]
+  **USER**: <local-command-caveat>Caveat: The messages below were generated by the user while running local commands. DO NOT respond to these messages or otherwise consider them in your response unless the user e
+  **USER**: <command-name>/effort</command-name>             <command-message>effort</command-message>             <command-args>max</command-args>
+
+---
+
+### 12. `a6a05740` — score 8
+
+**Goal:** Validate that the ENG-98 quick capture form implementation plan was correctly executed
+
+**Outcome:** `not_achieved` | **Helpfulness:** `unhelpful` | **Interruptions:** 0 | **Tool errors:** 1
+
+**Friction:** Session terminated by API 529 overloaded error before validation could complete
+
+**Friction types:** {"api_error": 1} | **Themes:** Unclassified
+
+**Raw JSONL:** `~/.claude/projects/-Users-sam-workspace-rekurve-www/a6a05740-2571-4f22-b633-ca7a18934513.jsonl`
+
+**Corrective turns:**
+
+  **USER**: <command-message>validate_plan</command-message> <command-name>/validate_plan</command-name> <command-args>2026-04-05-ENG-98-quick-capture-form.md</command-args>
+  **USER** ← CORRECTION: # Validate Plan  You are tasked with validating that an implementation plan was correctly executed, verifying all success criteria and identifying any deviations or issues.  ## Initial Setup  When inv
+  **ASSISTANT**: 
+  **ASSISTANT**: [tool:Read {"file_path": "/Users/sam/workspace/rekurve/www/thoughts/pla]
+
+  **ASSISTANT**: [tool:Read {"file_path": "/Users/sam/workspace/rekurve/www/thoughts/pla]
+  **USER** ← CORRECTION: [tool_result_ERROR:File content (11993 tokens) exceeds maximum allowed tokens (10000). Use offset a]
+  **ASSISTANT**: [tool:Read {"file_path": "/Users/sam/workspace/rekurve/www/thoughts/pla]
+  **USER**: [tool_result:1	# Quick Capture Form (#98) Implementation Plan 2	 3	## Overview 4	 5	Build a m]
+
+---
+
+### 13. `7be8c779` — score 8
+
+**Goal:** Implement an approved plan to fix failing E2E tests across multiple phases, updating page objects and source testids
+
+**Outcome:** `partially_achieved` | **Helpfulness:** `moderately_helpful` | **Interruptions:** 1 | **Tool errors:** 2
+
+**Friction:** User interrupted Phase 4 work mid-exploration and redirected Claude to document progress for handoff rather than continue
+
+**Friction types:** {"user_interrupted": 1} | **Themes:** Agent sub-task interruption
+
+**Raw JSONL:** `~/.claude/projects/-Users-sam-workspace-rekurve-www/7be8c779-20dd-49e9-90be-66a657acf00a.jsonl`
+
+_No corrective turns extracted (session file may be absent)._
+
+---
+
+### 14. `fc85c7db` — score 8
+
+**Goal:** Implement an approved technical plan for the nurture scheduler feature
+
+**Outcome:** `not_achieved` | **Helpfulness:** `unhelpful` | **Interruptions:** 0 | **Tool errors:** 0
+
+**Friction:** Claude hit 'Extra usage required for 1M context' API errors twice, forcing the user to switch models and ultimately exit without making progress.
+
+**Friction types:** {"tool_unavailable": 2} | **Themes:** Unclassified
+
+**Raw JSONL:** `~/.claude/projects/-Users-sam-workspace-rekurve-www/fc85c7db-9e2e-40c2-97e5-fc36f898fcd9.jsonl`
+
+**Corrective turns:**
+
+  **USER**: <command-message>implement_plan</command-message> <command-name>/implement_plan</command-name> <command-args>2026-04-20-ENG-132-nurture-scheduler.md</command-args>
+  **USER** ← CORRECTION: # Implement Plan  You are tasked with implementing an approved technical plan from `thoughts/plans/`. These plans contain phases with specific changes and success criteria.  ## Getting Started  When g
+  **ASSISTANT**: API Error: Extra usage is required for 1M context · run /extra-usage to enable, or /model to switch to standard context
+  **USER**: <local-command-caveat>Caveat: The messages below were generated by the user while running local commands. DO NOT respond to these messages or otherwise consider them in your response unless the user e
+
+  **USER**: <command-message>implement_plan</command-message> <command-name>/implement_plan</command-name> <command-args>2026-04-20-ENG-132-nurture-scheduler.md</command-args>
+  **USER** ← CORRECTION: # Implement Plan  You are tasked with implementing an approved technical plan from `thoughts/plans/`. These plans contain phases with specific changes and success criteria.  ## Getting Started  When g
+  **ASSISTANT**: API Error: Extra usage is required for 1M context · run /extra-usage to enable, or /model to switch to standard context
+  **USER**: <local-command-caveat>Caveat: The messages below were generated by the user while running local commands. DO NOT respond to these messages or otherwise consider them in your response unless the user e
+
+---
+
+### 15. `da4bc01c` — score 8
+
+**Goal:** Implement an approved technical plan for a nurture scheduler feature
+
+**Outcome:** `not_achieved` | **Helpfulness:** `slightly_helpful` | **Interruptions:** 1 | **Tool errors:** 0
+
+**Friction:** User interrupted Claude while it was writing the first schema file, suggesting the approach or pace was not aligned with expectations
+
+**Friction types:** {"user_rejected_action": 1} | **Themes:** Wrong first action / pace
+
+**Raw JSONL:** `~/.claude/projects/-Users-sam-workspace-rekurve-www/da4bc01c-7fb8-4839-b601-626b0c41dfff.jsonl`
+
+**Corrective turns:**
+
+  **USER**: <command-message>implement_plan</command-message> <command-name>/implement_plan</command-name> <command-args>2026-04-20-ENG-132-nurture-scheduler.md</command-args>
+  **USER** ← CORRECTION: # Implement Plan  You are tasked with implementing an approved technical plan from `thoughts/plans/`. These plans contain phases with specific changes and success criteria.  ## Getting Started  When g
+  **ASSISTANT**: 
+  **ASSISTANT**: [tool:Read {"file_path": "/Users/sam/workspace/rekurve/www/thoughts/pla]
+
+  **USER**: [tool_result:File created successfully at: /Users/sam/workspace/rekurve/www/src/server/api/sc]
+  **USER** ← CORRECTION: [Request interrupted by user]
+
+---
+
+### 16. `a82eea81` — score 7
+
+**Goal:** Continue implementing an approved plan to fix failing E2E tests, then document progress for hand-off
+
+**Outcome:** `mostly_achieved` | **Helpfulness:** `very_helpful` | **Interruptions:** 1 | **Tool errors:** 3
+
+**Friction:** Initial test fix attempts with NumericFormat input required multiple iterations before discovering .blur() after .fill() was needed
+
+**Friction types:** {"buggy_code": 1} | **Themes:** Test debugging loop
+
+**Raw JSONL:** `~/.claude/projects/-Users-sam-workspace-rekurve-www/a82eea81-acff-45d8-a09f-180d1fcb1e73.jsonl`
+
+_No corrective turns extracted (session file may be absent)._
+
+---
+
+### 17. `f6e15c37` — score 7
+
+**Goal:** Validate the ENG-128 action queue view implementation plan and then conduct a design review
+
+**Outcome:** `partially_achieved` | **Helpfulness:** `moderately_helpful` | **Interruptions:** 1 | **Tool errors:** 1
+
+**Friction:** User interrupted the design review agent tool call before it could complete
+
+**Friction types:** {"user_rejected_action": 1} | **Themes:** Unclassified
+
+**Raw JSONL:** `~/.claude/projects/-Users-sam-workspace-rekurve-www/f6e15c37-06a9-4b5d-b114-c5cb12eaf5f0.jsonl`
+
+**Corrective turns:**
+
+  **USER**: <command-message>validate_plan</command-message> <command-name>/validate_plan</command-name> <command-args>2026-04-13-ENG-128-action-queue-view.md</command-args>
+  **USER** ← CORRECTION: # Validate Plan  You are tasked with validating that an implementation plan was correctly executed, verifying all success criteria and identifying any deviations or issues.  ## Initial Setup  When inv
+  **ASSISTANT**: 
+  **ASSISTANT**: [tool:Bash {"command": "find /Users/sam/workspace/rekurve/www/thoughts ]
+
+  **ASSISTANT**: [tool:Bash {"command": "cat /private/tmp/claude-501/-Users-sam-workspac]
+  **USER** ← CORRECTION: [tool_result:yarn check Checked 257 files in 60ms. No fixes applied.]
+  **ASSISTANT**: [tool:Read {"file_path": "/Users/sam/workspace/rekurve/www/src/app/(app]
+  **USER**: [tool_result:1	"use client"; 2	 3	import { Mail, MessageSquare } from "lucide-react"; 4	impor]
+
+  **USER**: <command-message>design_review</command-message> <command-name>/design_review</command-name>
+  **USER** ← CORRECTION: You are an elite design review specialist with deep expertise in user experience, visual design, accessibility, and front-end implementation. You conduct world-class design reviews following the rigor
+  **ASSISTANT**: 
+  **ASSISTANT**: [tool:Agent {"description": "Design review: action queue view", "subagen]
+
+  **ASSISTANT**: [tool:Agent {"description": "Design review: action queue view", "subagen]
+  **USER** ← CORRECTION: [tool_result_ERROR:The user doesn't want to proceed with this tool use. The tool use was rejected (]
+  **USER**: [Request interrupted by user for tool use]
+
+  **USER**: [tool_result_ERROR:The user doesn't want to proceed with this tool use. The tool use was rejected (]
+  **USER** ← CORRECTION: [Request interrupted by user for tool use]
+
+---
+
+### 18. `35898331` — score 6
+
+**Goal:** Design and implement a codebase-verification sub-agent that isolates verbose make build/test output from the main context window
+
+**Outcome:** `fully_achieved` | **Helpfulness:** `very_helpful` | **Interruptions:** 0 | **Tool errors:** 5
+
+**Friction:** Initial agent prompt didn't enforce strict output format on refusal path, requiring a second edit and session restart to fix haiku's conversational drift
+
+**Friction types:** {"wrong_approach": 1} | **Themes:** CLAUDE.md rule violation
+
+**Raw JSONL:** `~/.claude/projects/-Users-sam-workspace-rekurve-www/35898331-35dd-4b6f-b42e-23b9df0dc82e.jsonl`
+
+**Corrective turns:**
+
+  **USER**: <command-message>brainstorm</command-message> <command-name>/brainstorm</command-name> <command-args>a "codebase-verification" sub-agent in .calude/agents/  The purpose of this agent is to execute con
+  **USER** ← CORRECTION: # Brainstorming Ideas Into Designs  ## Overview  Help turn ideas into fully formed designs and specs through natural collaborative dialogue.  Start by understanding the current project context, then a
+  **ASSISTANT**: 
+  **ASSISTANT**: [tool:Bash {"command": "ls -la /Users/sam/workspace/rekurve/www/.claude]
+
+  **ASSISTANT**: [tool:Agent {"subagent_type": "web-search-researcher", "description": "R]
+  **USER** ← CORRECTION: [tool_result_ERROR:Exit code 1 total 112 drwxr-xr-x@ 10 sam  staff   320 Mar 31 23:02 . drwxr-xr-x@]
+  **USER**: [tool_result_ERROR:<tool_use_error>Cancelled: parallel tool call Bash(ls -la /Users/sam/workspace/r]
+  **ASSISTANT**: 
+
+  **USER**: [tool_result_ERROR:Exit code 1 total 112 drwxr-xr-x@ 10 sam  staff   320 Mar 31 23:02 . drwxr-xr-x@]
+  **USER** ← CORRECTION: [tool_result_ERROR:<tool_use_error>Cancelled: parallel tool call Bash(ls -la /Users/sam/workspace/r]
+  **ASSISTANT**: 
+  **ASSISTANT**: [tool:Bash {"command": "ls -la /Users/sam/workspace/rekurve/www/.claude]
+
+  **ASSISTANT**: [tool:Read {"file_path": "/Users/sam/.claude/agents/codebase-locator.md]
+  **USER** ← CORRECTION: [tool_result_ERROR:File does not exist. Note: your current working directory is /Users/sam/workspac]
+  **USER**: [tool_result_ERROR:File does not exist. Note: your current working directory is /Users/sam/workspac]
+  **ASSISTANT**: 
+
+  **USER**: [tool_result_ERROR:File does not exist. Note: your current working directory is /Users/sam/workspac]
+  **USER** ← CORRECTION: [tool_result_ERROR:File does not exist. Note: your current working directory is /Users/sam/workspac]
+  **ASSISTANT**: 
+  **ASSISTANT**: [tool:Bash {"command": "ls -la /Users/sam/workspace/rekurve/www/.claude]
+
+---
+
+### 19. `c11d6faa` — score 5
+
+**Goal:** Validate the ENG-128 action queue view implementation against its plan, update the GitHub issue acceptance criteria, and create a PR
+
+**Outcome:** `fully_achieved` | **Helpfulness:** `very_helpful` | **Interruptions:** 0 | **Tool errors:** 4
+
+**Friction:** Git push hook blocked Claude's push, requiring the user to manually push the branch before PR creation could proceed
+
+**Friction types:** {"tool_permission_blocked": 1} | **Themes:** Unclassified
+
+**Raw JSONL:** `~/.claude/projects/-Users-sam-workspace-rekurve-www/c11d6faa-e8a2-41ed-8aeb-b3d90c1a84d2.jsonl`
+
+**Corrective turns:**
+
+  **USER**: <command-message>validate_plan</command-message> <command-name>/validate_plan</command-name> <command-args>2026-04-13-ENG-128-action-queue-view.md and then udpate the github issue Acceptance criteria 
+  **USER** ← CORRECTION: # Validate Plan  You are tasked with validating that an implementation plan was correctly executed, verifying all success criteria and identifying any deviations or issues.  ## Initial Setup  When inv
+  **ASSISTANT**: 
+  **ASSISTANT**: [tool:Bash {"command": "find /Users/sam/workspace/rekurve/www/thoughts ]
+
+  **ASSISTANT**: [tool:Bash {"command": "tail -50 /private/tmp/claude-501/-Users-sam-wor]
+  **USER** ← CORRECTION: [tool_result:yarn check Checked 257 files in 43ms. No fixes applied.]
+  **ASSISTANT**: [tool:TaskOutput {"task_id": "bg90zd9f9", "block": true, "timeout": 180000}]
+  **USER**: [tool_result:<retrieval_status>success</retrieval_status>  <task_id>bg90zd9f9</task_id>  <tas]
+
+  **ASSISTANT**: [tool:Bash {"command": "grep -E \"action-queue\" /private/tmp/claude-50]
+  **USER** ← CORRECTION: [tool_result:(Bash completed with no output)]
+  **ASSISTANT**: [tool:Bash {"command": "grep -i \"action.queue\\|Action Queue\" /privat]
+  **USER**: [tool_result:  ✓  241 [mobile] › e2e/features/dashboard-shell.spec.ts:135:3 › Dashboard Shell]
+
+  **ASSISTANT**: [tool:Bash {"command": "grep -E \"action-queue\\.spec\" /private/tmp/cl]
+  **USER** ← CORRECTION: [tool_result:(Bash completed with no output)]
+  **ASSISTANT**: [tool:Bash {"command": "head -100 /private/tmp/claude-501/-Users-sam-wo]
+  **USER**: [tool_result:  -  215 [mobile] › e2e/features/booking-form.spec.ts:129:3 › Booking Form Valid]
+
+  **USER**: <command-message>describe_pr</command-message> <command-name>/describe_pr</command-name>
+  **USER** ← CORRECTION: # Generate PR Description  You are tasked with generating a clear and concise pull request description following the repository's standard template.  ## Steps to follow:  1. **Read the PR description 
+  **ASSISTANT**: 
+  **ASSISTANT**: [tool:Bash {"command": "ls docs/pr_template.md 2>&1; gh pr view --json ]
+
+---
+
+### 20. `683212e8` — score 5
+
+**Goal:** Update /implement_plan and /validate_plan Claude commands to stay consistent with a recently revised /create_plan template
+
+**Outcome:** `mostly_achieved` | **Helpfulness:** `very_helpful` | **Interruptions:** 0 | **Tool errors:** 3
+
+**Friction:** Claude initially dropped `make build` from an edit and had to retry after saving feedback to memory
+
+**Friction types:** {"excessive_changes": 1} | **Themes:** Unclassified
+
+**Raw JSONL:** `~/.claude/projects/-Users-sam-workspace-rekurve-www/683212e8-cd51-43ab-a10a-d73be101bfe1.jsonl`
+
+**Corrective turns:**
+
+  **ASSISTANT**: [tool:Bash {"command": "ls ~/.claude/skills/ ~/.claude/commands/ 2>/dev]
+  **USER** ← CORRECTION: [tool_result_ERROR:Exit code 1 /Users/sam/.claude/skills/: context7-mcp]
+  **ASSISTANT**: [tool:Bash {"command": "find ~/.claude -type f -name \"*.md\" 2>/dev/nu]
+  **USER**: [tool_result:(Bash completed with no output)]
+
+  **ASSISTANT**: [tool:Bash {"command": "find ~/.claude -type f -name \"*.md\" 2>/dev/nu]
+  **USER** ← CORRECTION: [tool_result:(Bash completed with no output)]
+  **ASSISTANT**: [tool:Bash {"command": "find ~/.claude -type d 2>/dev/null | head -50",]
+  **USER**: [tool_result:/Users/sam/.claude /Users/sam/.claude/ide /Users/sam/.claude/tasks /Users/sam/.c]
+
+  **ASSISTANT**: [tool:Bash {"command": "find ~/.claude -maxdepth 4 -type f \\( -name \"]
+  **USER** ← CORRECTION: [tool_result:(Bash completed with no output)]
+  **ASSISTANT**: [tool:Bash {"command": "find ~/.claude -type f \\( -name \"*create*plan]
+  **USER**: [tool_result:(Bash completed with no output)]
+
+  **ASSISTANT**: [tool:Bash {"command": "find ~/.claude -type f \\( -name \"*create*plan]
+  **USER** ← CORRECTION: [tool_result:(Bash completed with no output)]
+  **ASSISTANT**: [tool:Bash {"command": "ls ~/.claude/plugins/marketplaces/claude-plugin]
+  **USER**: [tool_result:README.md external_plugins plugins --- /Users/sam/.claude/plugins /Users/sam/.cl]
+
+  **ASSISTANT**: [tool:Bash {"command": "find ~/.claude/plugins -type f -name \"*.md\" |]
+  **USER** ← CORRECTION: [tool_result:(Bash completed with no output)]
+  **ASSISTANT**: [tool:Bash {"command": "find ~/.claude/plugins -type f -name \"*.md\" -]
+  **USER**: [tool_result:/Users/sam/.claude/plugins/marketplaces/claude-plugins-official/plugins/feature-]
+
+---
+
+## Theme Hypotheses for Future Guardrails
+
+Recurring residual themes that might warrant future CLAUDE.md or command edits (≥2 sessions, not currently planned):
+
+### CLAUDE.md rule violation (3 sessions)
+Claude knows the rule but bypasses it
+
+Sessions: 35898331, 2cc718bf, 1536e6cf
+
+Possible fix: _(not scheduled — assess whether a guardrail in CLAUDE.md or a command edit would prevent recurrence)_
+
+### Wrong first action / pace (3 sessions)
+Claude picks wrong first tool call or starts without enough context
+
+Sessions: 79b39a84, a20ddbb8, da4bc01c
+
+Possible fix: _(not scheduled — assess whether a guardrail in CLAUDE.md or a command edit would prevent recurrence)_
+
+### Agent sub-task interruption (2 sessions)
+User interrupted mid-implementation and redirected
+
+Sessions: 7be8c779, 3cc24e37
+
+Possible fix: _(not scheduled — assess whether a guardrail in CLAUDE.md or a command edit would prevent recurrence)_
+
+### Commit/PR mechanics (2 sessions)
+Wrong files staged, wrong commit message, bad branch
+
+Sessions: c99080bb, 5064c307
+
+Possible fix: _(not scheduled — assess whether a guardrail in CLAUDE.md or a command edit would prevent recurrence)_

--- a/thoughts/research/2026-04-21-sub-agent-eval-pipeline-transcript.md
+++ b/thoughts/research/2026-04-21-sub-agent-eval-pipeline-transcript.md
@@ -1,0 +1,368 @@
+# Session Transcript — Sub-Agent Eval Pipeline Brainstorm
+
+**Date:** 2026-04-21
+**Purpose:** Preserve the research output of the old `web-search-researcher` agent and the brainstorm dialogue that produced `thoughts/designs/2026-04-21-sub-agent-eval-pipeline.md`, so the new `web-lookup` / `web-research` agents can be re-run on the same prompt for quality comparison.
+**Design artefact:** `thoughts/designs/2026-04-21-sub-agent-eval-pipeline.md`
+**Old agent (deleted this session):** `.claude/agents/web-search-researcher.md`
+**New agents:** `.claude/agents/web-lookup.md` (haiku), `.claude/agents/web-research.md` (opus)
+
+---
+
+## 0. User's opening prompt
+
+> Review the sub-agent metadata and prompt (configuration) for `.claude/agents/web-search-researcher.md` and suggest how to optimize / improve both or either the metadata (description, model, tools, effort) or prompt.
+>
+> Provide some initial suggestions that have verified evidence to back up the suggested change.
+>
+> Then I'd like to design an evaluation pipeline to using something like autoresearch, a custom llm-as-a-judge or GEPA optimisation pipeline, or even a more recent strategy incorporating relevant parts of Stanford's Meta-Harness (https://arxiv.org/html/2603.28052v1#S4)
+>
+> Idealy the solution we design will be used to continuously improve (or even create) other sub-agents under `.claude/agents/`
+>
+> Then possiblly progress into creating/improving slash commands (.claude/commands/) and skills (.claude/skills/)
+
+---
+
+## 1. Research prompt sent to the OLD `web-search-researcher` agent
+
+This is the verbatim prompt. Re-run it through `web-research` (multi-source synthesis) to compare.
+
+> I'm designing an evaluation + continuous-improvement pipeline for Claude Code sub-agents (markdown files with YAML frontmatter defining description/model/tools, followed by a system prompt). The goal is to automatically score sub-agent quality on representative tasks and iteratively improve their prompts/metadata.
+>
+> Please research all of the following and return a consolidated, citation-backed briefing. Do NOT synthesize recommendations — just return faithful, well-quoted findings I can use to design the system myself.
+>
+> ## 1. Stanford Meta-Harness paper
+> URL: https://arxiv.org/html/2603.28052v1#S4
+>
+> Fetch the paper (especially §4). I need:
+> - What is the Meta-Harness? (core idea in 2-4 sentences)
+> - How does it evaluate agents/prompts? (pipeline stages, scorers, judges)
+> - What metrics does it report?
+> - What makes it different from vanilla LLM-as-judge or GEPA?
+> - Any specific techniques (rubric design, test generation, calibration) that transfer to evaluating Claude Code sub-agents
+>
+> Quote the paper directly where possible.
+>
+> ## 2. GEPA (Genetic-Pareto / reflective prompt optimization)
+> Search for the latest GEPA paper/implementation (originated 2024-2025, associated with DSPy / Stanford NLP / Lakera or similar). Find:
+> - Core algorithm (mutation, Pareto selection, reflective feedback loop)
+> - What inputs/outputs it expects (prompt templates, eval set, scorer)
+> - Reference implementations (github repos, DSPy modules)
+> - Reported gains vs baselines like MIPROv2, OPRO, random search
+> - How it handles multi-objective trade-offs (quality vs cost vs latency)
+>
+> ## 3. AutoResearch / automated research agent eval
+> Several projects share this name. Identify which is relevant for agent evaluation:
+> - Is there a framework specifically called "autoresearch" for evaluating research agents?
+> - Alternatives in the same space: OpenAI Evals, Inspect AI (UK AISI), LangSmith evals, Braintrust, Promptfoo, Ragas, DeepEval — which are best suited for evaluating *agents* (not just one-shot prompts)?
+>
+> ## 4. LLM-as-judge best practices (2025)
+> - Rubric design (numeric scales vs pairwise comparison vs structured rubric)
+> - Calibration against human judgment (ChatBot Arena, MT-Bench findings)
+> - Known failure modes (position bias, length bias, self-preference bias)
+> - Techniques to mitigate (pairwise with randomized order, ensemble judges, reference-based scoring)
+>
+> ## 5. Claude Code sub-agent best practices
+> Search Anthropic docs, engineering blog, and Claude Code docs for:
+> - Official guidance on writing sub-agent descriptions (what triggers invocation)
+> - Tool scoping recommendations
+> - Model selection (haiku vs sonnet vs opus for different agent roles)
+> - Prompt structure patterns that work well
+>
+> ## Output format
+> For each section above, return:
+> - 3-8 bullet points of key findings with inline citations (URL + quoted text where possible)
+> - A short "transfers to our use case" line noting which findings are directly applicable to evaluating markdown-based sub-agents
+>
+> Keep it factual and sourced — no opinions. Target ~1500-2500 words total.
+
+---
+
+## 2. OLD agent output (verbatim, to compare against new agent reruns)
+
+### Section 1: Stanford Meta-Harness Paper (arxiv.org/html/2603.28052v1)
+
+**Core idea.** Meta-Harness is "an outer-loop system that searches over harness code for LLM applications." A coding agent reads a filesystem of all prior candidates' source code, execution traces, and scores, then proposes a new harness implementation. The loop runs N times; each iteration produces k new harness proposals informed by full history.
+
+- The fundamental differentiation is information richness. Table 1 contrasts context budgets: GEPA uses ~0.008 M tokens per iteration (summaries), while Meta-Harness provides ~10.0 M tokens per iteration (full filesystem access). Prior methods "typically operate with short-horizon or heavily compressed feedback: some condition only on the current candidate, others rely primarily on scalar scores, and others restrict feedback to short templates or LLM-generated summaries." (§1)
+
+- Pipeline stages (Algorithm 1, §3): (1) Filesystem inspection — the coding agent uses grep/cat on prior candidates' code, traces, and scores; (2) Proposal generation — the proposer reasons about failure modes and produces a new harness; (3) Evaluation — the harness runs on a search set; (4) Filesystem storage — all code, scores, and traces go into a new directory for future reference.
+
+- What makes it different from vanilla LLM-as-judge: it delegates proposer work to a coding agent with unrestricted filesystem access, rather than compressing feedback into a short prompt. An ablation (Table 3, §4.1) shows "scores-only" reaches 34.6% median accuracy vs. Meta-Harness at 50.0%, demonstrating that raw execution traces — not just scalar rewards — are essential.
+
+- What makes it different from GEPA specifically: GEPA is listed in Table 1 as a text optimizer with compressed feedback; Meta-Harness operates at the harness (code) level with full trace access rather than evolving prompt text against scalar scores.
+
+- Metrics reported (three domains): (a) Text classification — accuracy and context tokens; result: 48.6% accuracy vs. ACE's 40.9% baseline, using 11.4K vs. 50.8K tokens. (b) Math reasoning — Pass@1 on 200 IMO-level problems; 4.7-point average improvement over no retrieval. (c) Agentic coding — pass rate on TerminalBench-2 (89 tasks); 76.4% on Opus 4.6, 37.6% on Haiku 4.5.
+
+- Pareto frontier analysis is used to navigate accuracy–efficiency tradeoffs (Figure 3, §4.1), so the proposer "discover[s] harnesses across a broad range of the frontier" without committing to a single scalar objective upfront.
+
+- No explicit rubric design or calibration procedures are described. The paper delegates scoring to task-specific reward functions (pass/fail, accuracy). The implicit calibration mechanism is the proposer reading raw execution traces, not a rubric.
+
+**Transfers to our use case:** The filesystem-as-memory pattern (storing every eval run's code, traces, and scores for the next proposer iteration) directly transfers. For markdown-based sub-agent evaluation, this means persisting full agent transcripts alongside scores so an optimizer can read raw tool-call traces — not just final scores — when proposing prompt improvements.
+
+### Section 2: GEPA (Genetic-Pareto Reflective Prompt Optimization)
+
+Paper: "GEPA: Reflective Prompt Evolution Can Outperform Reinforcement Learning," Agrawal et al., arxiv:2507.19457, accepted ICLR 2026 (Oral).
+
+- Core algorithm (5 steps from the gepa-ai/gepa README): (1) Select a candidate from the Pareto frontier; (2) Execute on a minibatch, capturing full execution traces; (3) Reflect — an LLM reads the traces and diagnoses why the candidate failed; (4) Mutate — generate an improved candidate informed by the diagnosis; (5) Accept — add to the candidate pool if improved, update the Pareto frontier.
+
+- Pareto frontier maintenance: rather than keeping only the global best, GEPA maintains "the set of candidates which achieve the highest score on at least one evaluation instance." Candidates are selected probabilistically weighted by their coverage on the validation set. This preserves complementary strategies and avoids local optima. (DSPy GEPA overview docs)
+
+- Inputs/outputs: inputs are a seed candidate (e.g., a dict with `"system_prompt"` key), a training set, a validation set, and a metric function. The metric function must return `(score, feedback)` tuples — the textual `feedback` field "provides GEPA more visibility into why the system got the score that it did, and then GEPA can introspect to identify how to improve the score." (DSPy API docs) Output is an optimized program with evolved prompts, plus optional `detailed_results` containing all candidates and lineage.
+
+- DSPy integration: `dspy.GEPA(metric=your_metric, reflection_lm=dspy.LM(model='gpt-5', temperature=1.0), max_metric_calls=5000)` compiled via `gepa.compile(student, trainset=train_data, valset=val_data)`. Standalone use via `pip install gepa` with `gepa.optimize(seed_candidate, trainset, valset, task_lm, reflection_lm, max_metric_calls)`.
+
+- Reported gains vs baselines: vs. GRPO (RL): +6% average, up to +20% on individual tasks, using 35x fewer rollouts. Vs. MIPROv2: >10% outperformance, +12% accuracy on AIME-2025. Real-world claims from the gepa-ai README: 32% → 89% on an ARC-AGI agent; 55% → 82% coding agent resolve rate; 46.6% → 56.6% GPT-4.1 Mini on AIME 2025.
+
+- Multi-objective handling: GEPA "combine[s] complementary lessons from the Pareto frontier of its own attempts," enabling tradeoffs between accuracy, cost, latency without collapsing to a single scalar. (arxiv abstract)
+
+- Reference implementations: [github.com/gepa-ai/gepa](https://github.com/gepa-ai/gepa); [dspy.ai/api/optimizers/GEPA/overview/](https://dspy.ai/api/optimizers/GEPA/overview/); [stanfordnlp/dspy GEPA docs](https://github.com/stanfordnlp/dspy/blob/main/docs/docs/api/optimizers/GEPA/overview.md).
+
+**Transfers to our use case:** The metric function's `(score, feedback)` interface is directly applicable — when scoring a markdown sub-agent run, returning a structured string explaining why a score was given (not just the number) enables GEPA's reflection step to propose targeted description/prompt edits. The Pareto frontier design handles the inherent multi-objective nature of sub-agent quality (accuracy, token cost, latency).
+
+### Section 3: Agent Evaluation Frameworks
+
+No single project called "autoresearch" dominates the agent-eval space. The relevant landscape breaks into two tiers: frameworks purpose-built for agent trajectory evaluation, and those primarily designed for single-turn prompt evaluation.
+
+**Purpose-built for agent evaluation:**
+
+- **Inspect AI (UK AISI)** — open-source (MIT), Python-first, explicitly designed for agent evals. Architecture: Tasks/Datasets/Solvers/Scorers. "Agent Bridge enables the use of agents from 3rd party frameworks like OpenAI Agents SDK, LangChain, and Pydantic AI." Ships curated agent benchmarks: GAIA, SWE-Bench, GDM CTF, Cybench. [inspect.aisi.org.uk](https://inspect.aisi.org.uk/)
+
+- **DeepEval (Confident AI)** — Python-native, pytest-based. Specifically models the agent as two-layer: reasoning layer and action layer. Agent-specific metrics include: `ToolCorrectnessMetric`, `ArgumentCorrectnessMetric`, `PlanQualityMetric`, `PlanAdherenceMetric`, `TaskCompletionMetric`, `StepEfficiencyMetric`. "Unlike simple LLM applications that respond to single prompts, agents operate in loops—reasoning, acting, observing results, and adapting their approach until the task is complete." Evaluates component-level (single tool call) and end-to-end (full trace). [deepeval.com/guides/guides-ai-agent-evaluation](https://deepeval.com/guides/guides-ai-agent-evaluation)
+
+- **Braintrust** — cloud-hosted, recommended "for teams that have moved past local testing and need to measure AI agents in production, giving detailed traces across every agent step." Suited for trace-level production monitoring and prompt iteration collaboration.
+
+- **LangSmith** and **Langfuse** — both support trajectory capture and agent-step-level scoring; primarily complement existing LangChain/LangGraph toolchains.
+
+**Primarily prompt/single-turn evaluation (less suited for agent trajectory evals):**
+
+- **Promptfoo** — CLI-first, YAML-based, acquired by OpenAI; strong for red-teaming and single-turn assertion testing. Less designed for multi-step agent trajectories.
+
+- **OpenAI Evals** — restricted to OpenAI API users.
+
+- **Ragas** — specialized in RAG pipeline evaluation (retrieval quality, faithfulness); not general-purpose agent eval.
+
+- **Anthropic's own guidance** (from the engineering blog "Demystifying evals for AI agents") recommends combined grader strategies: code-based ("fast, cheap, objective, reproducible"), model-based ("flexible, scalable, captures nuance"), and human graders for calibration. Practical roadmap: start with 20-50 tasks from actual user failures, write unambiguous specs with reference solutions, build balanced positive/negative problem sets, and design isolated environments per trial. [anthropic.com/engineering/demystifying-evals-for-ai-agents](https://www.anthropic.com/engineering/demystifying-evals-for-ai-agents)
+
+**Transfers to our use case:** Inspect AI's Solver/Scorer separation and DeepEval's two-layer model (reasoning + action) are directly applicable to evaluating markdown sub-agents: the `description` field governs routing (an agent-level decision) while the system prompt governs execution quality (a trajectory-level concern) — these require separate scorers.
+
+### Section 4: LLM-as-Judge Best Practices (2025)
+
+Primary source: "Judging LLM-as-a-Judge with MT-Bench and Chatbot Arena," Zheng et al., NeurIPS 2023, arxiv:2306.05685 — the seminal calibration study. Supplementary: "Autorubric: Unifying Rubric-based LLM Evaluation," arxiv:2603.00077v2.
+
+**Rubric design:**
+
+- Autorubric establishes that analytic rubrics — decomposing evaluation into independent criteria scored separately — "prevent criterion conflation and halo effects, enable reliability measurement via Cohen's κ, and provide optimization signals." (§2)
+
+- Criterion types in order of reliability: binary (MET/UNMET, highest inter-rater reliability) > ordinal (3–5 Likert levels with behavioral anchors) > nominal (unordered categories). Continuous-valued criteria are explicitly excluded "due to poor LLM calibration on unbounded numeric scales." (§2)
+
+- Negative-weight criteria serve as penalties for anti-patterns, counteracting the leniency bias documented in LLM judges. Weighted aggregation formula: `score = max(0, min(1, Σ(vᵢ·wᵢ)/Σ(wᵢ>0·wᵢ)))` (Equation 1, Autorubric)
+
+**Calibration against human judgment:**
+
+- MT-Bench findings: "GPT-4 with both pairwise comparison and single answer grading show very high agreements with human experts. The agreement under setup S2 (w/o tie) between GPT-4 and humans reaches 85%" — "even higher than the agreement among humans (81%)." (§4.2, Table 5, arxiv:2306.05685)
+
+- Few-shot calibration is most impactful for weaker judges: on RiceChem, Gemini-3-Flash improved from 77.2% (0-shot) to 80.0% (5-shot); removing few-shot cost LLaMA-3.1-8B −15.0pp. Verdict-balanced sampling prevents judges from "inferring a base-rate prior." (Autorubric §2, Table 4)
+
+**Known failure modes:**
+
+- **Position bias**: "All LLM judges tested exhibit strong position bias, with most LLM judges favoring the first position." (§3.3, MT-Bench) GPT-4 showed only 65% consistency when answer order was swapped; Claude-v1 managed 23.8%.
+
+- **Verbosity/length bias**: A "repetitive list" attack (lengthening responses without adding information) caused Claude-v1 and GPT-3.5 to fail at 91.3%; "all LLMs may be prone to verbosity bias though GPT-4 defends significantly better" at 8.7% failure. (§3.3, Table 4, MT-Bench)
+
+- **Self-enhancement bias**: "GPT-4 favors itself with a 10% higher win rate; Claude-v1 favors itself with a 25% higher win rate." (§3.3, MT-Bench) — though authors note this could reflect genuine quality differences.
+
+- **Reasoning limitations**: GPT-4 failed 14/20 (70%) math questions when judging with misleading provided answers. (§3.3, Table 4)
+
+**Mitigation techniques:**
+
+- Position swapping: "call a judge twice by swapping the order of two answers and only declare a win when an answer is preferred in both orders." (§3.4, MT-Bench) Reduces position bias at the cost of 2x API calls.
+
+- Reference-guided scoring: providing a reference solution reduced GPT-4's math failure rate from 14/20 to 3/20. (§3.4, Table 4, MT-Bench)
+
+- Few-shot prompting: improved GPT-4 positional consistency from 65% to 77.5%. (§D.2, Table 13, MT-Bench)
+
+- Randomized option order with explicit numeric values: Autorubric "randomizes option order per evaluation by default, using explicit numeric values to decouple score from position." (§3, Table 1)
+
+- Multi-judge ensembles: same-model ensembles (k=3,5) provided negligible gains for strong models but lifted LLaMA by up to 26pp. (Autorubric Table 4) Regression-based bias correction calibrated on a small set of human-annotated examples can "halve residual error relative to best ensembles."
+
+**Transfers to our use case:** For scoring markdown sub-agents, use binary or 3-point ordinal criteria per dimension (description clarity, tool scoping correctness, prompt specificity, output format compliance) rather than a single 1-10 score. Always randomize option order in pairwise comparisons and provide reference solutions (the "ideal" sub-agent output) to anchor the judge.
+
+### Section 5: Claude Code Sub-Agent Best Practices
+
+Source: [code.claude.com/docs/en/sub-agents](https://code.claude.com/docs/en/sub-agents) (official Anthropic docs, fetched April 2026).
+
+**Description field — what triggers invocation:**
+
+- "Claude uses each subagent's description to decide when to delegate tasks. When you create a subagent, write a clear description so Claude knows when to use it." The description field is defined as "When Claude should delegate to this subagent."
+
+- Adding "use proactively" in the description encourages automatic delegation: "To encourage proactive delegation, include phrases like 'use proactively' in your subagent's description field."
+
+- The built-in code-reviewer example shows the pattern: `"Expert code review specialist. Proactively reviews code for quality, security, and maintainability. Use immediately after writing or modifying code."` — it names the role, names the domain, and states the invocation trigger condition.
+
+**Tool scoping:**
+
+- Two complementary fields: `tools` (allowlist) and `disallowedTools` (denylist). "If both are set, `disallowedTools` is applied first, then `tools` is resolved against the remaining pool." A tool in both lists is removed.
+
+- Official best practice tip: "Limit tool access: grant only necessary permissions for security and focus." The Explore built-in uses Haiku + read-only tools as the canonical minimal-scope pattern.
+
+- MCP servers can be scoped to a single sub-agent via `mcpServers` inline definitions, preventing parent-context pollution: "To keep an MCP server out of the main conversation entirely and avoid its tool descriptions consuming context there, define it inline here rather than in `.mcp.json`."
+
+- `PreToolUse` hooks enable conditional tool gating beyond static allowlists (e.g., blocking SQL write operations while allowing Bash for SELECT queries).
+
+**Model selection:**
+
+- Model resolution order (highest to lowest priority): (1) `CLAUDE_CODE_SUBAGENT_MODEL` environment variable; (2) per-invocation `model` parameter; (3) frontmatter `model` field; (4) main conversation's model.
+
+- Built-in patterns: Explore uses **Haiku** (fast, low-latency, read-only exploration); statusline-setup uses **Sonnet**; Claude Code Guide uses **Haiku**; Plan and general-purpose agents inherit from the main conversation.
+
+- Official guidance: "Control costs by routing tasks to faster, cheaper models like Haiku." The data-scientist example explicitly sets `model: sonnet` for "more capable analysis."
+
+- Available aliases: `sonnet`, `opus`, `haiku`, full model IDs (e.g., `claude-sonnet-4-6`), or `inherit` (default if omitted).
+
+**Prompt structure patterns:**
+
+- Sub-agents receive "only this system prompt (plus basic environment details like working directory), not the full Claude Code system prompt." This means all necessary context must be in the markdown body.
+
+- The official examples share a consistent structure: (1) role statement ("You are a senior code reviewer..."); (2) "When invoked:" numbered workflow; (3) a checklist or "key practices" section; (4) output format specification ("Provide feedback organized by priority: Critical / Warnings / Suggestions").
+
+- `skills` field injects domain knowledge at startup: "The full content of each skill is injected into the subagent's context, not just made available for invocation. Subagents don't inherit skills from the parent conversation; you must list them explicitly."
+
+- `memory` field enables cross-session learning. Recommended tip: "Include memory instructions directly in the subagent's markdown file so it proactively maintains its own knowledge base."
+
+- Sub-agents cannot spawn other sub-agents: "Subagents cannot spawn other subagents." For nested delegation, chain sub-agents from the main conversation or use Skills.
+
+**Transfers to our use case:** The description field is the primary routing signal — evaluating it means testing whether the description correctly triggers (and doesn't false-positive trigger) delegation on a representative task set. The structured body pattern (role → workflow → checklist → output format) provides a natural rubric template for scoring prompt quality. Model selection is a scorable metadata field: Haiku for read-only/fast tasks, Sonnet for analysis, Opus for complex reasoning.
+
+### Sources cited
+
+- [Meta-Harness paper (arxiv:2603.28052v1)](https://arxiv.org/html/2603.28052v1#S4)
+- [GEPA paper abstract (arxiv:2507.19457)](https://arxiv.org/abs/2507.19457)
+- [GEPA PDF (arxiv:2507.19457)](https://arxiv.org/pdf/2507.19457)
+- [GEPA reference implementation (gepa-ai/gepa)](https://github.com/gepa-ai/gepa)
+- [GEPA DSPy optimizer overview (dspy.ai)](https://dspy.ai/api/optimizers/GEPA/overview/)
+- [GEPA DSPy source docs (stanfordnlp/dspy)](https://github.com/stanfordnlp/dspy/blob/main/docs/docs/api/optimizers/GEPA/overview.md)
+- [Judging LLM-as-a-Judge with MT-Bench and Chatbot Arena (arxiv:2306.05685)](https://arxiv.org/html/2306.05685v4)
+- [Autorubric: Unifying Rubric-based LLM Evaluation (arxiv:2603.00077v2)](https://arxiv.org/html/2603.00077v2)
+- [Anthropic engineering: Demystifying evals for AI agents](https://www.anthropic.com/engineering/demystifying-evals-for-ai-agents)
+- [Claude Code sub-agent official docs](https://code.claude.com/docs/en/sub-agents)
+- [Inspect AI (UK AISI)](https://inspect.aisi.org.uk/)
+- [DeepEval AI agent evaluation guide](https://deepeval.com/guides/guides-ai-agent-evaluation)
+- [Braintrust](https://www.braintrust.dev/articles)
+- [GEPA overview on DeepEval](https://deepeval.com/docs/prompt-optimization-gepa)
+
+### Agent telemetry
+
+- `total_tokens: 43356`
+- `tool_uses: 18`
+- `duration_ms: 464686` (~7m 45s)
+
+---
+
+## 3. Brainstorm Q&A (condensed — full text in the conversation log)
+
+All decisions locked in below. Evidence citations for each decision live in the design doc at `thoughts/designs/2026-04-21-sub-agent-eval-pipeline.md`.
+
+### Q1 — Pipeline scope
+**A:** Option 2 now (measurement + reflective feedback), Option 3 (closed-loop GEPA mutation) once the judge is calibrated.
+
+### Q2 — Task sourcing
+**A:** (4) Hybrid — 5 hand-curated golden + 5 mined real invocations + 5 synthetic adversarial per agent.
+**Split:** routing tasks (score invocation decision) vs. execution tasks (score output quality).
+
+### Q3 — Rubric design
+**Q3a (structure):** shared core + per-agent extensions.
+**Q3b (cost/latency):** excluded until quality plateaus.
+**Q3c (weights):** evidence-based asymmetric — correctness +2.0, process +1.0, anti-patterns −1.5, verbosity −0.5. Rationale: Autorubric leniency asymmetry, MT-Bench reference-grounded correctness signal, GEPA Pareto shape.
+
+### Q4 — Judge configuration
+**Q4a (mode):** single-answer rubric now; add pairwise-with-swap at step 3.
+**Q4b (model):** Opus 4.7 + 3-shot verdict-balanced, no ensemble.
+**Q4c (bias mitigations):** all five (randomise criteria + exemplars, reference-based, swap-gated, identity-blind).
+**Q4d (calibration gate):** κ ≥ 0.6 primary / ≥ 0.4 secondary, 50-item sample, two disjoint passes.
+
+### Q5 — Execution substrate
+**Q5a:** Claude Agent SDK headless now, DSPy adapter layered on for step 3.
+**Q5b:** Python (pyproject.toml sibling; DSPy is Python-only).
+**Q5c:** Nested trajectory layout `runs/{timestamp}/{agent}/{task-id}/{meta.json, transcript.jsonl, score.json}` (Meta-Harness compatible).
+
+### Q6 — Storage & reporting
+**Q6a (location):** `.claude/eval/` (portable to other Claude Code projects).
+**Q6b (report sections):** Header / Leaderboard / Regressions / Reflective feedback digest / Calibration drift / Suggested edits.
+**Q6c (distribution):** local + GitHub Issue.
+
+### Q7 — Trigger cadence
+**Q7a:** Phased — manual only now → add PR-gate after κ gate → add nightly cron after step 3 activation.
+**Q7b:** PR gating is advisory-only, never blocking. Human veto preserved.
+**Q7c:** Single namespaced slash command `/eval <subcommand>`.
+
+### Q8 — Extension to commands and skills
+**Q8a:** Phased (agents → commands → skills); full design captured in the design doc.
+**Q8b (skills eval):** Pairwise A/B with swap (inherits step-3 judge stack).
+**Q8c (agent creation):** Describe in scope as Phase 4, defer implementation.
+
+### Q9 — Step 3 activation criteria
+**Q9a (stability):** Spearman ρ ≥ 0.9 across 3 reruns.
+**Q9b (mutation scope):** body-only first, then body + description, never model/tools.
+**Q9c (acceptance):** ≥+0.05 aggregate, no ≥0.1 regression on primary-axis criteria, held-out test split must also improve.
+**Q9d (rollback):** PR-for-review + shadow-eval on merge.
+**Q9e (budget):** 500 `max_metric_calls` per agent per session (~$40/agent).
+**Q9f (auto-disable):** both triggers (κ drift + ≥3 merged-then-reverted mutations).
+
+---
+
+## 4. How to re-run the research
+
+### Via `web-research` (recommended — multi-source synthesis task)
+
+Launch the agent with the **verbatim prompt in §1** above. Target output: the same 5-section structured briefing with inline citations. Compare against §2 along these axes:
+
+| Axis | Check |
+|---|---|
+| **Coverage** | Are all 5 sections returned? Are key facts (Meta-Harness Table 3 ablation, GEPA's 32→89% gain, MT-Bench position bias 65%, Autorubric κ methodology, Anthropic sub-agent description pattern) present? |
+| **Citation discipline** | New agent's citation contract is binary. Count uncited claims — target: 0. Old agent's output has ~6 claims that are quoted-but-not-linked. |
+| **Publication dates** | New agent's contract mandates dates per source. Old output includes some (arxiv IDs, NeurIPS 2023, ICLR 2026) but not consistently. |
+| **Conflicts section** | Old output has none (no source disagreements surfaced). New agent should explicitly emit "## Conflicts" or note its absence. |
+| **Length** | Old output is ~2,700 words. New agent cap is 800 unless "deep dive" requested. This prompt is a deep-dive — either raise the cap via caller instruction or compare at 800 for fidelity-per-word. |
+| **Telemetry** | Old: 43,356 tokens, 18 tool uses, ~7m 45s. Compare against new agent run. |
+
+### Via `web-lookup` (partial comparison — NOT the same task)
+
+`web-lookup` is scoped to single-fact queries — this prompt is out of scope. But you can sample the five most fact-like sub-questions and run each independently:
+
+1. "What is Meta-Harness's reported TerminalBench-2 pass rate on Opus 4.6 vs Haiku 4.5?"
+2. "What Pareto frontier win does GEPA claim over GRPO in the ICLR 2026 paper?"
+3. "What position-bias consistency rate did GPT-4 show in MT-Bench, and what dropped it to what?"
+4. "What does Anthropic's sub-agent doc recommend for encouraging proactive delegation?"
+5. "What is Autorubric's aggregation formula?"
+
+Compare each answer against the corresponding fact in §2. Target: all five exact-match on the core number/quote.
+
+### Success criteria for the split
+
+The split is a success if:
+
+- `web-research` produces **equal or better** coverage on the full prompt (§1), with stricter citation discipline and explicit conflict/gap surfacing.
+- `web-lookup` produces the five sub-facts in <60 seconds each, at lower token cost than the old agent's per-fact share.
+- Combined cost of (one `web-research` run + five `web-lookup` runs) is comparable to or lower than the old single-agent run (43K tokens).
+
+If `web-research` drops coverage or `web-lookup` fabricates citations, flag the regression — it means the split went too aggressive on scoping or budget.
+
+---
+
+## 5. Files changed in this session
+
+| File | Change |
+|---|---|
+| `.claude/agents/web-search-researcher.md` | **Deleted** |
+| `.claude/agents/web-lookup.md` | **Created** — haiku, tight budget, context7-first |
+| `.claude/agents/web-research.md` | **Created** — opus, deep synthesis, context7-first with fallback |
+| `.claude/commands/brainstorm.md:23` | Updated agent references from `web-search-researcher` to `web-lookup` / `web-research` |
+| `thoughts/designs/2026-04-21-sub-agent-eval-pipeline.md` | **Created** — full design doc |
+| `thoughts/research/2026-04-21-sub-agent-eval-pipeline-transcript.md` | **Created** — this file |
+
+Stale historical references to `web-search-researcher` remain intact in:
+
+- `thoughts/plans/2026-02-02-skills-adoption.md`
+- `thoughts/designs/2026-01-20-claude-code-github-actions.md`
+
+These are timestamped records of prior decisions, not live routing instructions — left unchanged on purpose.

--- a/thoughts/research/2026-04-21-web-research-agent-iteration-transcript.md
+++ b/thoughts/research/2026-04-21-web-research-agent-iteration-transcript.md
@@ -1,0 +1,204 @@
+# Session Transcript — `web-research` Agent Iteration
+
+**Date:** 2026-04-21
+**Purpose:** Iteratively improve the new `web-research` sub-agent until it matches or exceeds the old `web-search-researcher` agent on the sub-agent eval pipeline brainstorm prompt (see `thoughts/research/2026-04-21-sub-agent-eval-pipeline-transcript.md`).
+**Companion files:**
+- `thoughts/research/2026-04-21-sub-agent-eval-pipeline-transcript.md` — original brainstorm + old agent output (baseline)
+- `thoughts/designs/2026-04-21-sub-agent-eval-pipeline.md` — design artefact grounded in that baseline
+- `.claude/agents/web-research.md` — target agent (iterated across this session)
+- `.claude/agents/web-lookup.md` — companion fast-lookup agent (also modified)
+
+---
+
+## 1. Session goal
+
+The old `web-search-researcher` agent was deleted earlier and replaced with two scoped agents: `web-lookup` (fast single-fact) and `web-research` (multi-source synthesis). The first `web-research` run regressed vs the old agent on coverage (missing Autorubric, DeepEval metric class names, GEPA real-world gains, Anthropic sub-agent frontmatter details).
+
+This session diagnoses each regression, applies minimal generic edits to `web-research.md` (the agent must remain project-neutral), and reruns the research prompt after each edit to measure whether the gap closed.
+
+The prompt used for every run is the 5-section eval-pipeline research briefing verbatim from `thoughts/research/2026-04-21-sub-agent-eval-pipeline-transcript.md` §1.
+
+---
+
+## 2. Runs — telemetry summary
+
+| Run | Agent state | Tokens | Tool uses | Duration | Output words |
+|---|---|---|---|---|---|
+| **Old** | `web-search-researcher` (sonnet, no context7, length unrestricted) | 43,356 | 18 | 7m 45s | ~2,700 |
+| **#1** | `web-research` v1: opus + mandatory context7-first + 800w cap | 65,068 | 19 | 3m 38s | ~1,400 |
+| **#2** | v2 edits: sonnet, context7 removed, adaptive word cap | 28,232 | 11 | 6m 30s | ~2,100 |
+| **#3** | v3 edits: + advisory "project-specific claims" branch | 36,277 | 14 | 5m 10s | ~2,200 |
+| **#4** | v4 edits: + mandatory README extraction branch | 29,391 | 13 | 3m 02s | ~2,400 |
+| **#5** | v5 state: **opus + `effort: max`** (manually toggled by user) | 60,543 | 18 | 4m 36s | ~2,900 |
+
+---
+
+## 3. Edits applied to `.claude/agents/web-research.md`
+
+Each edit targeted a specific regression observed in the preceding run. All edits remained generic (no GEPA-, Autorubric-, or design-doc-specific language).
+
+### Edit set A — applied after run #1 diagnosis (produced run #2)
+
+1. **`model: opus → sonnet`.** Web research is extraction-shaped, not reasoning-shaped; opus was 2–5× more expensive per token with no measurable quality gain and added verbose internal deliberation.
+2. **Removed context7 tools and mandatory "context7 first" policy.** Replaced with a "Library-docs delegation" section stating the agent does *not* handle API/syntax/config questions — those go to `web-lookup`. This eliminated the premature-satisfaction bias where context7's API-doc hits made the agent mark a topic "covered" before reading the paper/README deeply.
+3. **Adaptive length budget.** Default cap stays 800 words, but an explicit caller target ("~2000 words", "deep dive") uses the target instead; prompts with ≥4 numbered sub-sections raise to 400w per section. Closed the regression where the prompt's "Target ~1500-2500 words" was ignored and the agent compressed to ~1,400.
+
+### Companion edits to `.claude/agents/web-lookup.md`
+
+Since `web-research` no longer handles library docs, `web-lookup` became the primary library-docs surface:
+1. **`model: haiku → sonnet`.** Its scope expanded from pure single-fact to "read a doc page and faithfully extract the right three lines" — haiku was marginal for that.
+2. **Description broadened** to explicitly mention library API/config/syntax + positioned as a parallel helper for `web-research` syntheses that need factual anchors.
+
+### Edit set B — applied after run #2 diagnosis (produced run #3)
+
+Added **"For project-specific claims"** branch to Search strategy (advisory version):
+> For any topic that has both a paper and an implementation repo, fetch **both**, even if the paper alone appears to satisfy the prompt. Papers carry methodology and controlled-baseline numbers; READMEs carry real-world gain claims often absent from the paper.
+
+### Edit set C — applied after run #3 diagnosis (produced run #4)
+
+Tightened the project-claims branch from advisory to **mandatory verbatim extraction**:
+> For any topic that has both a paper/preprint AND an implementation repo, you **must** fetch the repo README (and the landing page / launch blog post if one exists) in addition to the paper. Extract any quantified real-world gain claims **verbatim** (e.g. "X% → Y% on benchmark Z"). Treat the README fetch as non-optional for this source type — not a "fetch if the paper is insufficient" fallback.
+
+### User-applied change — between run #4 and run #5
+
+User manually set `model: opus` and `effort: max` on the agent.
+
+---
+
+## 4. Coverage evolution (key facts, compressed)
+
+✅ = present; ❌ = missing; ⚠️ = partial/displaced; **bold** = new finding not in old agent.
+
+| Fact | Old | #1 | #2 | #3 | #4 | #5 |
+|---|---|---|---|---|---|---|
+| Meta-Harness Table 3 ablation (50.0 / 34.6) | ✅ | ✅ | ⚠️ | ⚠️ | ✅ | ✅ (+34.9 summary baseline) |
+| Meta-Harness 500× context ratio | ✅ | ✅ | ✅ | ⚠️ | partial | ✅ |
+| **Meta-Harness Appendix A.2 proposer behaviour** | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ |
+| **Meta-Harness file access stats (median 82)** | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ |
+| GEPA algorithm (5-step or 6-step loop) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| GEPA vs GRPO / MIPROv2 numbers | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| GEPA DSPy metric signature `{score, feedback}` | ✅ | ✅ | ❌ | ✅ | partial | partial |
+| GEPA AIME 46.6→56.6 | ✅ | ❌ | ❌ | ❌ | ✅ | ✅ |
+| GEPA ARC-AGI 32→89 | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ |
+| GEPA MATH 67→93 | ❌ | ❌ | ❌ | ❌ | ✅ | — |
+| GEPA 90× cost reduction vs Opus | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ |
+| **GEPA 35× faster than RL** | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ |
+| **GEPA "works with as few as 3 examples"** | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ |
+| **GEPA production uses (Shopify/Databricks/OpenAI/Pydantic)** | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ |
+| **`GEPAAdapter` API surface + code example** | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ |
+| **Built-in adapters list** | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ |
+| **GEPA v0.1.1 release date + stars** | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ |
+| Autorubric (criteria types + aggregation) | ✅ | ❌ | ✅ | ❌ | ⚠️ flagged | ❌ **still missing** |
+| DeepEval agent-specific metrics | ✅ named | ❌ | partial | partial | ✅ | ✅ |
+| **Ragas Tool Call / Agent Goal Accuracy** | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ |
+| Braintrust CI/CD | ✅ | ❌ | ✅ | ✅ | ✅ | ✅ |
+| Inspect AI primitives | ✅ | ✅ | ✅ | ⚠️ gap | ✅ | ✅ + adoption note |
+| **inspect_evals 200+ prebuilt** | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ |
+| **autoresearch disambiguation (3 distinct projects)** | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ |
+| MT-Bench position bias (65% / 23.8% / 46.2%) | ✅ | ✅ | ❌ | ⚠️ IJCNLP | ❌ | ✅ |
+| MT-Bench verbosity (91.3% / 8.7%) | ✅ | ✅ | ❌ | ❌ | ❌ | ✅ |
+| MT-Bench self-enhancement (+10% / +25%) | ✅ | ✅ | ❌ | ❌ | ❌ | ✅ |
+| **MT-Bench math grading (70% / 30% / 15%)** | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ |
+| Few-shot consistency 65% → 77.5% | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ |
+| **Length bias mitigations (length-norm, conciseness dim)** | partial | ❌ | ❌ | ❌ | ❌ | ✅ |
+| **Reference-guided 4× cost multiplier** | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ |
+| **Position Bias paper arXiv:2602.02219** (2026) | ❌ | ❌ | ❌ | ❌ | ✅ | — |
+| **10-permutation balanced rotation mitigation** | ❌ | ❌ | ❌ | ❌ | ✅ | — |
+| Cohen's κ / Krippendorff's α | ✅ | ❌ | ✅ | ❌ | ❌ | ✅ |
+| Anthropic description pattern | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| **Canonical description pattern (role + proactively + trigger)** | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ strongest |
+| Tool scoping precedence (allowlist/denylist) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| **Tool scoping framed as security boundary** | partial | ❌ | ❌ | ❌ | ✅ | ⚠️ dropped |
+| Model resolution order | ✅ | ❌ | ✅ | ✅ | ✅ | ✅ |
+| Built-in model assignments | ✅ | partial | ✅ | ✅ | ✅ | ✅ |
+| `isolation: worktree` field | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ |
+| **Full frontmatter field enumeration (all 16)** | partial | partial | ✅ | ✅ | ✅ | ✅ |
+| **Sub-agent transcript JSONL path** | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ |
+| **"Subagents cannot spawn sub-agents" constraint** | ✅ | ❌ | ✅ | ✅ | ✅ | ✅ explicit impl. |
+| **Anthropic agent feedback loop quote** | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ |
+| **Anthropic rules-based feedback quote** | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ |
+| Explicit Conflicts section | ❌ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Explicit Gaps section | ❌ | ✅ | ✅ | ✅ | ✅ | ✅ |
+
+---
+
+## 5. Diagnoses that drove each edit
+
+### Run #1 → Edit set A
+Three independent causes of the regression, ranked:
+1. **Word cap acting as ceiling.** The prompt's "Target ~1500-2500 words" was treated as a limit rather than authorization to exceed the 800-word default.
+2. **Mandatory context7-first policy** steered the agent toward API-doc-shaped sources for paper-shaped questions (GEPA gains, Autorubric methodology). Context7 returns API docs with a "satisfied" signal.
+3. **`model: opus` overkill** — web research is extraction-shaped; opus cost 50% more tokens without quality benefit.
+
+### Run #2 → Edit set B
+Diagnosis: **no search-strategy branch covered "project-level claims."** Existing branches (library/API docs, best-practices, comparisons, technical solutions) all sent the agent to papers or official domains. GEPA's 32→89% and 55→82% claims live in the `gepa-ai/gepa` README — adjacent to the search path but never landed on.
+
+### Run #3 → Edit set C
+Diagnosis: the advisory branch *allowed* fetching the README but the agent still treated the paper as satisfying. Headline numbers were either not extracted or extracted but not quoted. Tightened to mandatory verbatim extraction with explicit "not a fallback" framing.
+
+### Run #4 → (user toggled opus + effort:max)
+Diagnosis: the mandatory-README edit fired correctly (AIME 46.6→56.6, MATH 67→93, 90× cost recovered) but partial — ARC-AGI and coding-agent numbers were still missed, suggesting the agent opened the README and extracted only some of the headline claims. User's hypothesis was that a stronger model with max effort would extract more completely.
+
+### Run #5 — result
+Hypothesis confirmed: opus + effort:max recovered ARC-AGI 32→89, picked up production-uses, 35× faster than RL, 3-examples minimum, full `GEPAAdapter` API with code example, sub-agent JSONL transcript path, and Anthropic blog's agent feedback loop quote. Cost doubled vs run #4 (60K vs 29K tokens) but coverage dramatically expanded.
+
+---
+
+## 6. Final state of `.claude/agents/web-research.md`
+
+As of end-of-session, post user toggle:
+- `model: opus`
+- `effort: max` (manually applied by user)
+- Tools: `WebSearch, WebFetch, TodoWrite, Read, Grep, Glob, LS` (no context7)
+- Library-docs delegation section redirecting to `web-lookup`
+- Adaptive length cap (caller targets / ≥4 sub-sections → raised)
+- Search strategy includes "For project-specific claims" mandatory-README branch
+- Mandatory Conflicts / Gaps / Sources output sections
+
+## Final state of `.claude/agents/web-lookup.md`
+- `model: sonnet` (upgraded from haiku)
+- Description broadened to include library docs + parallel-helper role
+- context7 retained as primary library-docs surface
+
+---
+
+## 7. Known remaining gaps (to inform design-doc review)
+
+Fed into the design doc at `thoughts/designs/2026-04-21-sub-agent-eval-pipeline.md`, these are findings either present in run #5 that weren't in the original baseline, OR still missing from run #5 vs the old agent:
+
+### Present in run #5 but not in original baseline — worth adding to the design
+1. **`GEPAAdapter` interface** (`evaluate()` + `make_reflective_dataset()`) — a concrete Python API surface we can implement against directly. More actionable than the design doc's current abstract metric-function description.
+2. **Sub-agent transcript JSONL path** (`~/.claude/projects/{project}/{sessionId}/subagents/agent-{agentId}.jsonl`) — native Claude Code artefact the eval pipeline can read without custom capture plumbing. Design currently assumes we need to build a custom trace capture layer.
+3. **"Subagents cannot spawn sub-agents" constraint** — the eval harness cannot itself be a sub-agent (must be a main-session orchestrator or a skill). Design Q8 (slash command `/eval <subcommand>`) is consistent with this constraint but the reasoning wasn't documented.
+4. **`isolation: worktree` frontmatter field** — directly useful for sandboxed eval runs. Design Q5c (trajectory layout) didn't consider this.
+5. **Built-in `GEPAAdapter` variants** (`DSPyFullProgramAdapter`, `GenericRAGAdapter`, `ConfidenceAdapter`, `MCPAdapter`, `DefaultAdapter`) — our sub-agent evaluator could start from `DefaultAdapter` rather than rolling custom.
+6. **GEPA production-uses list** (Shopify, Databricks, OpenAI, Pydantic) — raises the confidence level of the "Step 3 activation" decision. Design Q9 budget (500 metric calls, ~$40/agent) can be cross-checked against community reports.
+7. **Anthropic agent feedback-loop principle** ("gather context → take action → verify work → repeat") and rules-based feedback ("The best form of feedback is providing clearly defined rules for an output, then explaining which rules failed and why") — aligns with the design's pairwise-with-swap + analytic rubric direction but gives Anthropic-authoritative framing to cite.
+8. **Ragas Tool Call Accuracy / Agent Goal Accuracy** metrics — named prior-art for two rubric dimensions the design calls "description routing accuracy" and "end-to-end task success." Worth citing.
+9. **Inspect AI `dataset → Task → Solver → Scorer` primitives** — the design's "execution substrate" (Q5) uses Claude Agent SDK headless + DSPy adapter; Inspect AI's primitives are a named mental model we could align vocabulary with.
+10. **Meta-Harness Appendix A.2 proposer behaviour** (reads median 82 files/iteration, 41% harness code, 40% traces, non-Markovian patterns, diagnostic pivot after 6 failures) — concrete evidence for the "filesystem-as-memory" pattern the design Q5c adopts. Can be cited as empirical support.
+11. **Position Bias 2026 paper (arXiv:2602.02219) 10-permutation rotation mitigation** (from run #4, not run #5) — more recent and more rigorous than MT-Bench 2023's 2× swap mitigation. Design Q4c "swap-gated" is consistent but could be strengthened.
+12. **MT-Bench reference-guided 4× cost multiplier** — named trade-off for Q4c (reference-based scoring). Currently the design treats reference-guided as free.
+13. **MT-Bench math grading failure rates** (default 70% / CoT 30% / reference-guided 15%) — quantified evidence for CoT + reference-guided rubric design.
+
+### Still missing in run #5 (needs targeted follow-up)
+1. **Autorubric (arXiv:2603.00077)** — flagged as a gap by run #5. The design doc's rubric weight rationale (Q3c: correctness +2.0, process +1.0, anti-patterns −1.5, verbosity −0.5) cites Autorubric's leniency asymmetry. If future runs drop Autorubric, the rationale chain breaks. **Action:** a targeted `web-lookup` against `arxiv:2603.00077` to extract the weight formula verbatim for permanent citation.
+2. **GEPA coding agent 55→82% claim** — in the old agent's output but not in run #5. Lower priority than Autorubric.
+3. **Full GEPA Algorithm 1 pseudocode** — PDF-fetch only returned a summary. If the design's Step 3 GEPA integration needs it, a follow-up WebFetch of `arxiv.org/pdf/2507.19457` §3.
+
+### Methodology gaps (process-level)
+1. The iteration happened across 5 runs. Later runs sometimes displaced earlier findings (e.g. run #4 picked up Position Bias 2026 paper + 10-permutation mitigation; run #5 replaced with MT-Bench originals). No single run is a superset.
+   - **Implication:** a load-bearing design doc should cite the **union** across the old agent + best new runs, not rely on any single run as authoritative.
+2. The `web-research` agent's token/cost varies 2× between runs (29K–65K) for the same prompt. Non-determinism is real; re-running for a fresh perspective is cheap insurance.
+3. No run recovered Autorubric reliably — the fact is in arxiv search results but the agent consistently deprioritises it. Possible root cause: "Autorubric" is a paper name that sounds library-ish, which may trigger the library-docs-delegation redirect to `web-lookup`. Worth investigating in future if reliance on Autorubric increases.
+
+---
+
+## 8. Suggested next step
+
+Review `thoughts/designs/2026-04-21-sub-agent-eval-pipeline.md` against §7.1 (present but not in baseline) and §7.2 (still missing). For each item, decide:
+- **Integrate** — add to the design doc with a citation to run #5's output or the primary source
+- **Defer** — note as a known follow-up without changing the current design
+- **Discard** — not relevant to the locked scope
+
+Then run targeted `web-lookup` calls for §7.2 items (Autorubric at minimum) to fill the verified-gap rows.


### PR DESCRIPTION
## Context/Motivation

Two parallel workstreams that built on each other as the nurture feature was implemented:

1. **Nurture scheduler (ENG-132):** Without an automated scheduler, the message queue only fills when consultants manually trigger leads. This PR closes that gap by auto-starting stage-appropriate nurture sequences on lead create/update and running a Vercel Cron job daily to draft messages for due sequences.

2. **Claude harness improvements:** While working through ENG-132, several agent and tooling gaps surfaced (no dedicated web-research/lookup agents, git safety gaps in the heredoc-blocking script, missing E2E cleanup guardrails). These were fixed in the same branch.

## Description of Changes

### Nurture Scheduler (feat)

- **Scheduler** (`src/server/nurture/scheduler.ts`) — `runSchedulerTick` queries sequences where `nextStepAt <= now()`, drafts a message per sequence (sequential to amortise AI prompt-cache hits), inserts `pending` rows into `message_queue`, and advances `nextStepAt`. Errors log and advance anyway so a failing row never blocks the tick.
- **Auto-start wiring** (`leads.ts`) — `startOrUpdateSequence` called non-blockingly on `leadsRouter.create` and `.update`; failure logs but never blocks the lead operation. Cadence: `unqualified` → discovery/3d, `nurture` → nurture/14d, `warm` → warm_progression/7d. Hot leads auto-complete any active sequence.
- **tRPC router** (`nurture.ts`) — replaces the 7-line stub with `listActive`, `startSequence`, `pauseSequence`, `resumeSequence`.
- **Zod schemas** (`src/server/api/schemas/nurture.ts`) — typed input schemas for all mutations.
- **Cron route** (`GET /api/cron/nurture-scheduler`) — bearer-auth via `CRON_SECRET`, scheduled daily at 00:00 UTC in `vercel.json` (Hobby plan limit).
- **Dev helper** (`POST /api/dev/nurture/advance`) — backdates `nextStepAt` by 1 minute to trigger a tick without waiting; returns 404 in production.
- **AI stub** (`src/server/ai/stub.ts`) — deterministic draft function injected via `x-ai-stub: 1` header; enables E2E tests without calling the real AI.
- **DB migration** — partial unique index `nurture_active_one_per_lead_uidx ON (lead_id) WHERE status = 'active'` enforces one active sequence per lead at the DB level.
- **Env** — `CRON_SECRET` added to `src/env.js` (min 16 chars) and CI secrets.

### Claude Harness Improvements (chore)

- **New agents** — `web-lookup` (single-fact/library-docs, context7-first, 200-word cap) and `web-research` (deep multi-source synthesis, ≥3 sources, 800-word default cap, Opus model) replace the one-size-fits-all `web-search-researcher` for clearer routing.
- **`web-search-researcher`** — rewritten with hard contracts (citation, search budget, staleness, length budget), mandatory output format, and clear scope boundary vs the new agents.
- **`codebase-pattern-finder`** — upgraded from haiku to sonnet for better pattern extraction.
- **Git safety script** (`block-dangerous-git.sh`) — heredoc pattern detection improved; previously allowed dangerous commits when git args spanned multiple lines.
- **E2E cleanup skill** (`.claude/skills/tdd/e2e-cleanup.md`) — added as a TDD sub-file with per-spec cleanup, dotenv load order, flake double-run, and test data isolation rules.
- **CLAUDE.md** — added Vercel CLI section, Testing section, expanded E2E guardrails, and GitHub Actions note about dispatch triggers always running from `main`.
- **Makefile** — `vercel_link`, `env_pull`, `env_pull_preview` targets.
- **Command descriptors** — ultrathink prompts and routing hints tightened across `brainstorm`, `create_plan`, `describe_pr`, `implement_plan`, `iterate_plan`, `review_roadmap`, `validate_plan`, `write_ticket`.

## Testing Information

- [x] Unit tests pass (`make test`) — new suites: nurture schemas, scheduler, nurture router, cron route, leads auto-start, AI stub
- [x] `make check` passes (lint + typecheck)
- [ ] Integration tests pass (requires live Neon branch)
- [ ] Manual testing completed

**Test steps:**
1. `make check` — lint + typecheck
2. `make test` — unit tests (Rstest)
3. `make test_e2e` — Playwright E2E (`e2e/features/nurture-scheduler.spec.ts` covers auto-start, cron tick, pause/resume, hot-lead completion)
4. Manual: seed a lead, call `POST /api/dev/nurture/advance`, hit `GET /api/cron/nurture-scheduler` with the `CRON_SECRET` bearer token, confirm a `pending` row appears in `message_queue`

## Screenshots/Videos

N/A — no UI changes.

## Relevant Links

- Closes #132

## Breaking Changes

**BREAKING CHANGE:** `CRON_SECRET` env var is now required (minimum 16 characters). Vercel sets this automatically for cron routes; local `.env.local` must be re-pulled via `make env_pull` after this merges.
