### PR TITLE
refactor(leads): extract intake orchestration into src/server/leads/intake.ts

### DIFF
--- a/src/server/api/__tests__/leads-router.test.ts
+++ b/src/server/api/__tests__/leads-router.test.ts
@@ -56,7 +56,6 @@ beforeEach(() => {
     }),
   }));
 
-  // Build a mock db — methods are configured per test
   mockDb = {
     insert: rs.fn(),
     update: rs.fn(),
@@ -70,88 +69,12 @@ beforeEach(() => {
     },
   };
 
-  // Default chainable mock for db.update used by synchronous re-scoring in
-  // create/update. Tests can override this by calling mockReturnValue again.
-  const defaultUpdateReturning = rs.fn().mockResolvedValue([mockLead]);
-  const defaultUpdateWhere = rs
-    .fn()
-    .mockReturnValue({ returning: defaultUpdateReturning });
-  const defaultUpdateSet = rs
-    .fn()
-    .mockReturnValue({ where: defaultUpdateWhere });
-  (mockDb.update as ReturnType<typeof rs.fn>).mockReturnValue({
-    set: defaultUpdateSet,
-  });
-
   rs.doMock("~/server/db", () => ({ db: mockDb }));
 
-  rs.doMock("~/server/scoring", () => ({
-    qualifyAndScore: rs.fn().mockReturnValue({
-      score: 45,
-      stage: "nurture",
-      breakdown: {
-        land: { score: 15, maxScore: 30, reasoning: "test" },
-        finance: { score: 15, maxScore: 25, reasoning: "test" },
-        timeline: { score: 12, maxScore: 20, reasoning: "test" },
-        budget: { score: 0, maxScore: 10, reasoning: "test" },
-        propertyType: { score: 3, maxScore: 10, reasoning: "test" },
-        engagement: { score: 0, maxScore: 5, reasoning: "test" },
-      },
-      gaps: [],
-      nextQuestion: "test question",
-    }),
-  }));
-
-  rs.doMock("~/server/nurture/scheduler", () => ({
-    startOrUpdateSequence: rs.fn().mockResolvedValue(undefined),
-  }));
-
-  rs.doMock("~/server/hubspot", () => ({
-    findExistingContact: rs.fn().mockResolvedValue(null),
-    createContact: rs.fn().mockResolvedValue({
-      id: "hs-123",
-      properties: {},
-      createdAt: "2026-01-01T00:00:00.000Z",
-      updatedAt: "2026-01-01T00:00:00.000Z",
-    }),
-    updateContact: rs.fn().mockResolvedValue({
-      id: "hs-123",
-      properties: {},
-      createdAt: "2026-01-01T00:00:00.000Z",
-      updatedAt: "2026-01-01T00:00:00.000Z",
-    }),
-    toContactProperties: rs
-      .fn()
-      .mockImplementation((data: Record<string, unknown>) => {
-        const map: Record<string, string> = {
-          firstName: "firstname",
-          lastName: "lastname",
-          email: "email",
-          phone: "phone",
-          hasLand: "has_land",
-          landRegistered: "land_registered",
-          landAddress: "land_address",
-          landSizeSqm: "land_size_sqm",
-          propertyType: "property_type",
-          budget: "budget",
-          seenBroker: "seen_broker",
-          constructionTimeline: "construction_timeline",
-          resolveFinanceOptedIn: "resolve_finance_opted_in",
-          preferredContactTime: "preferred_contact_time",
-          landWidth: "land_width",
-          landDepth: "land_depth",
-          leadScore: "lead_score",
-          leadStage: "lead_stage",
-          notes: "notes",
-          leadSource: "lead_source",
-        };
-        const result: Record<string, string> = {};
-        for (const [k, v] of Object.entries(data)) {
-          const hk = map[k];
-          if (hk && v != null) result[hk] = String(v);
-        }
-        return result;
-      }),
+  // The router now delegates create/update to the intake module
+  rs.doMock("~/server/leads/intake", () => ({
+    captureLead: rs.fn().mockResolvedValue(mockLead),
+    updateLead: rs.fn().mockResolvedValue(mockLead),
   }));
 });
 
@@ -165,60 +88,8 @@ async function getCaller(): Promise<Caller> {
 // --- leads.create ---
 
 describe("leads.create", () => {
-  test("creates a lead with full form data", async () => {
-    const returning = rs.fn().mockResolvedValue([mockLead]);
-    const onConflictDoUpdate = rs.fn().mockReturnValue({ returning });
-    const values = rs.fn().mockReturnValue({ onConflictDoUpdate });
-    (mockDb.insert as ReturnType<typeof rs.fn>).mockReturnValue({ values });
-
-    const caller = await getCaller();
-    const result = await caller.leads.create({
-      firstName: "John",
-      lastName: "Smith",
-      email: "john@example.com",
-      phone: "0412345678",
-      hasLand: true,
-      propertyType: "first_home_buyer",
-    });
-
-    expect(result.firstName).toBe("John");
-    expect(result.leadStage).toBe("unqualified");
-    expect(result.leadScore).toBe(0);
-  });
-
-  test("creates a lead with quick capture data", async () => {
-    const quickLead = { ...mockLead, email: null, notes: "Met at BBQ" };
-    const insertReturning = rs.fn().mockResolvedValue([quickLead]);
-    const insertOnConflict = rs
-      .fn()
-      .mockReturnValue({ returning: insertReturning });
-    const values = rs
-      .fn()
-      .mockReturnValue({ onConflictDoUpdate: insertOnConflict });
-    (mockDb.insert as ReturnType<typeof rs.fn>).mockReturnValue({ values });
-
-    // scoreLead's db.update returns the scored version of the same row so
-    // the router's response still carries the quick-capture fields.
-    const updateReturning = rs.fn().mockResolvedValue([quickLead]);
-    const where = rs.fn().mockReturnValue({ returning: updateReturning });
-    const set = rs.fn().mockReturnValue({ where });
-    (mockDb.update as ReturnType<typeof rs.fn>).mockReturnValue({ set });
-
-    const caller = await getCaller();
-    const result = await caller.leads.create({
-      firstName: "John",
-      lastName: "Smith",
-      phone: "0412345678",
-      notes: "Met at BBQ",
-    });
-
-    expect(result.firstName).toBe("John");
-    expect(result.notes).toBe("Met at BBQ");
-  });
-
   test("rejects invalid input", async () => {
     const caller = await getCaller();
-
     try {
       // @ts-expect-error — intentionally invalid input
       await caller.leads.create({ firstName: "" });
@@ -228,79 +99,75 @@ describe("leads.create", () => {
       expect((e as TRPCError).code).toBe("BAD_REQUEST");
     }
   });
-});
 
-// --- leads.create — HubSpot sync ---
-
-describe("leads.create — HubSpot sync", () => {
-  test("creates HubSpot contact when no dedup match", async () => {
-    const leadWithHs = { ...mockLead, hubspotContactId: "hs-123" };
-    const returning = rs.fn().mockResolvedValue([leadWithHs]);
-    const onConflictDoUpdate = rs.fn().mockReturnValue({ returning });
-    const values = rs.fn().mockReturnValue({ onConflictDoUpdate });
-    (mockDb.insert as ReturnType<typeof rs.fn>).mockReturnValue({ values });
-
-    const { createContact } = await import("~/server/hubspot");
-
+  test("rejects unauthenticated request", async () => {
+    rs.doMock("~/lib/session", () => ({
+      getSession: rs.fn().mockResolvedValue(null),
+    }));
     const caller = await getCaller();
-    await caller.leads.create({
-      firstName: "John",
-      lastName: "Smith",
-      email: "john@example.com",
-    });
-
-    expect(createContact).toHaveBeenCalled();
-  });
-
-  test("updates existing HubSpot contact when dedup match found", async () => {
-    const { findExistingContact, updateContact } = await import(
-      "~/server/hubspot"
-    );
-    (findExistingContact as ReturnType<typeof rs.fn>).mockResolvedValue({
-      id: "hs-existing",
-      properties: {},
-      createdAt: "2026-01-01T00:00:00.000Z",
-      updatedAt: "2026-01-01T00:00:00.000Z",
-    });
-
-    const leadWithHs = { ...mockLead, hubspotContactId: "hs-existing" };
-    const returning = rs.fn().mockResolvedValue([leadWithHs]);
-    const onConflictDoUpdate = rs.fn().mockReturnValue({ returning });
-    const values = rs.fn().mockReturnValue({ onConflictDoUpdate });
-    (mockDb.insert as ReturnType<typeof rs.fn>).mockReturnValue({ values });
-
-    const caller = await getCaller();
-    await caller.leads.create({
-      firstName: "John",
-      lastName: "Smith",
-      email: "john@example.com",
-    });
-
-    expect(updateContact).toHaveBeenCalledWith(
-      "hs-existing",
-      expect.objectContaining({ firstname: "John" }),
-    );
-  });
-
-  test("throws INTERNAL_SERVER_ERROR on DB failure after HubSpot success", async () => {
-    const returning = rs.fn().mockRejectedValue(new Error("DB down"));
-    const onConflictDoUpdate = rs.fn().mockReturnValue({ returning });
-    const values = rs.fn().mockReturnValue({ onConflictDoUpdate });
-    (mockDb.insert as ReturnType<typeof rs.fn>).mockReturnValue({ values });
-
-    const caller = await getCaller();
-
     try {
-      await caller.leads.create({
-        firstName: "John",
-        lastName: "Smith",
-      });
+      await caller.leads.create({ firstName: "John", lastName: "Smith" });
       expect.unreachable("Should have thrown");
     } catch (e) {
       expect(e).toBeInstanceOf(TRPCError);
-      expect((e as TRPCError).code).toBe("INTERNAL_SERVER_ERROR");
-      expect((e as TRPCError).message).toContain("hs-123");
+      expect((e as TRPCError).code).toBe("UNAUTHORIZED");
     }
+  });
+
+  test("delegates to captureLead and returns its result", async () => {
+    const { captureLead } = await import("~/server/leads/intake");
+    const caller = await getCaller();
+
+    const result = await caller.leads.create({
+      firstName: "John",
+      lastName: "Smith",
+      email: "john@example.com",
+      phone: "0412345678",
+      hasLand: true,
+      propertyType: "first_home_buyer",
+    });
+
+    expect(captureLead).toHaveBeenCalledOnce();
+    expect(captureLead).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ firstName: "John", lastName: "Smith" }),
+      expect.objectContaining({ userId: "test-user-id" }),
+    );
+    expect(result).toEqual(mockLead);
+  });
+});
+
+// --- leads.update ---
+
+describe("leads.update", () => {
+  test("rejects invalid uuid", async () => {
+    const caller = await getCaller();
+    try {
+      await caller.leads.update({ id: "not-a-uuid", firstName: "Test" });
+      expect.unreachable("Should have thrown");
+    } catch (e) {
+      expect(e).toBeInstanceOf(TRPCError);
+      expect((e as TRPCError).code).toBe("BAD_REQUEST");
+    }
+  });
+
+  test("delegates to updateLead and returns its result", async () => {
+    const { updateLead } = await import("~/server/leads/intake");
+    const caller = await getCaller();
+
+    const result = await caller.leads.update({
+      id: mockLead.id,
+      budget: "$700K",
+    });
+
+    expect(updateLead).toHaveBeenCalledOnce();
+    expect(updateLead).toHaveBeenCalledWith(
+      expect.anything(),
+      mockLead.id,
+      expect.objectContaining({ budget: "$700K" }),
+      expect.objectContaining({ userId: "test-user-id" }),
+    );
+    expect(result).toEqual(mockLead);
   });
 });
 
@@ -409,106 +276,6 @@ describe("leads.list", () => {
   });
 });
 
-// --- leads.update ---
-
-describe("leads.update", () => {
-  test("updates a lead with partial fields", async () => {
-    (
-      mockDb.query as { leads: { findFirst: ReturnType<typeof rs.fn> } }
-    ).leads.findFirst.mockResolvedValue({ hubspotContactId: null });
-
-    const updatedLead = { ...mockLead, budget: "$700K" };
-    const returning = rs.fn().mockResolvedValue([updatedLead]);
-    const where = rs.fn().mockReturnValue({ returning });
-    const set = rs.fn().mockReturnValue({ where });
-    (mockDb.update as ReturnType<typeof rs.fn>).mockReturnValue({ set });
-
-    const caller = await getCaller();
-    const result = await caller.leads.update({
-      id: mockLead.id,
-      budget: "$700K",
-    });
-
-    expect(result.budget).toBe("$700K");
-  });
-
-  test("throws NOT_FOUND when lead does not exist", async () => {
-    (
-      mockDb.query as { leads: { findFirst: ReturnType<typeof rs.fn> } }
-    ).leads.findFirst.mockResolvedValue(undefined);
-
-    const caller = await getCaller();
-
-    try {
-      await caller.leads.update({
-        id: "00000000-0000-0000-0000-000000000000",
-        firstName: "Ghost",
-      });
-      expect.unreachable("Should have thrown");
-    } catch (e) {
-      expect(e).toBeInstanceOf(TRPCError);
-      expect((e as TRPCError).code).toBe("NOT_FOUND");
-    }
-  });
-
-  test("rejects invalid uuid", async () => {
-    const caller = await getCaller();
-
-    try {
-      await caller.leads.update({ id: "not-a-uuid", firstName: "Test" });
-      expect.unreachable("Should have thrown");
-    } catch (e) {
-      expect(e).toBeInstanceOf(TRPCError);
-      expect((e as TRPCError).code).toBe("BAD_REQUEST");
-    }
-  });
-});
-
-// --- leads.update — HubSpot sync ---
-
-describe("leads.update — HubSpot sync", () => {
-  test("updates HubSpot before local DB when linked", async () => {
-    (
-      mockDb.query as { leads: { findFirst: ReturnType<typeof rs.fn> } }
-    ).leads.findFirst.mockResolvedValue({ hubspotContactId: "hs-123" });
-
-    const updatedLead = { ...mockLead, budget: "$700K" };
-    const returning = rs.fn().mockResolvedValue([updatedLead]);
-    const where = rs.fn().mockReturnValue({ returning });
-    const set = rs.fn().mockReturnValue({ where });
-    (mockDb.update as ReturnType<typeof rs.fn>).mockReturnValue({ set });
-
-    const { updateContact } = await import("~/server/hubspot");
-
-    const caller = await getCaller();
-    await caller.leads.update({ id: mockLead.id, budget: "$700K" });
-
-    expect(updateContact).toHaveBeenCalledWith(
-      "hs-123",
-      expect.objectContaining({ budget: "$700K" }),
-    );
-  });
-
-  test("skips HubSpot when lead has no hubspotContactId", async () => {
-    (
-      mockDb.query as { leads: { findFirst: ReturnType<typeof rs.fn> } }
-    ).leads.findFirst.mockResolvedValue({ hubspotContactId: null });
-
-    const updatedLead = { ...mockLead, budget: "$700K" };
-    const returning = rs.fn().mockResolvedValue([updatedLead]);
-    const where = rs.fn().mockReturnValue({ returning });
-    const set = rs.fn().mockReturnValue({ where });
-    (mockDb.update as ReturnType<typeof rs.fn>).mockReturnValue({ set });
-
-    const { updateContact } = await import("~/server/hubspot");
-
-    const caller = await getCaller();
-    await caller.leads.update({ id: mockLead.id, budget: "$700K" });
-
-    expect(updateContact).not.toHaveBeenCalled();
-  });
-});
-
 // --- leads.delete ---
 
 describe("leads.delete", () => {
@@ -539,280 +306,6 @@ describe("leads.delete", () => {
       expect(e).toBeInstanceOf(TRPCError);
       expect((e as TRPCError).code).toBe("NOT_FOUND");
     }
-  });
-});
-
-// --- leads.create — scoring integration ---
-
-describe("leads.create — scoring integration", () => {
-  test("returns a scored lead when input contains qualifying data", async () => {
-    const { qualifyAndScore } = await import("~/server/scoring");
-    (qualifyAndScore as ReturnType<typeof rs.fn>).mockReturnValueOnce({
-      score: 85,
-      stage: "hot",
-      breakdown: {
-        land: { score: 30, maxScore: 30, reasoning: "registered" },
-        finance: { score: 15, maxScore: 25, reasoning: "broker" },
-        timeline: { score: 20, maxScore: 20, reasoning: "ready now" },
-        budget: { score: 10, maxScore: 10, reasoning: "in range" },
-        propertyType: { score: 10, maxScore: 10, reasoning: "clear intent" },
-        engagement: { score: 0, maxScore: 5, reasoning: "no data" },
-      },
-      gaps: [],
-      nextQuestion: "All good",
-    });
-
-    // Insert returns the unscored row
-    const insertReturning = rs.fn().mockResolvedValue([mockLead]);
-    const insertOnConflict = rs
-      .fn()
-      .mockReturnValue({ returning: insertReturning });
-    const values = rs
-      .fn()
-      .mockReturnValue({ onConflictDoUpdate: insertOnConflict });
-    (mockDb.insert as ReturnType<typeof rs.fn>).mockReturnValue({ values });
-
-    // scoreLead's db.update returns the fully-scored row
-    const scoredLead = {
-      ...mockLead,
-      leadScore: 85,
-      leadStage: "hot" as const,
-      scoreMetadata: {
-        score: 85,
-        stage: "hot" as const,
-        breakdown: {
-          land: { score: 30, maxScore: 30, reasoning: "registered" },
-          finance: { score: 15, maxScore: 25, reasoning: "broker" },
-          timeline: { score: 20, maxScore: 20, reasoning: "ready now" },
-          budget: { score: 10, maxScore: 10, reasoning: "in range" },
-          propertyType: { score: 10, maxScore: 10, reasoning: "clear intent" },
-          engagement: { score: 0, maxScore: 5, reasoning: "no data" },
-        },
-        gaps: [],
-        nextQuestion: "All good",
-        scoredAt: "2026-04-10T00:00:00.000Z",
-      },
-    };
-    const updateReturning = rs.fn().mockResolvedValue([scoredLead]);
-    const where = rs.fn().mockReturnValue({ returning: updateReturning });
-    const set = rs.fn().mockReturnValue({ where });
-    (mockDb.update as ReturnType<typeof rs.fn>).mockReturnValue({ set });
-
-    const caller = await getCaller();
-    const result = await caller.leads.create({
-      firstName: "John",
-      lastName: "Smith",
-      hasLand: true,
-      landRegistered: true,
-      landSizeSqm: "450",
-      seenBroker: true,
-      constructionTimeline: "ready_now",
-      budget: "$650000",
-      propertyType: "first_home_buyer",
-    });
-
-    expect(result.leadScore).toBe(85);
-    expect(result.leadStage).toBe("hot");
-    expect(result.scoreMetadata).not.toBeNull();
-    expect(result.scoreMetadata?.score).toBe(85);
-    expect(result.scoreMetadata?.gaps).toHaveLength(0);
-    expect(qualifyAndScore).toHaveBeenCalled();
-  });
-
-  test("returns an unqualified lead with 5 gaps for quick-capture input", async () => {
-    const { qualifyAndScore } = await import("~/server/scoring");
-    (qualifyAndScore as ReturnType<typeof rs.fn>).mockReturnValueOnce({
-      score: 0,
-      stage: "unqualified",
-      breakdown: {
-        land: { score: 0, maxScore: 30, reasoning: "none" },
-        finance: { score: 0, maxScore: 25, reasoning: "unknown" },
-        timeline: { score: 0, maxScore: 20, reasoning: "none" },
-        budget: { score: 0, maxScore: 10, reasoning: "none" },
-        propertyType: { score: 0, maxScore: 10, reasoning: "none" },
-        engagement: { score: 0, maxScore: 5, reasoning: "no data" },
-      },
-      gaps: [
-        { field: "land", impact: "high", description: "No land" },
-        { field: "finance", impact: "high", description: "Unknown" },
-        { field: "timeline", impact: "high", description: "No timeline" },
-        { field: "budget", impact: "medium", description: "No budget" },
-        { field: "propertyType", impact: "medium", description: "No type" },
-      ],
-      nextQuestion: "Do you have land?",
-    });
-
-    const quickLead = { ...mockLead, email: null };
-    const insertReturning = rs.fn().mockResolvedValue([quickLead]);
-    const insertOnConflict = rs
-      .fn()
-      .mockReturnValue({ returning: insertReturning });
-    const values = rs
-      .fn()
-      .mockReturnValue({ onConflictDoUpdate: insertOnConflict });
-    (mockDb.insert as ReturnType<typeof rs.fn>).mockReturnValue({ values });
-
-    const scoredQuickLead = {
-      ...quickLead,
-      leadScore: 0,
-      leadStage: "unqualified" as const,
-      scoreMetadata: {
-        score: 0,
-        stage: "unqualified" as const,
-        breakdown: {
-          land: { score: 0, maxScore: 30, reasoning: "none" },
-          finance: { score: 0, maxScore: 25, reasoning: "unknown" },
-          timeline: { score: 0, maxScore: 20, reasoning: "none" },
-          budget: { score: 0, maxScore: 10, reasoning: "none" },
-          propertyType: { score: 0, maxScore: 10, reasoning: "none" },
-          engagement: { score: 0, maxScore: 5, reasoning: "no data" },
-        },
-        gaps: [
-          {
-            field: "land",
-            impact: "high" as const,
-            description: "No land",
-          },
-          {
-            field: "finance",
-            impact: "high" as const,
-            description: "Unknown",
-          },
-          {
-            field: "timeline",
-            impact: "high" as const,
-            description: "No timeline",
-          },
-          {
-            field: "budget",
-            impact: "medium" as const,
-            description: "No budget",
-          },
-          {
-            field: "propertyType",
-            impact: "medium" as const,
-            description: "No type",
-          },
-        ],
-        nextQuestion: "Do you have land?",
-        scoredAt: "2026-04-10T00:00:00.000Z",
-      },
-    };
-    const updateReturning = rs.fn().mockResolvedValue([scoredQuickLead]);
-    const where = rs.fn().mockReturnValue({ returning: updateReturning });
-    const set = rs.fn().mockReturnValue({ where });
-    (mockDb.update as ReturnType<typeof rs.fn>).mockReturnValue({ set });
-
-    const caller = await getCaller();
-    const result = await caller.leads.create({
-      firstName: "John",
-      lastName: "Smith",
-      phone: "0412345678",
-    });
-
-    expect(result.leadScore).toBe(0);
-    expect(result.leadStage).toBe("unqualified");
-    expect(result.scoreMetadata?.gaps).toHaveLength(5);
-  });
-});
-
-// --- leads.update — scoring integration ---
-
-describe("leads.update — scoring integration", () => {
-  test("re-scores and returns the new score when a scoring field changes", async () => {
-    (
-      mockDb.query as { leads: { findFirst: ReturnType<typeof rs.fn> } }
-    ).leads.findFirst.mockResolvedValue({ hubspotContactId: null });
-
-    const { qualifyAndScore } = await import("~/server/scoring");
-    (qualifyAndScore as ReturnType<typeof rs.fn>).mockReturnValueOnce({
-      score: 20,
-      stage: "unqualified",
-      breakdown: {
-        land: { score: 0, maxScore: 30, reasoning: "none" },
-        finance: { score: 0, maxScore: 25, reasoning: "unknown" },
-        timeline: { score: 20, maxScore: 20, reasoning: "ready now" },
-        budget: { score: 0, maxScore: 10, reasoning: "none" },
-        propertyType: { score: 0, maxScore: 10, reasoning: "none" },
-        engagement: { score: 0, maxScore: 5, reasoning: "no data" },
-      },
-      gaps: [],
-      nextQuestion: "All good",
-    });
-
-    // First call: main update returns the unscored edited row.
-    // Second call: scoreLead's update returns the scored row.
-    const editedLead = {
-      ...mockLead,
-      constructionTimeline: "ready_now" as const,
-    };
-    const scoredEditedLead = {
-      ...editedLead,
-      leadScore: 20,
-      leadStage: "unqualified" as const,
-      scoreMetadata: {
-        score: 20,
-        stage: "unqualified" as const,
-        breakdown: {
-          land: { score: 0, maxScore: 30, reasoning: "none" },
-          finance: { score: 0, maxScore: 25, reasoning: "unknown" },
-          timeline: { score: 20, maxScore: 20, reasoning: "ready now" },
-          budget: { score: 0, maxScore: 10, reasoning: "none" },
-          propertyType: { score: 0, maxScore: 10, reasoning: "none" },
-          engagement: { score: 0, maxScore: 5, reasoning: "no data" },
-        },
-        gaps: [],
-        nextQuestion: "All good",
-        scoredAt: "2026-04-10T00:00:00.000Z",
-      },
-    };
-    const returning = rs
-      .fn()
-      .mockResolvedValueOnce([editedLead])
-      .mockResolvedValueOnce([scoredEditedLead]);
-    const where = rs.fn().mockReturnValue({ returning });
-    const set = rs.fn().mockReturnValue({ where });
-    (mockDb.update as ReturnType<typeof rs.fn>).mockReturnValue({ set });
-
-    const caller = await getCaller();
-    const result = await caller.leads.update({
-      id: mockLead.id,
-      constructionTimeline: "ready_now",
-    });
-
-    expect(qualifyAndScore).toHaveBeenCalled();
-    expect(result.leadScore).toBe(20);
-    expect(result.scoreMetadata?.breakdown.timeline.score).toBe(20);
-  });
-
-  test("does not re-score or rewrite scoreMetadata for non-scoring fields", async () => {
-    (
-      mockDb.query as { leads: { findFirst: ReturnType<typeof rs.fn> } }
-    ).leads.findFirst.mockResolvedValue({ hubspotContactId: null });
-
-    const { qualifyAndScore } = await import("~/server/scoring");
-    const updatedLead = {
-      ...mockLead,
-      notes: "Met at BBQ",
-      leadScore: 42,
-      scoreMetadata: null,
-    };
-    const returning = rs.fn().mockResolvedValue([updatedLead]);
-    const where = rs.fn().mockReturnValue({ returning });
-    const set = rs.fn().mockReturnValue({ where });
-    (mockDb.update as ReturnType<typeof rs.fn>).mockReturnValue({ set });
-
-    const caller = await getCaller();
-    const result = await caller.leads.update({
-      id: mockLead.id,
-      notes: "Met at BBQ",
-    });
-
-    expect(qualifyAndScore).not.toHaveBeenCalled();
-    // Main update was called exactly once (no second score-write)
-    expect(set).toHaveBeenCalledTimes(1);
-    expect(result.leadScore).toBe(42);
-    expect(result.scoreMetadata).toBeNull();
   });
 });
 
@@ -908,68 +401,6 @@ describe("leads.getByStage", () => {
 
     expect(findMany).toHaveBeenCalledWith(
       expect.objectContaining({ where: expect.anything() }),
-    );
-  });
-});
-
-// --- leads.create — nurture auto-start ---
-
-describe("leads.create — nurture auto-start", () => {
-  test("calls startOrUpdateSequence with post-scoring stage after create", async () => {
-    const returning = rs.fn().mockResolvedValue([mockLead]);
-    const onConflictDoUpdate = rs.fn().mockReturnValue({ returning });
-    const values = rs.fn().mockReturnValue({ onConflictDoUpdate });
-    (mockDb.insert as ReturnType<typeof rs.fn>).mockReturnValue({ values });
-
-    const { startOrUpdateSequence } = await import(
-      "~/server/nurture/scheduler"
-    );
-
-    const caller = await getCaller();
-    await caller.leads.create({ firstName: "John", lastName: "Smith" });
-
-    expect(startOrUpdateSequence).toHaveBeenCalledWith(
-      expect.anything(),
-      mockLead.id,
-      mockLead.leadStage,
-    );
-  });
-});
-
-// --- leads.update — nurture auto-start ---
-
-describe("leads.update — nurture auto-start", () => {
-  test("calls startOrUpdateSequence when a qualification field changes", async () => {
-    (
-      mockDb.query as { leads: { findFirst: ReturnType<typeof rs.fn> } }
-    ).leads.findFirst.mockResolvedValue({ hubspotContactId: null });
-
-    const updatedLead = {
-      ...mockLead,
-      constructionTimeline: "ready_now" as const,
-    };
-    const returning = rs
-      .fn()
-      .mockResolvedValueOnce([updatedLead])
-      .mockResolvedValueOnce([{ ...updatedLead, leadScore: 20 }]);
-    const where = rs.fn().mockReturnValue({ returning });
-    const set = rs.fn().mockReturnValue({ where });
-    (mockDb.update as ReturnType<typeof rs.fn>).mockReturnValue({ set });
-
-    const { startOrUpdateSequence } = await import(
-      "~/server/nurture/scheduler"
-    );
-
-    const caller = await getCaller();
-    await caller.leads.update({
-      id: mockLead.id,
-      constructionTimeline: "ready_now",
-    });
-
-    expect(startOrUpdateSequence).toHaveBeenCalledWith(
-      expect.anything(),
-      mockLead.id,
-      expect.any(String),
     );
   });
 });

--- a/src/server/api/routers/leads.ts
+++ b/src/server/api/routers/leads.ts
@@ -9,142 +9,14 @@ import {
 } from "~/server/api/schemas/leads";
 import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
 import { leads } from "~/server/db/schema";
-import {
-  createContact,
-  findExistingContact,
-  toContactProperties,
-  updateContact as updateHubSpotContact,
-} from "~/server/hubspot";
-import { startOrUpdateSequence } from "~/server/nurture/scheduler";
-import type { ScoreMetadata } from "~/server/scoring";
-import { qualifyAndScore } from "~/server/scoring";
-
-/**
- * Synchronously re-score a lead, persist the new score/stage/metadata, and
- * push the score/stage to HubSpot if linked. Returns the fully-scored row so
- * callers can send an authoritative response back to the client.
- *
- * Scoring and the score write propagate errors. HubSpot push errors are
- * logged, not thrown — scoring must not fail because of a CRM outage.
- */
-async function scoreLead(
-  db: typeof import("~/server/db").db,
-  lead: typeof leads.$inferSelect,
-  hubspotContactId: string | null,
-): Promise<typeof leads.$inferSelect> {
-  const result = qualifyAndScore(lead);
-  const metadata: ScoreMetadata = {
-    ...result,
-    scoredAt: new Date().toISOString(),
-  };
-
-  const [scored] = await db
-    .update(leads)
-    .set({
-      leadScore: result.score,
-      leadStage: result.stage,
-      scoreMetadata: metadata,
-      updatedAt: new Date(),
-    })
-    .where(eq(leads.id, lead.id))
-    .returning();
-
-  if (hubspotContactId) {
-    await updateHubSpotContact(
-      hubspotContactId,
-      toContactProperties({ leadScore: result.score, leadStage: result.stage }),
-    ).catch((err) => {
-      console.error(`[scoring] HubSpot sync failed for lead ${lead.id}:`, err);
-    });
-  }
-
-  return scored!;
-}
-
-// Qualification fields that trigger re-scoring
-const SCORING_FIELDS = new Set([
-  "hasLand",
-  "landRegistered",
-  "landAddress",
-  "landSizeSqm",
-  "landWidth",
-  "landDepth",
-  "seenBroker",
-  "constructionTimeline",
-  "budget",
-  "propertyType",
-  "preferredEstates",
-  "preferredSuburbs",
-]);
+import { captureLead, updateLead } from "~/server/leads/intake";
 
 export const leadsRouter = createTRPCRouter({
   create: protectedProcedure
     .input(leadCreateSchema)
-    .mutation(async ({ ctx, input }) => {
-      // 1. Extract HubSpot-mapped fields from input
-      const hubspotData = toContactProperties(input);
-
-      // 2. Dedup: search HubSpot for existing contact by email/phone
-      const existing = await findExistingContact(input.email, input.phone);
-      const hubspotContact = existing
-        ? await updateHubSpotContact(existing.id, hubspotData)
-        : await createContact(hubspotData);
-
-      // 3. Write to local DB with hubspotContactId. Upsert on
-      // hubspot_contact_id so we cooperate with the inbound webhook: if
-      // HubSpot's contact.creation webhook lands first (e.g. when HubSpot
-      // fires it between our HubSpot write and this insert), its
-      // placeholder row is replaced with the full form data instead of
-      // causing a unique-constraint error.
-      let lead: typeof leads.$inferSelect;
-      try {
-        const [inserted] = await ctx.db
-          .insert(leads)
-          .values({
-            ...input,
-            hubspotContactId: hubspotContact.id,
-            leadStage: "unqualified",
-            leadScore: 0,
-          })
-          .onConflictDoUpdate({
-            target: leads.hubspotContactId,
-            set: {
-              ...input,
-              hubspotContactId: hubspotContact.id,
-              updatedAt: new Date(),
-            },
-          })
-          .returning();
-        lead = inserted!;
-      } catch (err) {
-        const cause = err instanceof Error ? err.cause : undefined;
-        console.error(
-          `[leads.create] local insert failed for HubSpot contact ${hubspotContact.id}:`,
-          err,
-          "cause:",
-          cause,
-        );
-        throw new TRPCError({
-          code: "INTERNAL_SERVER_ERROR",
-          message: `Lead saved to HubSpot (contact ID: ${hubspotContact.id}) but local save failed. Retry or check HubSpot.`,
-        });
-      }
-
-      // 4. Score synchronously so the response reflects the final score/stage
-      const scored = await scoreLead(ctx.db, lead, lead.hubspotContactId);
-
-      // 5. Auto-start nurture sequence (non-blocking — nurture failure must not block lead create)
-      await startOrUpdateSequence(ctx.db, scored.id, scored.leadStage).catch(
-        (err) => {
-          console.error(
-            `[leads.create] nurture sequence start failed for lead ${scored.id}:`,
-            err,
-          );
-        },
-      );
-
-      return scored;
-    }),
+    .mutation(({ ctx, input }) =>
+      captureLead(ctx.db, input, { db: ctx.db, userId: ctx.session.user.id }),
+    ),
 
   getById: protectedProcedure
     .input(z.object({ id: z.string().uuid() }))
@@ -215,60 +87,12 @@ export const leadsRouter = createTRPCRouter({
 
   update: protectedProcedure
     .input(leadUpdateSchema)
-    .mutation(async ({ ctx, input }) => {
+    .mutation(({ ctx, input }) => {
       const { id, ...data } = input;
-
-      // Fetch the lead to get its hubspotContactId
-      const existing = await ctx.db.query.leads.findFirst({
-        where: eq(leads.id, id),
-        columns: { hubspotContactId: true },
+      return updateLead(ctx.db, id, data, {
+        db: ctx.db,
+        userId: ctx.session.user.id,
       });
-      if (!existing) {
-        throw new TRPCError({ code: "NOT_FOUND", message: "Lead not found" });
-      }
-
-      // Write mapped fields to HubSpot first (if linked)
-      if (existing.hubspotContactId) {
-        const hubspotData = toContactProperties(data);
-        if (Object.keys(hubspotData).length > 0) {
-          await updateHubSpotContact(existing.hubspotContactId, hubspotData);
-        }
-      }
-
-      // Update local DB
-      const [updated] = await ctx.db
-        .update(leads)
-        .set({ ...data, updatedAt: new Date() })
-        .where(eq(leads.id, id))
-        .returning();
-
-      if (!updated) {
-        throw new TRPCError({ code: "NOT_FOUND", message: "Lead not found" });
-      }
-
-      // Re-score if qualification fields changed — awaited so the returned
-      // row always reflects the latest score/stage/scoreMetadata.
-      const hasQualificationChange = Object.keys(data).some((k) =>
-        SCORING_FIELDS.has(k),
-      );
-      if (hasQualificationChange) {
-        const scored = await scoreLead(
-          ctx.db,
-          updated,
-          updated.hubspotContactId,
-        );
-        await startOrUpdateSequence(ctx.db, scored.id, scored.leadStage).catch(
-          (err) => {
-            console.error(
-              `[leads.update] nurture sequence update failed for lead ${scored.id}:`,
-              err,
-            );
-          },
-        );
-        return scored;
-      }
-
-      return updated;
     }),
 
   delete: protectedProcedure

--- a/src/server/leads/__tests__/intake.integration.test.ts
+++ b/src/server/leads/__tests__/intake.integration.test.ts
@@ -1,0 +1,459 @@
+// dotenv MUST be imported first so process.env is populated before ~/env is evaluated
+import "dotenv/config";
+
+import { afterAll, beforeEach, describe, expect, rs, test } from "@rstest/core";
+import { TRPCError } from "@trpc/server";
+import { eq, inArray } from "drizzle-orm";
+import { toContactProperties } from "~/server/hubspot/properties";
+
+// Unique per-run prefix keeps test data isolated across concurrent runs
+const RUN_ID = `${Date.now()}.${Math.random().toString(36).slice(2)}`;
+
+describe.skipIf(!process.env.INTEGRATION_DB)(
+  "captureLead / updateLead integration",
+  () => {
+    const createdLeadIds: string[] = [];
+
+    let mockFindExisting: ReturnType<typeof rs.fn>;
+    let mockCreateContact: ReturnType<typeof rs.fn>;
+    let mockUpdateContact: ReturnType<typeof rs.fn>;
+    let mockStartOrUpdateSequence: ReturnType<typeof rs.fn>;
+
+    beforeEach(() => {
+      rs.resetModules();
+
+      mockFindExisting = rs.fn().mockResolvedValue(null);
+      mockCreateContact = rs.fn().mockResolvedValue({
+        id: `hs-default-${RUN_ID}`,
+        properties: {},
+        createdAt: "",
+        updatedAt: "",
+      });
+      mockUpdateContact = rs.fn().mockResolvedValue({
+        id: `hs-default-${RUN_ID}`,
+        properties: {},
+        createdAt: "",
+        updatedAt: "",
+      });
+      mockStartOrUpdateSequence = rs.fn().mockResolvedValue(undefined);
+
+      // toContactProperties is captured before resetModules so we get the real fn
+      rs.doMock("~/server/hubspot", () => ({
+        findExistingContact: mockFindExisting,
+        createContact: mockCreateContact,
+        updateContact: mockUpdateContact,
+        toContactProperties,
+      }));
+
+      // Always mock the scheduler — doMock registrations persist across
+      // resetModules() calls, so a test-body doMock would leak into later tests.
+      // Behaviour is configured per-test via mockStartOrUpdateSequence.
+      rs.doMock("~/server/nurture/scheduler", () => ({
+        startOrUpdateSequence: mockStartOrUpdateSequence,
+      }));
+    });
+
+    afterAll(async () => {
+      const { db } = await import("~/server/db");
+      const { leads } = await import("~/server/db/schema");
+      if (createdLeadIds.length > 0) {
+        await db.delete(leads).where(inArray(leads.id, createdLeadIds));
+      }
+    });
+
+    // ---- captureLead ----
+
+    test("captureLead — new contact, no existing HubSpot match", async () => {
+      const { db } = await import("~/server/db");
+      const { leads } = await import("~/server/db/schema");
+      const { captureLead } = await import("~/server/leads/intake");
+
+      const email = `intake.${RUN_ID}.t1@test.example`;
+      const hsId = `hs-t1-${RUN_ID}`;
+      mockCreateContact.mockResolvedValue({
+        id: hsId,
+        properties: {},
+        createdAt: "",
+        updatedAt: "",
+      });
+      mockUpdateContact.mockResolvedValue({
+        id: hsId,
+        properties: {},
+        createdAt: "",
+        updatedAt: "",
+      });
+
+      const input = {
+        firstName: "Integration",
+        lastName: "Test",
+        email,
+        hasLand: true,
+        landRegistered: true,
+        landSizeSqm: "450",
+        seenBroker: true,
+        constructionTimeline: "ready_now" as const,
+        budget: "$650000",
+        propertyType: "first_home_buyer" as const,
+      };
+
+      const lead = await captureLead(db, input, {
+        db,
+        userId: "integration-test",
+      });
+      createdLeadIds.push(lead.id);
+
+      expect(mockCreateContact).toHaveBeenCalledOnce();
+      expect(mockCreateContact).toHaveBeenCalledWith(
+        expect.objectContaining({ firstname: "Integration" }),
+      );
+      expect(mockUpdateContact).toHaveBeenCalledWith(
+        hsId,
+        expect.objectContaining({
+          lead_score: expect.any(String),
+          lead_stage: expect.any(String),
+        }),
+      );
+
+      const row = await db.query.leads.findFirst({
+        where: eq(leads.id, lead.id),
+      });
+      expect(row).toBeDefined();
+      expect(row!.hubspotContactId).toBe(hsId);
+      expect(row!.leadScore).toBeGreaterThan(0);
+      expect(row!.leadStage).not.toBe("unqualified");
+      expect(row!.scoreMetadata).not.toBeNull();
+
+      expect(mockStartOrUpdateSequence).toHaveBeenCalledWith(
+        expect.anything(),
+        lead.id,
+        expect.any(String),
+      );
+    });
+
+    test("captureLead — existing HubSpot match", async () => {
+      const { db } = await import("~/server/db");
+      const { captureLead } = await import("~/server/leads/intake");
+
+      const email = `intake.${RUN_ID}.t2@test.example`;
+      const hsId = `hs-t2-existing-${RUN_ID}`;
+      mockFindExisting.mockResolvedValue({
+        id: hsId,
+        properties: {},
+        createdAt: "",
+        updatedAt: "",
+      });
+      mockUpdateContact.mockResolvedValue({
+        id: hsId,
+        properties: {},
+        createdAt: "",
+        updatedAt: "",
+      });
+
+      const lead = await captureLead(
+        db,
+        { firstName: "Existing", lastName: "Contact", email },
+        { db, userId: "integration-test" },
+      );
+      createdLeadIds.push(lead.id);
+
+      expect(mockCreateContact).not.toHaveBeenCalled();
+      // updateContact called twice: once for data push, once for score sync
+      expect(mockUpdateContact).toHaveBeenCalledTimes(2);
+      expect(lead.hubspotContactId).toBe(hsId);
+    });
+
+    test("captureLead — webhook-conflict resolve (onConflictDoUpdate)", async () => {
+      const { db } = await import("~/server/db");
+      const { leads } = await import("~/server/db/schema");
+      const { captureLead } = await import("~/server/leads/intake");
+
+      const hsId = `hs-t3-conflict-${RUN_ID}`;
+      // Simulate webhook landing first — placeholder row already exists
+      const [placeholder] = await db
+        .insert(leads)
+        .values({
+          firstName: "Placeholder",
+          lastName: "Row",
+          hubspotContactId: hsId,
+        })
+        .returning();
+      createdLeadIds.push(placeholder!.id);
+
+      mockCreateContact.mockResolvedValue({
+        id: hsId,
+        properties: {},
+        createdAt: "",
+        updatedAt: "",
+      });
+      mockUpdateContact.mockResolvedValue({
+        id: hsId,
+        properties: {},
+        createdAt: "",
+        updatedAt: "",
+      });
+
+      const email = `intake.${RUN_ID}.t3@test.example`;
+      const lead = await captureLead(
+        db,
+        { firstName: "Real", lastName: "Person", email, hasLand: true },
+        { db, userId: "integration-test" },
+      );
+
+      // onConflictDoUpdate updates the placeholder in-place — same row, not a new one
+      expect(lead.id).toBe(placeholder!.id);
+      expect(lead.firstName).toBe("Real");
+      expect(lead.email).toBe(email);
+      expect(lead.scoreMetadata).not.toBeNull();
+
+      const rows = await db
+        .select({ id: leads.id })
+        .from(leads)
+        .where(eq(leads.hubspotContactId, hsId));
+      expect(rows).toHaveLength(1);
+    });
+
+    test("captureLead — HubSpot dedup failure propagates, no row inserted", async () => {
+      const { db } = await import("~/server/db");
+      const { leads } = await import("~/server/db/schema");
+      const { captureLead } = await import("~/server/leads/intake");
+
+      mockFindExisting.mockRejectedValue(new Error("HubSpot 500"));
+      const email = `intake.${RUN_ID}.t4@test.example`;
+
+      await expect(
+        captureLead(
+          db,
+          { firstName: "Fail", lastName: "Test", email },
+          { db, userId: "integration-test" },
+        ),
+      ).rejects.toThrow("HubSpot 500");
+
+      const notCreated = await db.query.leads.findFirst({
+        where: eq(leads.email, email),
+      });
+      expect(notCreated).toBeUndefined();
+    });
+
+    test("captureLead — post-write HubSpot score sync failure is swallowed", async () => {
+      const { db } = await import("~/server/db");
+      const { captureLead } = await import("~/server/leads/intake");
+
+      const email = `intake.${RUN_ID}.t5@test.example`;
+      const hsId = `hs-t5-${RUN_ID}`;
+      mockCreateContact.mockResolvedValue({
+        id: hsId,
+        properties: {},
+        createdAt: "",
+        updatedAt: "",
+      });
+      mockUpdateContact.mockRejectedValue(new Error("score sync failed"));
+
+      const consoleSpy = rs
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
+
+      const lead = await captureLead(
+        db,
+        { firstName: "Score", lastName: "SyncFail", email },
+        { db, userId: "integration-test" },
+      );
+      createdLeadIds.push(lead.id);
+
+      expect(lead).toBeDefined();
+      expect(lead.hubspotContactId).toBe(hsId);
+      expect(consoleSpy).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "[intake.captureLead] HubSpot score sync failed",
+        ),
+        expect.anything(),
+      );
+
+      consoleSpy.mockRestore();
+    });
+
+    test("captureLead — nurture-start failure is swallowed", async () => {
+      // Configure the always-registered scheduler mock to reject for this test
+      mockStartOrUpdateSequence.mockRejectedValue(new Error("nurture failed"));
+
+      const { db } = await import("~/server/db");
+      const { captureLead } = await import("~/server/leads/intake");
+
+      const email = `intake.${RUN_ID}.t6@test.example`;
+      const hsId = `hs-t6-${RUN_ID}`;
+      mockCreateContact.mockResolvedValue({
+        id: hsId,
+        properties: {},
+        createdAt: "",
+        updatedAt: "",
+      });
+      mockUpdateContact.mockResolvedValue({
+        id: hsId,
+        properties: {},
+        createdAt: "",
+        updatedAt: "",
+      });
+
+      const consoleSpy = rs
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
+
+      const lead = await captureLead(
+        db,
+        { firstName: "Nurture", lastName: "Fail", email },
+        { db, userId: "integration-test" },
+      );
+      createdLeadIds.push(lead.id);
+
+      expect(lead).toBeDefined();
+      expect(consoleSpy).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "[intake.captureLead] nurture sequence start failed",
+        ),
+        expect.anything(),
+      );
+
+      consoleSpy.mockRestore();
+    });
+
+    // ---- updateLead ----
+
+    test("updateLead — non-qualification field change does not re-score", async () => {
+      const { db } = await import("~/server/db");
+      const { leads } = await import("~/server/db/schema");
+      const { updateLead } = await import("~/server/leads/intake");
+
+      const hsId = `hs-t7-${RUN_ID}`;
+      mockUpdateContact.mockResolvedValue({
+        id: hsId,
+        properties: {},
+        createdAt: "",
+        updatedAt: "",
+      });
+
+      const [lead] = await db
+        .insert(leads)
+        .values({
+          firstName: "Notes",
+          lastName: "Test",
+          hubspotContactId: hsId,
+          leadScore: 20,
+          leadStage: "nurture",
+        })
+        .returning();
+      createdLeadIds.push(lead!.id);
+
+      const updated = await updateLead(
+        db,
+        lead!.id,
+        { notes: "meeting notes" },
+        { db, userId: "integration-test" },
+      );
+
+      expect(updated.notes).toBe("meeting notes");
+      expect(updated.leadScore).toBe(20);
+      expect(updated.leadStage).toBe("nurture");
+
+      // updateContact called once for data push only — no score sync
+      expect(mockUpdateContact).toHaveBeenCalledOnce();
+      expect(mockUpdateContact).toHaveBeenCalledWith(
+        hsId,
+        expect.objectContaining({ notes: "meeting notes" }),
+      );
+      expect(mockStartOrUpdateSequence).not.toHaveBeenCalled();
+    });
+
+    test("updateLead — qualification field change re-scores and fires nurture", async () => {
+      const { db } = await import("~/server/db");
+      const { leads } = await import("~/server/db/schema");
+      const { updateLead } = await import("~/server/leads/intake");
+
+      const hsId = `hs-t8-${RUN_ID}`;
+      mockUpdateContact.mockResolvedValue({
+        id: hsId,
+        properties: {},
+        createdAt: "",
+        updatedAt: "",
+      });
+
+      const [lead] = await db
+        .insert(leads)
+        .values({
+          firstName: "Rescore",
+          lastName: "Test",
+          hubspotContactId: hsId,
+          leadScore: 0,
+          leadStage: "unqualified",
+        })
+        .returning();
+      createdLeadIds.push(lead!.id);
+
+      const before = new Date();
+      const updated = await updateLead(
+        db,
+        lead!.id,
+        { landSizeSqm: "800", landRegistered: true, hasLand: true },
+        { db, userId: "integration-test" },
+      );
+
+      expect(updated.landSizeSqm).toBe("800");
+      expect(updated.leadScore).toBeGreaterThan(0);
+      expect(updated.scoreMetadata).not.toBeNull();
+      expect(
+        new Date(updated.scoreMetadata!.scoredAt).getTime(),
+      ).toBeGreaterThanOrEqual(before.getTime());
+
+      // updateContact: once for data, once for score sync
+      expect(mockUpdateContact).toHaveBeenCalledTimes(2);
+
+      expect(mockStartOrUpdateSequence).toHaveBeenCalledWith(
+        expect.anything(),
+        lead!.id,
+        expect.any(String),
+      );
+    });
+
+    test("updateLead — not found throws NOT_FOUND", async () => {
+      const { db } = await import("~/server/db");
+      const { updateLead } = await import("~/server/leads/intake");
+
+      try {
+        await updateLead(
+          db,
+          crypto.randomUUID(),
+          { notes: "ghost" },
+          { db, userId: "integration-test" },
+        );
+        expect.unreachable("Should have thrown");
+      } catch (e) {
+        expect(e).toBeInstanceOf(TRPCError);
+        expect((e as InstanceType<typeof TRPCError>).code).toBe("NOT_FOUND");
+      }
+    });
+
+    test("updateLead — no HubSpot link skips updateContact", async () => {
+      const { db } = await import("~/server/db");
+      const { leads } = await import("~/server/db/schema");
+      const { updateLead } = await import("~/server/leads/intake");
+
+      const [unlinked] = await db
+        .insert(leads)
+        .values({ firstName: "Unlinked", lastName: "Lead" })
+        .returning();
+      createdLeadIds.push(unlinked!.id);
+
+      await updateLead(
+        db,
+        unlinked!.id,
+        { notes: "no hubspot" },
+        { db, userId: "integration-test" },
+      );
+
+      expect(mockUpdateContact).not.toHaveBeenCalled();
+
+      const row = await db.query.leads.findFirst({
+        where: eq(leads.id, unlinked!.id),
+      });
+      expect(row!.notes).toBe("no hubspot");
+    });
+  },
+);

--- a/src/server/leads/__tests__/intake.test.ts
+++ b/src/server/leads/__tests__/intake.test.ts
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, rs, test } from "@rstest/core";
+import { TRPCError } from "@trpc/server";
+
+describe("captureLead — DB failure after HubSpot success", () => {
+  const HS_ID = "hs-unit-test-123";
+
+  let mockDb: {
+    insert: ReturnType<typeof rs.fn>;
+    query: { leads: { findFirst: ReturnType<typeof rs.fn> } };
+  };
+
+  beforeEach(() => {
+    rs.resetModules();
+
+    rs.doMock("~/env", () => ({
+      env: {
+        DATABASE_URL: "postgres://mock",
+        HUBSPOT_ACCESS_TOKEN: "mock-token",
+        HUBSPOT_CLIENT_SECRET: "mock-secret",
+      },
+    }));
+
+    rs.doMock("~/server/hubspot", () => ({
+      findExistingContact: rs.fn().mockResolvedValue(null),
+      createContact: rs.fn().mockResolvedValue({
+        id: HS_ID,
+        properties: {},
+        createdAt: "",
+        updatedAt: "",
+      }),
+      updateContact: rs.fn().mockResolvedValue({
+        id: HS_ID,
+        properties: {},
+        createdAt: "",
+        updatedAt: "",
+      }),
+      toContactProperties: rs.fn().mockReturnValue({}),
+    }));
+
+    rs.doMock("~/server/scoring", () => ({
+      qualifyAndScore: rs.fn().mockReturnValue({
+        score: 0,
+        stage: "unqualified",
+        breakdown: {
+          land: { score: 0, maxScore: 30, reasoning: "" },
+          finance: { score: 0, maxScore: 25, reasoning: "" },
+          timeline: { score: 0, maxScore: 20, reasoning: "" },
+          budget: { score: 0, maxScore: 10, reasoning: "" },
+          propertyType: { score: 0, maxScore: 10, reasoning: "" },
+          engagement: { score: 0, maxScore: 5, reasoning: "" },
+        },
+        gaps: [],
+        nextQuestion: "",
+      }),
+    }));
+
+    rs.doMock("~/server/nurture/scheduler", () => ({
+      startOrUpdateSequence: rs.fn().mockResolvedValue(undefined),
+    }));
+
+    mockDb = {
+      insert: rs.fn().mockReturnValue({
+        values: rs.fn().mockReturnValue({
+          onConflictDoUpdate: rs.fn().mockReturnValue({
+            returning: rs
+              .fn()
+              .mockRejectedValue(new Error("DB constraint violation")),
+          }),
+        }),
+      }),
+      query: { leads: { findFirst: rs.fn().mockResolvedValue(undefined) } },
+    };
+
+    rs.doMock("~/server/db", () => ({ db: mockDb }));
+  });
+
+  test("throws INTERNAL_SERVER_ERROR containing the HubSpot contact ID", async () => {
+    const { captureLead } = await import("~/server/leads/intake");
+
+    let thrown: unknown;
+    try {
+      await captureLead(
+        mockDb as never,
+        { firstName: "John", lastName: "Smith" },
+        { db: mockDb as never, userId: "user-1" },
+      );
+    } catch (e) {
+      thrown = e;
+    }
+
+    expect(thrown).toBeInstanceOf(TRPCError);
+    expect((thrown as TRPCError).code).toBe("INTERNAL_SERVER_ERROR");
+    expect((thrown as TRPCError).message).toContain(HS_ID);
+  });
+});

--- a/src/server/leads/intake.ts
+++ b/src/server/leads/intake.ts
@@ -1,0 +1,183 @@
+import { TRPCError } from "@trpc/server";
+import { eq } from "drizzle-orm";
+
+import type { LeadCreate, LeadUpdate } from "~/server/api/schemas/leads";
+import { leads } from "~/server/db/schema";
+import {
+  createContact,
+  findExistingContact,
+  toContactProperties,
+  updateContact,
+} from "~/server/hubspot";
+import { startOrUpdateSequence } from "~/server/nurture/scheduler";
+import type { ScoreMetadata } from "~/server/scoring";
+import { qualifyAndScore } from "~/server/scoring";
+
+// TODO(#258): swap Db for Tx (drizzle-orm/pg-core PgTransaction) when the outbox insert lands and the driver moves to neon-serverless
+type Db = typeof import("~/server/db").db;
+
+export type IntakeCtx = { db: Db; userId: string };
+
+const SCORING_FIELDS = new Set([
+  "hasLand",
+  "landRegistered",
+  "landAddress",
+  "landSizeSqm",
+  "landWidth",
+  "landDepth",
+  "seenBroker",
+  "constructionTimeline",
+  "budget",
+  "propertyType",
+  "preferredEstates",
+  "preferredSuburbs",
+]);
+
+export async function captureLead(
+  db: Db,
+  input: LeadCreate,
+  ctx: IntakeCtx,
+): Promise<typeof leads.$inferSelect> {
+  const hubspotProps = toContactProperties(input);
+  const existing = await findExistingContact(input.email, input.phone);
+  const hubspotContact = existing
+    ? await updateContact(existing.id, hubspotProps)
+    : await createContact(hubspotProps);
+
+  const scoreResult = qualifyAndScore(input);
+  const scoreMetadata: ScoreMetadata = {
+    ...scoreResult,
+    scoredAt: new Date().toISOString(),
+  };
+
+  let lead: typeof leads.$inferSelect;
+  try {
+    const [inserted] = await db
+      .insert(leads)
+      .values({
+        ...input,
+        hubspotContactId: hubspotContact.id,
+        leadScore: scoreResult.score,
+        leadStage: scoreResult.stage,
+        scoreMetadata,
+      })
+      .onConflictDoUpdate({
+        target: leads.hubspotContactId,
+        set: {
+          ...input,
+          hubspotContactId: hubspotContact.id,
+          leadScore: scoreResult.score,
+          leadStage: scoreResult.stage,
+          scoreMetadata,
+          updatedAt: new Date(),
+        },
+      })
+      .returning();
+    lead = inserted!;
+  } catch (err) {
+    const cause = err instanceof Error ? err.cause : undefined;
+    console.error(
+      `[intake.captureLead] local insert failed for HubSpot contact ${hubspotContact.id}:`,
+      err,
+      "cause:",
+      cause,
+    );
+    throw new TRPCError({
+      code: "INTERNAL_SERVER_ERROR",
+      message: `Lead saved to HubSpot (contact ID: ${hubspotContact.id}) but local save failed. Retry or check HubSpot.`,
+    });
+  }
+
+  await updateContact(
+    hubspotContact.id,
+    toContactProperties({
+      leadScore: scoreResult.score,
+      leadStage: scoreResult.stage,
+    }),
+  ).catch((err) => {
+    console.error(
+      `[intake.captureLead] HubSpot score sync failed for lead ${lead.id}:`,
+      err,
+    );
+  });
+
+  await startOrUpdateSequence(ctx.db, lead.id, lead.leadStage).catch((err) => {
+    console.error(
+      `[intake.captureLead] nurture sequence start failed for lead ${lead.id}:`,
+      err,
+    );
+  });
+
+  return lead;
+}
+
+export async function updateLead(
+  db: Db,
+  id: string,
+  input: Omit<LeadUpdate, "id">,
+  ctx: IntakeCtx,
+): Promise<typeof leads.$inferSelect> {
+  const existing = await db.query.leads.findFirst({ where: eq(leads.id, id) });
+  if (!existing) {
+    throw new TRPCError({ code: "NOT_FOUND", message: "Lead not found" });
+  }
+
+  if (existing.hubspotContactId) {
+    const hubspotProps = toContactProperties(input);
+    if (Object.keys(hubspotProps).length > 0) {
+      await updateContact(existing.hubspotContactId, hubspotProps);
+    }
+  }
+
+  const hasQualificationChange = Object.keys(input).some((k) =>
+    SCORING_FIELDS.has(k),
+  );
+
+  let scoreFields: Partial<typeof leads.$inferInsert> = {};
+  if (hasQualificationChange) {
+    const merged = { ...existing, ...input };
+    const result = qualifyAndScore(merged as typeof existing);
+    scoreFields = {
+      leadScore: result.score,
+      leadStage: result.stage,
+      scoreMetadata: { ...result, scoredAt: new Date().toISOString() },
+    };
+  }
+
+  const [updated] = await db
+    .update(leads)
+    .set({ ...input, ...scoreFields, updatedAt: new Date() })
+    .where(eq(leads.id, id))
+    .returning();
+  if (!updated) {
+    throw new TRPCError({ code: "NOT_FOUND", message: "Lead not found" });
+  }
+
+  if (hasQualificationChange && updated.hubspotContactId) {
+    await updateContact(
+      updated.hubspotContactId,
+      toContactProperties({
+        leadScore: updated.leadScore,
+        leadStage: updated.leadStage,
+      }),
+    ).catch((err) => {
+      console.error(
+        `[intake.updateLead] HubSpot score sync failed for lead ${updated.id}:`,
+        err,
+      );
+    });
+  }
+
+  if (hasQualificationChange) {
+    await startOrUpdateSequence(ctx.db, updated.id, updated.leadStage).catch(
+      (err) => {
+        console.error(
+          `[intake.updateLead] nurture sequence update failed for lead ${updated.id}:`,
+          err,
+        );
+      },
+    );
+  }
+
+  return updated;
+}


### PR DESCRIPTION
## Linked issue

Closes #257

## What changed

- **New module** `src/server/leads/intake.ts` exports `captureLead(db, input, ctx)` and `updateLead(db, id, input, ctx)`, owning the full HubSpot dedup/write → local upsert → score persist → HubSpot score-push → nurture-start orchestration.
- **Router** `src/server/api/routers/leads.ts` shrinks from 316 → 140 lines. `leads.create` and `leads.update` are now 3- and 5-line delegation bodies; `scoreLead` and `SCORING_FIELDS` are deleted from the router file and live (privately) in `intake.ts`.
- **Score computed upfront**: `qualifyAndScore` runs before the DB write; the row lands with its real score in a single `INSERT … ON CONFLICT … RETURNING`. Previously the row landed with `leadScore: 0` and was immediately updated in a second statement — no caller observed the placeholder state.
- **Test surface restructured**: `leads-router.test.ts` shrinks from 975 → 406 lines (mocks `~/server/leads/intake`, asserts delegation). Ten integration slices in `intake.integration.test.ts` (real Neon, HubSpot mocked, `INTEGRATION_DB=1`) and one unit test in `intake.test.ts` (DB-failure-after-HubSpot path) replace the former mock chain.
- **`neon-http` constraint documented**: the first parameter is typed `Db` (not `Tx`) because `neon-http` throws on `db.transaction()`. A single-statement upsert delivers equivalent atomicity; `TODO(#258)` at `intake.ts:16` marks the swap site for when the driver migrates.

## Behaviour preserved

Observable behaviour is unchanged. The synchronous HubSpot-first order (ADR-003), `onConflictDoUpdate` upsert semantics, HubSpot score-push swallow, and nurture-start swallow (ADR-008) are all preserved. The sole structural change — score landing in the initial insert rather than a follow-up update — is unobservable to any caller because no code path reads the row between the two old statements. The Playwright E2E suite exercises the tRPC surface end-to-end; `make check` and `make test` gate the new module's types and unit/router-delegation contracts.

## Out of scope

- `db.transaction()` wrap and `neon-http` → `neon-serverless` driver migration — both deferred to #258.
- Outbox-driven async fan-out (#258).
- `leads.list`, `leads.getById`, `leads.delete`, `leads.getByStage` — untouched.
- Any change to `qualifyAndScore`, score factors, or the scoring schema.

## Callouts

- **Score in the first write**: the `onConflictDoUpdate` clause now carries `leadScore`/`leadStage`/`scoreMetadata` into the conflict path too. A row inserted by the HubSpot webhook (placeholder, score=0) will have its score populated on the next `captureLead` call for the same contact. This is the desired behaviour but is a subtly wider change than a pure move.
- **Error log prefix added**: `console.error` calls now carry `[intake.captureLead]` / `[intake.updateLead]` prefixes. Log level and content are preserved; only the prefix is new — grep patterns on bare messages will need updating.
