### PR TITLE
test(e2e): remove stale HubSpot inbound-sync tests (dropped in #288)

### DIFF
--- a/e2e/features/hubspot-sync.spec.ts
+++ b/e2e/features/hubspot-sync.spec.ts
@@ -13,10 +13,7 @@ import {
   findContactByEmail,
   getLeadHubSpotId,
   getTestContactById,
-  updateTestContact,
   waitForContactProperty,
-  waitForLeadDeletion,
-  waitForLeadField,
   waitForLeadHubSpotId,
 } from "../utils/hubspot-helper";
 import { getSessionCookie } from "../utils/session-cookie";
@@ -200,107 +197,9 @@ test.describe("HubSpot Outbound Sync — E2E", () => {
   });
 });
 
-test.describe("HubSpot Inbound Sync — E2E", () => {
-  test.skip(
-    !process.env.HUBSPOT_ACCESS_TOKEN || !process.env.HUBSPOT_WEBHOOK_ACTIVE,
-    "Requires HUBSPOT_ACCESS_TOKEN and HUBSPOT_WEBHOOK_ACTIVE — only against production (webhook target is production-only)",
-  );
-
-  let session: TestSession;
-  const phones: string[] = [];
-
-  test.beforeAll(async () => {
-    session = await createTestSession();
-  });
-
-  test.afterAll(async () => {
-    await cleanupTestLeadsByPhone(phones);
-    await deleteTestSession(session.userId);
-  });
-
-  test("editing a contact's phone in HubSpot updates the local lead", async ({
-    context,
-    page,
-    baseURL,
-  }) => {
-    test.setTimeout(60_000); // Webhook latency
-
-    await context.addCookies([getSessionCookie(session.signedToken, baseURL!)]);
-
-    const uniqueId = Date.now().toString(36);
-    const testEmail = `e2e-${uniqueId}@test.rekurve.dev`;
-    const testPhone = uniquePhone();
-    phones.push(testPhone);
-
-    // Step 1: Create a lead via the app (establishes the HubSpot link)
-    await page.goto("/leads/new");
-    const form = new LeadFormSection(page);
-    await form.fillStep1({
-      firstName: "Inbound",
-      lastName: `Phone ${uniqueId}`,
-      phone: testPhone,
-      email: testEmail,
-    });
-    await form.clickNext();
-    await form.selectSegmented("Has land", "No");
-    await form.clickNext();
-    await form.selectSegmented("Property type", "First Home Buyer");
-    await form.clickNext();
-    await form.clickSubmit();
-    await form.expectSuccess(`Inbound Phone ${uniqueId}`);
-
-    // Step 2: Wait for the outbox worker to stamp hubspotContactId
-    const hubspotId = await waitForLeadHubSpotId(testEmail);
-    expect(hubspotId).not.toBeNull();
-
-    // Step 3: Update the contact's phone in HubSpot directly
-    const updatedPhone = "0499999999";
-    phones.push(updatedPhone);
-    await updateTestContact(hubspotId!, { phone: updatedPhone });
-
-    // Step 4: Wait for the webhook to update the local lead
-    await waitForLeadField(testEmail, "phone", updatedPhone);
-  });
-
-  test("deleting a contact in HubSpot removes the local lead", async ({
-    context,
-    page,
-    baseURL,
-  }) => {
-    test.setTimeout(60_000); // Webhook latency
-
-    await context.addCookies([getSessionCookie(session.signedToken, baseURL!)]);
-
-    const uniqueId = Date.now().toString(36);
-    const testEmail = `e2e-${uniqueId}@test.rekurve.dev`;
-    const testPhone = uniquePhone();
-    phones.push(testPhone);
-
-    // Step 1: Create a lead via the app
-    await page.goto("/leads/new");
-    const form = new LeadFormSection(page);
-    await form.fillStep1({
-      firstName: "Inbound",
-      lastName: `Delete ${uniqueId}`,
-      phone: testPhone,
-      email: testEmail,
-    });
-    await form.clickNext();
-    await form.selectSegmented("Has land", "No");
-    await form.clickNext();
-    await form.selectSegmented("Property type", "First Home Buyer");
-    await form.clickNext();
-    await form.clickSubmit();
-    await form.expectSuccess(`Inbound Delete ${uniqueId}`);
-
-    // Step 2: Wait for the outbox worker to stamp hubspotContactId
-    const hubspotId = await waitForLeadHubSpotId(testEmail);
-    expect(hubspotId).not.toBeNull();
-
-    // Step 3: Archive the contact in HubSpot
-    await archiveTestContact(hubspotId!);
-
-    // Step 4: Wait for the webhook to delete the local lead
-    await waitForLeadDeletion(testEmail);
-  });
-});
+// Inbound HubSpot → local sync (contact.propertyChange / contact.deletion) is
+// intentionally NOT honoured: the local DB is canonical and those webhook arms
+// were dropped in #288 (ADR-013). The drop is covered deterministically by the
+// webhook unit tests (src/app/api/hubspot/webhook/__tests__/route.test.ts:
+// "contact.propertyChange/deletion returns 200 with no DB writes"). The E2E
+// tests that asserted the old inbound-edit/-delete behaviour were removed here.

--- a/e2e/utils/hubspot-helper.ts
+++ b/e2e/utils/hubspot-helper.ts
@@ -110,14 +110,6 @@ export async function createTestContact(
   };
 }
 
-/** Update a contact's property in HubSpot. */
-export async function updateTestContact(
-  hubspotId: string,
-  properties: Record<string, string>,
-): Promise<void> {
-  await hubspot().crm.contacts.basicApi.update(hubspotId, { properties });
-}
-
 /** Archive (soft-delete) a contact in HubSpot. */
 export async function archiveTestContact(hubspotId: string): Promise<void> {
   await hubspot().crm.contacts.basicApi.archive(hubspotId);
@@ -262,50 +254,6 @@ export async function cleanupTestLeadsByPhone(phones: string[]): Promise<void> {
   }
 
   await sql()`DELETE FROM "leads" WHERE phone = ANY(${phones})`;
-}
-
-/**
- * Poll the local DB until a lead matching the email has the expected value,
- * or until the timeout expires. For verifying inbound webhook processing.
- */
-export async function waitForLeadField(
-  email: string,
-  field: string,
-  expected: string,
-  timeoutMs = 30_000,
-): Promise<void> {
-  const start = Date.now();
-  while (Date.now() - start < timeoutMs) {
-    const rows = await sql()`
-      SELECT * FROM "leads" WHERE email = ${email} LIMIT 1
-    `;
-    if (rows.length > 0 && String(rows[0]![field]) === expected) {
-      return;
-    }
-    await new Promise((r) => setTimeout(r, 2_000));
-  }
-  throw new Error(
-    `Timed out waiting for leads.${field} = "${expected}" (email: ${email})`,
-  );
-}
-
-/**
- * Poll the local DB until a lead matching the email no longer exists.
- * For verifying inbound webhook deletion.
- */
-export async function waitForLeadDeletion(
-  email: string,
-  timeoutMs = 30_000,
-): Promise<void> {
-  const start = Date.now();
-  while (Date.now() - start < timeoutMs) {
-    const rows = await sql()`
-      SELECT id FROM "leads" WHERE email = ${email} LIMIT 1
-    `;
-    if (rows.length === 0) return;
-    await new Promise((r) => setTimeout(r, 2_000));
-  }
-  throw new Error(`Timed out waiting for lead deletion (email: ${email})`);
 }
 
 /**


### PR DESCRIPTION
## What

Removes the two **"HubSpot Inbound Sync — E2E"** tests in `e2e/features/hubspot-sync.spec.ts` (`editing a contact's phone…` and `deleting a contact…`) and the three helpers they were the sole users of (`updateTestContact`, `waitForLeadField`, `waitForLeadDeletion`).

## Why

These tests assert behaviour that **#288** deliberately removed. Per **ADR-013** (local DB is canonical), the webhook now **drops** `contact.propertyChange` and `contact.deletion`:

```ts
case "contact.propertyChange":
case "contact.deletion":
  console.warn(`… Dropping ${event.subscriptionType} … inbound HubSpot edits are not honoured pre-PMF`);
  return;
```

So the inbound-edit test waits forever for a local change that will never happen → deterministic timeout (`Timed out waiting for leads.phone = "0499999999"`, **3/3 attempts**, ~43s each), and the delete test is skipped by serial mode after it.

### Why it stayed latent until now

The inbound block is gated on `HUBSPOT_WEBHOOK_ACTIVE`, set **only on production-targeted** post-deploy verification. #288's post-deploy runs were all **preview** (`HUBSPOT_WEBHOOK_ACTIVE` empty → block skipped → green). The first **production** run after #288 was the #296 merge commit (`86cc580`), which is where this surfaced — [run 26804064896](https://github.com/samjmarshall/rekurve/actions/runs/26804064896/job/79017356653). It is **not** caused by #296 (the dedup fix passed there); #288 simply never updated these E2E tests when it dropped the arms.

## Coverage

No real coverage lost — the drop is already covered deterministically and cheaply by the webhook **unit** tests:
- `route.test.ts` › *"contact.propertyChange returns 200 with no DB writes and a console.warn"*
- `route.test.ts` › *"contact.propertyChange ignores unmapped properties (still no DB write)"*
- `route.test.ts` › *"contact.deletion returns 200 with no DB writes and a console.warn"*

A left-behind comment in the spec points at those unit tests so the intent is discoverable.

## Verification

- `make check` — passes (incl. no unused-import lint errors after pruning).
- The outbound describe (`creating a lead…`, the #296 dedup fix) is untouched and unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)