### PR TITLE
ci(post-deploy): override commit status when verify is cancelled

### DIFF
--- a/.github/workflows/post-deploy.yml
+++ b/.github/workflows/post-deploy.yml
@@ -9,7 +9,7 @@ jobs:
   verify:
     name: Verify (${{ github.event.client_payload.environment }})
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 1
     permissions:
       contents: read
       actions: read
@@ -153,3 +153,29 @@ jobs:
             playwright-report/
             test-results/
           retention-days: 30
+
+  # Override the commit status when verify is cancelled (e.g. timeout).
+  # The Vercel post-status action reports `success` on cancellation, which
+  # masks failures on the PR. This job runs after verify completes and
+  # overwrites the commit status with `failure` so PR checks reflect reality.
+  override-cancelled-status:
+    name: Mark cancelled run as failed
+    needs: verify
+    if: ${{ always() && needs.verify.result == 'cancelled' }}
+    runs-on: ubuntu-latest
+    permissions:
+      statuses: write
+    steps:
+      - name: Post failure commit status
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SHA: ${{ github.event.client_payload.git.sha }}
+          REPO: ${{ github.repository }}
+          TARGET_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          gh api -X POST \
+            "repos/$REPO/statuses/$SHA" \
+            -f state=failure \
+            -f context="Post-Deploy Verification" \
+            -f description="Job cancelled (likely timeout)" \
+            -f target_url="$TARGET_URL"

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -18,11 +18,6 @@
       "sourceType": "github",
       "computedHash": "784f0dbb7403b0f00324bce9a112f715342777a0daee7bbb7385f9c6f0a170ea"
     },
-    "grill-me": {
-      "source": "mattpocock/skills",
-      "sourceType": "github",
-      "computedHash": "784f0dbb7403b0f00324bce9a112f715342777a0daee7bbb7385f9c6f0a170ea"
-    },
     "rstest-best-practices": {
       "source": "rstackjs/agent-skills",
       "sourceType": "github",


### PR DESCRIPTION
- The Vercel `repository-dispatch/actions/status@v1` post-hook reports `state: success` on cancelled runs, masking failures on PR Checks. Observed in https://github.com/samjmarshall/www/actions/runs/25092727032 — the verify job hit the 15-minute timeout mid-Playwright, but the post-hook still wrote `state: success` to the commit status.
- Add a dependent `override-cancelled-status` job that runs after `verify`. When `needs.verify.result == 'cancelled'`, it POSTs `state=failure` to the GitHub statuses API for the dispatch payload SHA. It runs after all of `verify`'s post-hooks complete, so it wins last-write on the commit status.
- Drive-by: remove duplicate `grill-me` entry in `skills-lock.json` (biome was blocking pre-commit on PR #162's leftover dupe).
- **Temporarily** set `timeout-minutes: 1` on the verify job to force a cancellation on the next preview deploy so we can validate the override path. Will revert (and likely bump above 15) once verified.