### PR TITLE
test(e2e): gate hubspot dedup on outbound patch, not ingest stamp

### DIFF
--- a/e2e/features/hubspot-sync.spec.ts
+++ b/e2e/features/hubspot-sync.spec.ts
@@ -14,6 +14,7 @@ import {
   getLeadHubSpotId,
   getTestContactById,
   updateTestContact,
+  waitForContactProperty,
   waitForLeadDeletion,
   waitForLeadField,
   waitForLeadHubSpotId,
@@ -132,6 +133,8 @@ test.describe("HubSpot Outbound Sync — E2E", () => {
     page,
     baseURL,
   }) => {
+    test.setTimeout(75_000); // Seed webhook + outbound dedup patch latency
+
     await context.addCookies([getSessionCookie(session.signedToken, baseURL!)]);
 
     const uniqueId = Date.now().toString(36);
@@ -173,22 +176,27 @@ test.describe("HubSpot Outbound Sync — E2E", () => {
     await form.clickSubmit();
     await form.expectSuccess(`Updated Dedup ${uniqueId}`);
 
-    // Lead sync is now async — wait for the hubspotContactId stamp
-    await waitForLeadHubSpotId(testEmail);
+    // The dedup update lands on the OUTBOUND path. Do NOT gate on
+    // waitForLeadHubSpotId(email): in prod, seeding the contact above fires a
+    // real `contact.creation` webhook that ingests a lead with
+    // hubspotContactId pre-stamped (hubspotSync:false), satisfying that id gate
+    // before the outbound "Updated" patch runs — so the assertion would race
+    // ahead and read the contact while it is still "Existing". Gate on the
+    // genuine end-state instead: poll the seeded contact until the patch lands.
+    await waitForContactProperty(seeded.id, "firstname", "Updated");
 
-    // Verify: the app linked the lead to the EXISTING contact (dedup) instead
-    // of creating a duplicate — the local lead now carries the seeded id.
-    const hubspotId = await getLeadHubSpotId(testEmail);
-    expect(hubspotId).toBe(seeded.id);
-
-    // Verify: that existing contact was UPDATED in place. Read by id — getById
+    // Verify: the existing contact was UPDATED in place. Read by id — getById
     // is read-after-write consistent, whereas findContactByEmail's Search API
     // lags ~30s re-indexing the changed firstname and returns the stale
-    // "Existing" value (the seed's original name), failing this assertion even
-    // though the contact record was already patched server-side.
+    // "Existing" value (the seed's original name).
     const contact = await getTestContactById(seeded.id);
     expect(contact.properties.firstname).toBe("Updated");
     expect(contact.properties.lastname).toBe(`Dedup ${uniqueId}`);
+
+    // Verify: the app linked the lead to the EXISTING contact (dedup) instead
+    // of creating a duplicate — the local lead carries the seeded id.
+    const hubspotId = await getLeadHubSpotId(testEmail);
+    expect(hubspotId).toBe(seeded.id);
   });
 });
 

--- a/e2e/utils/hubspot-helper.ts
+++ b/e2e/utils/hubspot-helper.ts
@@ -308,6 +308,37 @@ export async function waitForLeadDeletion(
   throw new Error(`Timed out waiting for lead deletion (email: ${email})`);
 }
 
+/**
+ * Poll HubSpot until a contact's property reaches the expected value, or until
+ * the timeout expires. Reads by id ({@link getTestContactById}) so it is
+ * read-after-write consistent — it observes the genuine end-state, not the
+ * eventually-consistent Search index.
+ *
+ * Use this to gate on an OUTBOUND HubSpot patch landing (e.g. the dedup
+ * fan-out updating a seeded contact). It is the correct signal where
+ * {@link waitForLeadHubSpotId} is not: in prod, seeding a contact fires a real
+ * `contact.creation` webhook that ingests a lead with `hubspotContactId`
+ * pre-stamped (hubspotSync:false), which satisfies the id gate before the
+ * outbound patch runs.
+ */
+export async function waitForContactProperty(
+  hubspotId: string,
+  property: string,
+  expected: string,
+  timeoutMs = 45_000,
+): Promise<void> {
+  const start = Date.now();
+  let last: string | null = null;
+  while (Date.now() - start < timeoutMs) {
+    last = (await getTestContactById(hubspotId)).properties[property] ?? null;
+    if (last === expected) return;
+    await new Promise((r) => setTimeout(r, 2_000));
+  }
+  throw new Error(
+    `Timed out waiting for contact ${hubspotId}.${property} = "${expected}" (last: "${last}")`,
+  );
+}
+
 /** Read the hubspot_contact_id for a lead from the local DB. */
 export async function getLeadHubSpotId(email: string): Promise<string | null> {
   const rows = await sql()`


### PR DESCRIPTION
## What

Fixes the recurring CI flake in the HubSpot dedup E2E test (`e2e/features/hubspot-sync.spec.ts` → *"creating a lead with an existing HubSpot email updates instead of duplicating"*). The test asserted the seeded contact's `firstname` became `"Updated"` but intermittently read `"Existing"` (all 3 retries, deterministic *within* a run; some runs green, some red).

## Root cause — a race on the ingest stamp (not Search-index lag)

The same commit both passes and fails across runs → a timing flake, not a per-commit regression.

1. The test seeds a contact directly in HubSpot (`firstname:"Existing"`). In **prod** this fires a real `contact.creation` webhook.
2. The webhook ingests a lead via the scored outbox with `hubspotContactId` **pre-stamped at ingest** and `hubspotSync:false` — so the fan-out worker never patches HubSpot for that row (`src/server/leads/intake.ts`).
3. The form submit (`firstName:"Updated"`, same email) updates that same lead row; the dedup patch to HubSpot happens on the **outbound** `lead.captured` fan-out (`hs-patch` in `src/inngest/functions/leads/lead-fanout.ts`).
4. The old gate `waitForLeadHubSpotId(email)` only checks that *some* lead with the email has an id — already satisfied by the **ingest stamp** — so the assertion races ahead and reads the contact **before** the outbound patch lands.

**Flake driver = webhook latency.** Fast webhook → id stamped before the patch → reads `"Existing"` → FAIL. Slow webhook → gate correctly waits for the outbound patch → PASS. Local/dev never reproduces because the webhook targets **production only**.

This is why **#287 didn't fix it**: it switched the read to `getById` (strongly consistent) assuming Search-index lag, but in the failing ordering the contact genuinely *is* `"Existing"` at read time, so a consistent read returns `"Existing"` anyway. #287 fixed a *secondary* Search-lag flake — hence some runs flipped green — leaving this primary race.

## Fix (test-only, narrow)

Gate on the **genuine end-state** rather than the ingest stamp:

- New `waitForContactProperty(hubspotId, property, expected)` helper polls the seeded contact **by id** (read-after-write consistent) until the outbound patch lands.
- Reordered the asserts so we **never assert on the lead's `firstName`** — a late webhook ingest can flip it back to `"Existing"` on the slow-webhook ordering. We assert only on contact properties + that the lead carries the seeded id (dedup, no duplicate row).
- Bumped the test timeout to 75s to cover seed-webhook + outbound-patch latency.

## Verification

- `make check` — passes.
- **Empirical before/after against prod** (throwaway script, deleted before this PR): seeding a real contact, the webhook ingested + stamped the lead in **~2.2s** while `getById(seed).firstname` was still `"Existing"` → the **old** assertion FAILS; the **shipped** `waitForContactProperty` waited for the simulated outbound patch and resolved on `"Updated"` → PASSES.

## Known secondary risk (not addressed here)

If HubSpot **Search** lags at fan-out time, `findExistingContact` can miss the seed and `createContact` makes a **duplicate** → the lead carries the new id, the seeded contact never flips to `"Updated"`, and the new poll would time out. That's a rarer **product-level** eventual-consistency issue, separate from this test-timing fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)