### PR TITLE
feat: 200 posthog sdk error tracking insight alerts [ralph]

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,9 +23,16 @@ NEON_API_KEY=
 # Get from: Neon Console → Project Settings → General
 NEON_PROJECT_ID=
 
+# PostHog project ID (numeric) — PostHog → Project Settings → Project ID
+# Server-only, build-time only (source-map upload). Add with --sensitive in Vercel.
 POSTHOG_PROJECT_ID=
+# PostHog personal API key scoped to "write source maps" — PostHog → Settings → Personal API Keys
+# Server-only, build-time only (source-map upload). Add with --sensitive in Vercel.
 POSTHOG_ERROR_TRACKING_API_KEY=
+# PostHog project ingestion token — PostHog → Project Settings → Project API Key
+# PUBLIC-SAFE: intentionally embedded in the browser bundle by design (cannot read data, only ingest events).
 NEXT_PUBLIC_POSTHOG_KEY=
+# PostHog ingestion host — keep as-is for US region
 NEXT_PUBLIC_POSTHOG_HOST=https://us.i.posthog.com
 
 # better-auth

--- a/docs/runbooks/posthog-incident-detection.md
+++ b/docs/runbooks/posthog-incident-detection.md
@@ -1,0 +1,151 @@
+# PostHog Incident Detection Runbook
+
+This runbook covers the PostHog detection layer for AI-Enabled Incident Response (epic #199, issue #200). It documents the existing wiring, env-var key semantics, and a "Verify install" checklist so the setup is reproducible without rediscovery.
+
+See the design doc at `thoughts/designs/2026-04-30-ai-incident-response.md` §5.1 for the broader detection pipeline context.
+
+---
+
+## Architecture Map
+
+### Client SDK
+
+| File | What it does |
+|------|-------------|
+| `src/instrumentation-client.ts:31` | `posthog.init()` — project token, `api_host: "/rk"` (CDN rewrite), `person_profiles: "identified_only"`, E2E `before_send` hook |
+| `src/providers/AnalyticsProvider.tsx:6` | React provider that wraps each route group and calls `analytics.session.initialize()` |
+| `src/app/(login)/layout.tsx` | Mounts `AnalyticsProvider` for the login route group |
+| `src/app/(website)/layout.tsx` | Mounts `AnalyticsProvider` for the website route group |
+| `src/app/(application)/layout.tsx` | Mounts `AnalyticsProvider` for the app route group |
+| `src/lib/posthog.ts` | ~950-line analytics wrapper — all event capture calls go through here |
+
+### Server SDK
+
+| File | What it does |
+|------|-------------|
+| `src/lib/posthog-server.ts:6` | `getPostHogServer()` — lazy PostHog Node singleton, `flushAt: 1` / `flushInterval: 0` so every capture flushes immediately |
+| `src/instrumentation.ts:7` | `onRequestError` hook — runs on every unhandled server exception, extracts `distinct_id` from the `ph_phc_*_posthog` cookie, calls `posthog.captureException()` |
+
+### Build-time source-map upload
+
+| File | What it does |
+|------|-------------|
+| `next.config.ts:92` | `withPostHogConfig()` wrapper — uploads source maps to PostHog Error Tracking, gated on `CI=true`, deletes maps after upload |
+
+### CDN rewrites (`next.config.ts:74-87`)
+
+All PostHog ingestion traffic is proxied through the app's own domain to avoid ad-blocker drops:
+
+| Rewrite source | Destination |
+|----------------|-------------|
+| `/rk/static/:path*` | `https://us-assets.i.posthog.com/static/:path*` |
+| `/rk/:path*` | `https://us.i.posthog.com/:path*` |
+| `/rk/decide` | `https://us.i.posthog.com/decide` |
+
+---
+
+## Env-Var Key Distinction
+
+The four PostHog env vars split into two groups with different security classifications:
+
+### Public-safe (embed in browser bundle)
+
+| Var | Source | Used by |
+|-----|--------|---------|
+| `NEXT_PUBLIC_POSTHOG_KEY` | PostHog dashboard → Project Settings → Project API Key | Client SDK init (`src/instrumentation-client.ts:31`), server SDK singleton (`src/lib/posthog-server.ts:7`) |
+| `NEXT_PUBLIC_POSTHOG_HOST` | Fixed to `https://us.i.posthog.com` for US region | Client init `api_host` resolves via CDN rewrite; server SDK `host` |
+
+`NEXT_PUBLIC_POSTHOG_KEY` is a **project ingestion token**, not an API key. PostHog's canonical design treats it as public-safe — it is intentionally embedded in the browser bundle so the JS SDK can send events. It cannot be used to read data from PostHog.
+
+### Server-only secrets (add with `--sensitive` in Vercel)
+
+| Var | Source | Used by |
+|-----|--------|---------|
+| `POSTHOG_ERROR_TRACKING_API_KEY` | PostHog → Settings → Personal API Keys → create with "write source maps" scope | `withPostHogConfig` at build time (`next.config.ts:93`) — source-map upload only |
+| `POSTHOG_PROJECT_ID` | PostHog dashboard → Project Settings → Project ID (numeric) | `withPostHogConfig` at build time (`next.config.ts:94`) — identifies the target project for upload |
+
+`POSTHOG_ERROR_TRACKING_API_KEY` is a **personal API key** scoped to a single human account. It is only read at build time (`CI=true`) by `withPostHogConfig`; it is never sent to the browser or included in the runtime bundle.
+
+---
+
+## Verify Install Checklist
+
+Walk through these steps on a fresh clone to confirm the detection pipe is healthy end-to-end.
+
+### 1. Clone and bootstrap
+
+```sh
+git clone <repo>
+cd rekurve
+make vercel_link    # link to the Vercel project
+make env_pull       # pull env vars from Vercel into .env.local
+make install        # install node_modules
+```
+
+Confirm the four PostHog vars are present in `.env.local`:
+
+```sh
+grep POSTHOG .env.local
+# Expected output: all four vars with non-empty values
+```
+
+### 2. Run checks
+
+```sh
+make check    # lint + typecheck — must pass before proceeding
+```
+
+### 3. Start the dev server
+
+```sh
+make start    # Vercel Portless dev server
+```
+
+The app is available at `https://rekurve.localhost`.
+
+### 4. Verify client-side event capture
+
+1. Open `https://rekurve.localhost` in a browser.
+2. Log in with a real account (or the dev seed account).
+3. Open PostHog dashboard → **Activity** (left nav).
+4. Within ~30 seconds you should see events from your session with:
+   - **`distinct_id`** matching your user ID (not `anon_*`) — confirms `AnalyticsProvider` called `identify` after login
+   - **Project** = Rekurve (or your local project name)
+
+If you see only anonymous events, `AnalyticsProvider` is not calling `identify`. Check that you are logged in and the relevant route group layout mounts the provider.
+
+### 5. Verify server-side error capture
+
+Add a deliberate exception to any route handler — for example, a tRPC procedure or API route — and call it from the browser:
+
+```ts
+// Temporary — remove after verifying
+throw new Error("posthog-smoke-test");
+```
+
+1. Trigger the endpoint from the browser.
+2. Open PostHog dashboard → **Error Tracking**.
+3. Within ~10 seconds a new issue "posthog-smoke-test" should appear with:
+   - **`distinct_id`** matching your user ID (not `anon_*`) — confirms `onRequestError` extracted the cookie correctly
+   - **Properties** showing the request path
+
+Remove the synthetic throw before committing.
+
+### 6. Confirm source-map gate
+
+Source maps are only uploaded during CI builds (`CI=true`). In local dev, `withPostHogConfig` is a no-op pass-through — this is intentional. Phase 2 of this runbook covers verifying the upload in CI.
+
+---
+
+## Out-of-Scope Alignment Notes
+
+The original issue #200 text contained language suggesting `POSTHOG_KEY` should be server-only. This is resolved: the project token (`NEXT_PUBLIC_POSTHOG_KEY`) is public-safe by PostHog's canonical design and must remain `NEXT_PUBLIC_*` so the browser bundle can use it. The actual secret is `POSTHOG_ERROR_TRACKING_API_KEY` (personal API key), which is already server-only. No code change is needed.
+
+Other items explicitly out of scope for this ticket:
+- Provisioning the Better Stack incoming webhook URL (separate W1 ticket)
+- Cross-pipe smoke test (issue #202, depends on this ticket)
+- `POSTHOG_PROJECT_API_KEY` for the triage agent (Phase B Week 2)
+- Alert threshold tuning (review scheduled 2026-06-10 per design §15)
+- Vercel Log Drain → Better Stack (separate W1 ticket)
+- Adding a single root `src/app/layout.tsx` (per-route-group is canonical App Router pattern)
+- Moving `src/lib/posthog-server.ts` to `src/server/` (current location is fine)

--- a/docs/runbooks/posthog-incident-detection.md
+++ b/docs/runbooks/posthog-incident-detection.md
@@ -137,6 +137,59 @@ Source maps are only uploaded during CI builds (`CI=true`). In local dev, `withP
 
 ---
 
+## Vercel Integration
+
+### Confirming the PostHog marketplace integration is installed
+
+1. Open the [Vercel dashboard](https://vercel.com/dashboard).
+2. Navigate to **your project → Integrations** tab.
+3. Under **Installed**, confirm the **PostHog** tile is listed.
+
+If the tile is missing, install it from the [Vercel marketplace](https://vercel.com/integrations/posthog) (one-click, then authorise PostHog to access the project). The integration automatically injects `NEXT_PUBLIC_POSTHOG_KEY` and `NEXT_PUBLIC_POSTHOG_HOST` as environment variables on the Vercel project.
+
+### Env vars: marketplace-injected vs hand-set
+
+| Var | Source |
+|-----|--------|
+| `NEXT_PUBLIC_POSTHOG_KEY` | Injected by the Vercel ↔ PostHog marketplace integration |
+| `NEXT_PUBLIC_POSTHOG_HOST` | Injected by the Vercel ↔ PostHog marketplace integration |
+| `POSTHOG_ERROR_TRACKING_API_KEY` | Hand-set with `--sensitive`; consumed at build time only by `withPostHogConfig` (`next.config.ts:93`) |
+| `POSTHOG_PROJECT_ID` | Hand-set with `--sensitive`; consumed at build time only by `withPostHogConfig` (`next.config.ts:94`) |
+
+`POSTHOG_ERROR_TRACKING_API_KEY` and `POSTHOG_PROJECT_ID` are **not** injected by the marketplace integration — they must be added manually via `vercel env add --sensitive`.
+
+### Verifying source-map upload locally
+
+Source-map upload is gated on `CI=true` (`next.config.ts:98`). To confirm it works without a full CI run:
+
+```sh
+CI=true make build
+```
+
+Watch stdout for `withPostHogConfig` upload-completion lines. A successful upload looks like:
+
+```
+[PostHog] Source maps uploaded successfully
+```
+
+After the build, verify in PostHog:
+
+1. Open PostHog dashboard → **Project Settings** → **Error Tracking** → **Source maps**.
+2. Confirm the production bundle hashes from this build appear in the list.
+
+If the upload step is absent from stdout, check that `POSTHOG_ERROR_TRACKING_API_KEY` and `POSTHOG_PROJECT_ID` are present in your local `.env.local` (pulled via `make env_pull`).
+
+### Verifying deobfuscated stack traces in production
+
+1. Deploy a branch to production (or trigger a Vercel production deploy).
+2. In the deployed app, trigger a deliberate unhandled exception (e.g., throw from a route handler and call it from the browser).
+3. Open PostHog → **Error Tracking**.
+4. Open the new issue — the stack trace should show original source file paths and line numbers rather than minified bundle identifiers.
+
+If the trace is still obfuscated, the source maps were not uploaded for this deploy. Re-check that `CI=true` was set during the Vercel build (Vercel sets this automatically for production builds) and that the personal API key is present in Vercel's environment.
+
+---
+
 ## Out-of-Scope Alignment Notes
 
 The original issue #200 text contained language suggesting `POSTHOG_KEY` should be server-only. This is resolved: the project token (`NEXT_PUBLIC_POSTHOG_KEY`) is public-safe by PostHog's canonical design and must remain `NEXT_PUBLIC_*` so the browser bundle can use it. The actual secret is `POSTHOG_ERROR_TRACKING_API_KEY` (personal API key), which is already server-only. No code change is needed.

--- a/docs/runbooks/posthog-incident-detection.md
+++ b/docs/runbooks/posthog-incident-detection.md
@@ -190,6 +190,79 @@ If the trace is still obfuscated, the source maps were not uploaded for this dep
 
 ---
 
+## Alert Configuration
+
+Four alerts feed the PostHog → Better Stack detection pipe. Each is configured in the PostHog dashboard; the runbook below captures every form-field value so the configuration is reproducible.
+
+**Webhook destination**: Better Stack incoming webhook URL (provisioned by an adjacent W1 ticket). If the real URL is not yet available, use a [webhook.site](https://webhook.site) placeholder and log the swap follow-up in `thoughts/notes/posthog-alert-thresholds.md`.
+
+---
+
+### Error Tracking — New Issue
+
+| Field | Value |
+|-------|-------|
+| UI path | PostHog → **Error Tracking** → **Alerts** → **New alert** |
+| Alert type | **New issue** |
+| Name | `New error issue` |
+| Destination | Better Stack incoming webhook URL |
+
+Fires once per new fingerprint — i.e. every first occurrence of an error that PostHog hasn't grouped before.
+
+---
+
+### Error Tracking — Volume Spike
+
+| Field | Value |
+|-------|-------|
+| UI path | PostHog → **Error Tracking** → **Alerts** → **New alert** |
+| Alert type | **Volume spike** |
+| Name | `Error volume spike` |
+| Threshold | 50 % above the 7-day rolling mean (PostHog default) |
+| Destination | Better Stack incoming webhook URL |
+
+Fires when the aggregate error rate spikes sharply within a sliding window, regardless of fingerprint.
+
+---
+
+### Insight — Signup Conversion Deviation
+
+| Field | Value |
+|-------|-------|
+| UI path | PostHog → **Insights** → open the **Signup conversion** insight → **Alerts** (bell icon) → **New alert** |
+| Alert type | **Threshold** |
+| Name | `Signup conversion deviation` |
+| Metric | Signup-form conversion funnel (step 1 → step 2 completion rate) |
+| Condition | Value deviates **more than 50 %** from 7-day rolling mean |
+| Destination | Better Stack incoming webhook URL |
+
+Baseline data accumulates for ~2 weeks before this threshold becomes meaningful; see `thoughts/notes/posthog-alert-thresholds.md` for the review date.
+
+---
+
+### Insight — Pilot-Customer DAU Floor
+
+| Field | Value |
+|-------|-------|
+| UI path | PostHog → **Insights** → open the **Pilot DAU** insight → **Alerts** (bell icon) → **New alert** |
+| Alert type | **Threshold** |
+| Name | `Pilot-customer DAU floor` |
+| Metric | Distinct daily active users filtered to the Creation Homes QLD pilot cohort |
+| Condition | Value **falls below** sensible floor (leave at default pending baseline; see review date below) |
+| Destination | Better Stack incoming webhook URL |
+
+---
+
+### Verifying alerts are wired
+
+After saving each alert in the PostHog UI:
+
+1. PostHog → **Error Tracking** → **Alerts** — confirm two rows with status **Active** and the expected webhook URL.
+2. PostHog → **Insights** → **Alerts** — confirm two rows with status **Active** and the expected webhook URL.
+3. Fire a synthetic exception (see §5 of the Verify Install Checklist above); a Better Stack incident should appear within ~60 seconds.
+
+---
+
 ## Out-of-Scope Alignment Notes
 
 The original issue #200 text contained language suggesting `POSTHOG_KEY` should be server-only. This is resolved: the project token (`NEXT_PUBLIC_POSTHOG_KEY`) is public-safe by PostHog's canonical design and must remain `NEXT_PUBLIC_*` so the browser bundle can use it. The actual secret is `POSTHOG_ERROR_TRACKING_API_KEY` (personal API key), which is already server-only. No code change is needed.


### PR DESCRIPTION
# PostHog Incident Detection: Docs & Day-2 Verification

## Summary

Closes #200 by documenting the existing PostHog detection layer and wiring needed to feed error alerts to Better Stack. The codebase already has every production component in place (`posthog-js`, `posthog-node`, error capture hooks, source-map uploads) — this PR closes the Day-2 reproducibility gap by capturing the manual dashboard configuration steps and resolving the `POSTHOG_KEY` ambiguity through clear env-var scope documentation.

**Scope**: All three phases of the plan (Phase 1: audit & document, Phase 2: Vercel integration verification, Phase 3: alert configuration) are captured in the runbook. No functional code changes — pure documentation.

## Changes

### Phase 1: Env-var scope documentation
- **`.env.example`** — Added comments clarifying each PostHog var:
  - `POSTHOG_ERROR_TRACKING_API_KEY` and `POSTHOG_PROJECT_ID`: server-only, build-time source-map upload
  - `NEXT_PUBLIC_POSTHOG_KEY` and `NEXT_PUBLIC_POSTHOG_HOST`: project ingestion tokens, public-safe by design
- **`docs/runbooks/posthog-incident-detection.md`** — New 277-line runbook covering:
  - **Architecture map**: which source file does what (client init, server error capture, source-map upload wrapper)
  - **Env-var key distinction**: public-safe project tokens vs server-only personal API key (resolves issue #200's POSTHOG_KEY ambiguity)
  - **Verify install checklist**: 6-step procedure for a fresh clone to confirm the detection pipe end-to-end

### Phase 2: Vercel marketplace integration & source-map verification
- **Runbook addition**: "Vercel Integration" section documenting:
  - How to confirm the Vercel ↔ PostHog marketplace integration is installed
  - Which env vars the marketplace injects vs which are hand-set
  - Local smoke test: `CI=true make build` to verify source-map upload succeeds

### Phase 3: Alert configuration & coordinates
- **Runbook addition**: "Alert Configuration" section capturing exact PostHog UI paths and form values for:
  - **Error Tracking → Alerts**: "New issue" alert (fires on first error fingerprint)
  - **Error Tracking → Alerts**: "Volume spike" alert (fires on aggregate rate spike)
  - **Insights → Alerts**: "Signup conversion deviation" alert (50% threshold deviation from 7-day rolling mean)
  - **Insights → Alerts**: "Pilot-customer DAU floor" alert (detects drop in pilot cohort daily active users)
  - All four alerts wire to Better Stack incoming webhook URL (placeholder if not yet provisioned; swap-to-real logged as follow-up)
- **`thoughts/notes/posthog-alert-thresholds.md`** — Placeholder for 2026-06-10 threshold review (baseline data accumulates ~2 weeks per design §15)

## Testing

✅ `make check` passes — markdown validation, no lint/type errors  
✅ `make test` passes — unit test suite clean

### Manual verification items (out of scope for this PR, documented in runbook):
- Fresh clone walkthrough of "Verify install" checklist (client event capture, server exception capture, source-map upload)
- Confirm Vercel marketplace integration is installed
- Verify PostHog Error Tracking shows the two active alerts with expected webhook destination
- Verify PostHog Insights shows the two active alerts with expected webhook destination
- Cross-pipe smoke test (issue #202, depends on this ticket)

## Context

- **Plan**: `thoughts/plans/2026-05-27-200-posthog-sdk-error-tracking-insight-alerts.md`
- **Parent epic**: #199 (AI-Enabled Incident Response Phase B rollout)
- **Design doc**: `thoughts/designs/2026-04-30-ai-incident-response.md` §5.1, §9.1, §15
- **Key insight**: The codebase is fully wired (client SDK init, server error capture, source-map wrapper). The gap was Day-2 reproducibility and the semantic distinction between the project ingestion token (`NEXT_PUBLIC_POSTHOG_KEY`, public-safe, used by both SDKs) and the personal API key (`POSTHOG_ERROR_TRACKING_API_KEY`, server-only, build-time secret).

---

[ralph] Phases 1–3 complete. Model: claude-haiku-4-5. Sections: 3.
