### PR TITLE
ci(post-deploy): restore timeout-minutes to 30

### DIFF
--- a/.github/workflows/post-deploy.yml
+++ b/.github/workflows/post-deploy.yml
@@ -9,7 +9,7 @@ jobs:
   verify:
     name: Verify (${{ github.event.client_payload.environment }})
     runs-on: ubuntu-latest
-    timeout-minutes: 1
+    timeout-minutes: 30
     permissions:
       contents: read
       actions: read


### PR DESCRIPTION
## Summary

- PR #164 temporarily set the verify job's `timeout-minutes` to 1 to validate the new `override-cancelled-status` job. That fix is confirmed working — see run [25101904701](https://github.com/samjmarshall/www/actions/runs/25101904701): `Verify` was cancelled at the 1-min cap, the override job ran, and the commit status on `1e9dcd5` is now `failure` (description "Job cancelled (likely timeout)") instead of the previous bogus `success`.
- Restore the timeout. Bumping to 30 (up from the original 15) — the previous 15-min cap was getting cancelled mid-Playwright around test 273 of 270+, so 15 wasn't enough headroom.