### PR TITLE
fix(agents): codebase-locator opus + codebase-* routing rewrite

### DIFF
--- a/.claude/agents/codebase-analyzer.md
+++ b/.claude/agents/codebase-analyzer.md
@@ -1,6 +1,6 @@
 ---
 name: codebase-analyzer
-description: Analyzes codebase implementation details. Call the codebase-analyzer agent when you need to find detailed information about specific components. As always, the more detailed your request prompt, the better!
+description: Traces how specific code works — control flow, data flow, and integration points — reported with file:line citations. Use when you have the files and need their mechanics explained. Not for locating where code lives (use codebase-locator), reusable examples to copy (use codebase-pattern-finder), or design rationale recorded in docs/thoughts (use docs-analyzer / thoughts-analyzer).
 tools: Read, Bash
 color: orange
 model: opus

--- a/.claude/agents/codebase-locator.md
+++ b/.claude/agents/codebase-locator.md
@@ -1,9 +1,9 @@
 ---
 name: codebase-locator
-description: Locates files, directories, and components relevant to a feature or task. Call `codebase-locator` with human language prompt describing what you're looking for.
+description: Locates where code lives — files and components for a topic, grouped by purpose; paths only, not contents. Use to find where something is in the codebase. Not for how that code works or its symbols (use codebase-analyzer), reusable examples to copy (use codebase-pattern-finder), or non-code docs (use docs-locator).
 tools: Bash, Read
 color: red
-model: sonnet
+model: opus
 ---
 
 You are a specialist at finding WHERE code lives. You locate the files relevant to a topic and organize them by purpose. You do not analyze contents — that is `codebase-analyzer`'s job.
@@ -12,12 +12,13 @@ You are a specialist at finding WHERE code lives. You locate the files relevant 
 
 - Invoke `Bash`/`Read` as REAL tool calls — never emit tool-call-shaped text. Tool-shaped text returns nothing, and the gap invites fabrication.
 - Ground every path in a tool result from THIS run. Never infer, pattern-match, or recall paths from training data or framework conventions. `auth-context.tsx` may be empty, deleted, or unrelated to auth — verify, don't assume.
+- Report WHERE code lives, never what its internals are *named*. Don't cite a file's table, export, function, or variable names unless you read them verbatim this run — naming them from convention or memory is the most common fabrication. Symbol-level detail is `codebase-analyzer`'s job.
 - Zero matches is a valid answer: return `No matches found for: <pattern>`. Never fill an empty result with plausible defaults or a conventional Next.js/React layout.
 - `Bash` is read-only — `grep`, `rg`, `find`, `ls`, `wc`, `head` (verify one short file only). No writes, no redirections, no `git`, no package managers.
 
 ## Scope
 
-Document where code lives today — nothing more. Report only path-derived facts: directory location, filename, the pattern a name matched, sibling-file counts. Do not describe what a file does, what state it holds, or whether the structure is good; if asked a content question, return paths and add: `Cannot describe contents — use codebase-analyzer.` You are a map-maker, not a critic or analyst.
+Document where code lives today — nothing more. Report only path-derived facts: directory location, filename, the pattern a name matched, sibling-file counts. Do not describe what a file does, name the symbols/exports/tables it defines, what state it holds, or whether the structure is good; if asked a content question, return paths and add: `Cannot describe contents — use codebase-analyzer.` You are a map-maker, not a critic or analyst.
 
 ## Responsibilities
 
@@ -58,6 +59,5 @@ For any requested category with no hits, write `No matches found for: <pattern>`
 
 - Report locations, not contents; never read a file to explain what it does.
 - Be thorough — check multiple names, extensions, and locations; don't skip tests, config, or docs.
-- Annotate paths only with path-derived facts (directory, matched pattern, sibling count).
+- Annotate paths only with path-derived facts (directory, matched pattern, sibling count) — never the symbols, exports, or tables a file defines; if you didn't read them verbatim this run, you'll invent them.
 - Don't critique structure, suggest reorganization, or infer purpose from a filename.
-</content>

--- a/.claude/agents/codebase-pattern-finder.md
+++ b/.claude/agents/codebase-pattern-finder.md
@@ -1,6 +1,6 @@
 ---
 name: codebase-pattern-finder
-description: Find similar implementations, usage examples, or existing patterns that can be modeled after. It will give you concrete code examples based on what you're looking for! It's similar to codebase-locator, but it will not only tell you the location of files, it will also give you code details!
+description: Finds existing code examples and usage patterns to model new work on — real, working snippets with file:line, including test patterns. Use when you want a concrete precedent to copy. Not for locating files by topic (use codebase-locator), explaining how one component works (use codebase-analyzer), or ranking which approach is best (it shows examples, it doesn't judge).
 tools: Bash, Read
 color: orange
 model: sonnet
@@ -63,4 +63,3 @@ If no pattern matches, write `No matches found for: <pattern>` rather than inven
 - Include the test pattern; show variations that genuinely exist.
 - Give enough surrounding context that the caller can copy the pattern correctly.
 - No evaluation — don't rank, critique, flag anti-patterns, or recommend which to use.
-</content>

--- a/.claude/skills/subagent-eval/AUTHORING.md
+++ b/.claude/skills/subagent-eval/AUTHORING.md
@@ -8,9 +8,9 @@ The suite is organised as locator/analyzer pairs, one family per source-of-truth
 
 | Family | Source of truth | Locator | Analyzer | Altitude |
 |---|---|---|---|---|
-| `codebase-*` | code | red / sonnet | orange / **opus** (code tracing) | ~63 / ~78 lines |
+| `codebase-*` | code | red / **opus** (anti-fabrication) | orange / **opus** (code tracing) | ~63 / ~78 lines |
 | `thoughts-*` | transient designs/plans (speculative — infer staleness) | blue / sonnet | blue / sonnet | ~59 / ~68 lines |
-| `docs-*` | authoritative ADRs/feature docs (report recorded Status) | green / sonnet | green / sonnet | ~60 / ~66 lines |
+| `docs-*` | authoritative ADRs/feature docs (report recorded Status) | green / sonnet | green / sonnet | ~60 / ~59 lines |
 
 Pick by *what the agent reads* and *whether that source is speculative or authoritative* — that choice drives the analyzer's core stance (infer-staleness vs report-recorded-status).
 

--- a/.claude/skills/subagent-eval/REFERENCE.md
+++ b/.claude/skills/subagent-eval/REFERENCE.md
@@ -31,6 +31,8 @@ Positive-weight denominator = **9** (2+2+2+1+1+1), so a clean run scores exactly
 
 Score the agent `description` field, not execution: Correct-invoke on positives (+2), Non-invoke on negatives (+2), Scope-clarity what/when/when-not (0/0.5/1.0), Verbosity penalty if >60 words without routing value (−0.5). Run this as a separate pass when you change descriptions.
 
+**Bundled harness: `routing-harness-template.js`.** Unlike `harness-template.js` (which runs §6.3 *execution* candidates), the routing harness runs **no candidate** — blinded Opus judges read the on-disk `description`s, route a set of labelled probes among them (correct-invoke / non-invoke, including reciprocal-redirect traps that stress the docs⇄thoughts⇄code when-not boundaries), and rate scope-clarity + verbosity. Aggregation mirrors §6.4: `score = clip(0, 1, (2·correct-invoke + 2·non-invoke + 1·scope-clarity − 0.5·verbosity) / 5)` (positive-weight denominator = **5**; correct-/non-invoke are rates ∈ [0,1] over the probes). Fill the `POOL` + `PROBES` — verify every `expected` routing against the tree first — and launch. Run it whenever you change a `description` or add an agent.
+
 ## Model decision rule
 
 Default **sonnet** for every agent. Adopt **opus** only if, on the deciding (variance-controlled) axis, `mean(opus) ≥ mean(sonnet) + 0.05` AND opus isn't dragged by over-templating. Bar haiku for anything needing anti-hallucination discipline (§14.1: haiku could not follow the CRITICAL rules in 2026-05-04 testing).
@@ -55,16 +57,21 @@ A sub-agent file created **this session** is NOT in the harness's hot agent regi
 
 The native baseline (`Explore`) is always registered, so the comparison stays fair either way.
 
+## Harness placement — the commit trap
+
+Keep an adapted harness **inline** (paste it as the Workflow `script`) or in **`/tmp`**. Never save it under `.claude/eval/` or any other Biome-linted path: a top-level `return` (valid in the Workflow runtime) is a **Biome parse error**, and the husky pre-commit runs `make check` → Biome over `**`, so the bad parse **blocks every commit in the repo** until the file is moved. `.claude/skills/` is the one `.claude/` path Biome excludes (`biome.json`: `!.claude/skills`) — which is why the bundled `*-harness-template.js` files live there safely. To iterate, edit the copy the Workflow tool persists to the session dir (it returns the path), not a repo file.
+
 ## Safety review (mandatory after any multi-agent run)
 
 - ☐ `git status --porcelain` — every change is inside the intended seam (the agent file(s), command wiring, research doc). `thoughts/` is gitignored, so the research doc won't appear — confirm it's on disk separately.
-- ☐ `ls .claude/agents/*.md | wc -l` — roster count unchanged (catch a stray deletion).
-- ☐ `git restore` / remove anything a sub-agent wrote outside the seam.
-- The agents' read-only-`Bash` Grounding fence is the structural mitigation; verify after the fact regardless.
+- ☐ `ls .claude/agents/*.md | wc -l` — roster count unchanged.
+- ☐ `git restore` / remove anything written outside the seam.
+- **Verify provenance before blaming a sub-agent.** If the working tree shifted mid-run, check `git reflog` + commit author first — it's usually the operator's own concurrent commit/branch switch, not a sub-agent. The registered agents' read-only-`Bash` fence makes a destructive sub-agent write unlikely; judges run with default tools, so still verify the seam.
 
-## Lessons from the three runs
+## Lessons from the runs
 
-- **Need headroom to discriminate.** A well-curated repo (explicit Status frontmatter, clear titles, cross-links) lets even `Explore@haiku` hit ~1.0 on analyze tasks — so the specialist *ties* rather than beats. Build at least one hard/adversarial task, and report ties honestly. The specialist's edge often lives in LOCATE + routing discipline, not analyze accuracy.
+- **Need headroom to discriminate.** A well-curated repo (explicit Status frontmatter, clear titles, cross-links) lets even `Explore@haiku` hit ~1.0 on analyze tasks — so the specialist *ties* rather than beats (confirmed four times, incl. the codebase webhook smoke). Build at least one hard/adversarial task, and report ties honestly. The specialist's edge often lives in LOCATE + routing discipline, not analyze accuracy.
 - **Real-tool-invocation is a proxy** in a Workflow (no transcript `tool_uses` mid-run) — the judge's path-verification covers the fabricated-path case.
-- **Variance is large** on prose tasks — a single run swings; the ≥3×≥2 control is what makes the model decision trustworthy.
+- **Variance is large — on locates too, not just prose.** A single run swings: one `codebase-locator@sonnet` run fabricated an `ln` naming scheme (2026-06-03 smoke) and flipped the decision rule to opus. The ≥3×≥2 control is what makes ANY model decision trustworthy — never decide from an n<3 cell.
+- **A verify-first judge can be more correct than the oracle.** In the smoke the panel flagged the oracle's own PRODUCERS mislabel (only the enqueuer produces). Trust the tree; fix the oracle when the judge is right.
 - **Corpus grows itself** — the `SubagentStop` harvest hook appends real runs to `corpus.jsonl`; mine before each eval to benchmark on real prompts.

--- a/.claude/skills/subagent-eval/SKILL.md
+++ b/.claude/skills/subagent-eval/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: subagent-eval
-description: Empirically evaluate and optimise Claude Code sub-agents via a blinded head-to-head against the production baseline, then decide each agent's model on data. Use when tuning a sub-agent's prompt, choosing or re-checking its model (e.g. after a new model release), proving an agent change before committing, or comparing a specialist agent against native Explore. Covers the loop: head-to-head harness, §6.3 rubric, model-decision rule, routing wiring, post-run safety review. To author a brand-new agent first, read AUTHORING.md.
+description: Empirically evaluate and optimise a Claude Code sub-agent via a blinded head-to-head against the production baseline, then pick its model on data. Use when tuning a sub-agent's prompt, choosing or re-checking its model (e.g. a new model release), proving an agent change before committing, or testing whether a specialist beats native Explore. To author a new agent first, read AUTHORING.md.
 ---
 
 # Sub-agent eval & optimise
@@ -20,26 +20,28 @@ This is a multi-agent `Workflow` (opt-in — it spends real tokens). Say "use a 
 
 1. **Frame & pick entry mode.** State the agent(s) under test and the decision to make (ship this prompt? which model?). For create, do AUTHORING.md first.
 2. **Build the benchmark.** Per archetype the agent serves (e.g. locate / analyze):
-   - Mine real prompts: `python3 .claude/eval/mine_subagents.py --print` → pull from `.claude/eval/mined/corpus.jsonl`.
+   - Mine real prompts: `python3 .claude/eval/mine_subagents.py --print` → pull from `.claude/eval/mined/corpus.jsonl` (shape rows into tasks with `shape_tasks.py`).
    - Add a **golden** task (hand-written, clear oracle) and an **adversarial** task (zero-match / trap).
    - Write a **verified oracle** for each — confirm every expected path/value against the tree *now*.
    - ☐ Include at least one HARD task with headroom. Near-ceiling tasks don't discriminate — a well-curated repo makes even `Explore@haiku` score ~1.0 (see `docs-*` example).
 3. **Run the head-to-head.** Adapt **[harness-template.js](harness-template.js)** and launch via `Workflow`. Candidates per task: native baseline (`Explore` @ its production model, usually haiku), specialist @ `sonnet`, specialist @ `opus`.
-   - ☐ **Variance-control the deciding axis**: ≥3 runs × ≥2 judges per cell for the model decision; 1 run is fine for low-variance locates.
+   - ☐ **Variance-control the deciding axis**: ≥3 runs × ≥2 judges per cell for any model decision. 1 run scouts a locate, but never flip a model from a single-run cell — a lone run can fabricate (the `ln` incident) and swing the mean; the harness now flags an n<3 promotion as inconclusive.
    - ☐ Judges are **blinded** (no candidate id) and **verify every claimed path/Status/citation against the tree** before scoring. See REFERENCE.md.
    - ☐ Registry gotcha: a just-created agent is NOT in the session's hot registry — either restart to register, or use the harness's adopt-on-disk bootstrap. See REFERENCE.md.
+   - ☐ Script placement: paste the harness inline (or keep it in `/tmp`); never save an adapted copy under `.claude/eval/` — its top-level `return` trips Biome and blocks the husky pre-commit. See REFERENCE.md.
 4. **Decide each model quality-first.** Default `sonnet`. Adopt `opus` for an agent ONLY if `mean(opus) ≥ mean(sonnet) + 0.05` AND it isn't dragged by over-templating. Model choice is **task-shaped, not class-shaped** — see REFERENCE.md § Model decision.
 5. **Wire routing** (if creating/changing an agent's role). Add it to the command fan-outs (`create_plan.md`, `brainstorm.md`, `iterate_plan.md`) and tighten reciprocal when-not redirects in sibling agents' descriptions.
 6. **Verify + safety.**
    - ☐ `make check` via **@agent-codebase-verification** (never run `make` directly).
-   - ☐ **After any multi-agent run**: review the FULL `git status` + `git diff`; confirm the agent roster count is unchanged (`ls .claude/agents/*.md | wc -l`); `git restore` anything a sub-agent touched outside the intended seam. A stray sub-agent `Bash` call once deleted an unrelated agent file.
+   - ☐ **After any multi-agent run**: review the FULL `git status` + `git diff`; confirm the agent roster count is unchanged (`ls .claude/agents/*.md | wc -l`); `git restore` anything outside the intended seam. Verify provenance before blaming a sub-agent — git state that shifts mid-run is usually the operator's own concurrent commits/branch switches (check `git reflog` + author), not a stray `Bash` call.
 7. **Record.** Write `thoughts/research/<YYYY-MM-DD>-<family>-agent-headtohead.md`, mirroring an existing example: TL;DR → Setup → Results → Decisions applied → Key findings → Per-run JSON → Caveats → Fast follow. Be honest — a tie or a null result is a real finding.
 
 ## References
 
-- **[REFERENCE.md](REFERENCE.md)** — §6.3 rubric, §6.4 aggregation, model-decision rule, judge-prompt pattern, registry/bootstrap gotcha, safety checklist, lessons from the 3 runs.
+- **[REFERENCE.md](REFERENCE.md)** — §6.3 rubric, §6.4 aggregation, model-decision rule, judge-prompt pattern, registry/bootstrap gotcha, safety checklist, lessons from the runs.
 - **[AUTHORING.md](AUTHORING.md)** — how to write a new agent before validating it.
-- **[harness-template.js](harness-template.js)** — parameterized `Workflow` head-to-head script; fill the tasks/oracles/candidates and launch.
+- **[harness-template.js](harness-template.js)** — parameterized `Workflow` head-to-head for the **§6.3 execution** pass; fill the tasks/oracles/candidates and launch.
+- **[routing-harness-template.js](routing-harness-template.js)** — the **§6.2 routing** pass: scores `description`s with no candidate execution — blinded judges route probes among the on-disk descriptions and rate scope-clarity + verbosity. See REFERENCE.md §6.2.
 - **System of record:** `thoughts/designs/2026-04-21-sub-agent-eval-pipeline.md` (§6.2 routing, §6.3 execution, §6.4 aggregation, §14.1 model floor).
 - **Worked examples** (copy one): `thoughts/research/2026-06-02-codebase-agent-headtohead.md`, `…/2026-06-03-thoughts-agent-headtohead.md`, `…/2026-06-03-docs-agent-headtohead.md`.
 - **Corpus tooling:** `.claude/eval/{mine_subagents,shape_tasks,harvest_hook}.py`.

--- a/.claude/skills/subagent-eval/harness-template.js
+++ b/.claude/skills/subagent-eval/harness-template.js
@@ -115,13 +115,17 @@ function meanOver(kind, candId) {
   const cs = cells.filter(c => runs.find(r=>r.taskId===c.taskId&&r.kind===kind) && c.candidateId===candId)
   return cs.length ? Number((cs.reduce((a,c)=>a+c.meanScore,0)/cs.length).toFixed(3)) : null
 }
-// Decision rule: default sonnet; adopt opus only if mean(opus) >= mean(sonnet)+0.05.
+// Decision rule: default sonnet; adopt opus only if mean(opus) >= mean(sonnet)+0.05
+// AND the deciding axis is variance-controlled (>=3 runs). A single run can fabricate and flip
+// the rule to opus on noise (the `ln` incident, 2026-06-03 smoke) — never promote from an n<3 cell.
 const decision = {}
 for (const kind of ['locate','analyze']) {
   const sonnet = meanOver(kind,'specialist-sonnet'), opus = meanOver(kind,'specialist-opus'), base = meanOver(kind,'explore-haiku')
-  decision[kind] = { baseline:base, sonnet, opus, beatsBaseline: sonnet!=null && base!=null && sonnet>base,
-                     ship: (opus!=null && sonnet!=null && opus-sonnet>=0.05) ? 'opus' : 'sonnet' }
-  log(`${kind}: baseline=${base} sonnet=${sonnet} opus=${opus} -> ship ${decision[kind].ship}`)
+  const decidingN = Math.min(Infinity, ...cells.filter(c => runs.find(r=>r.taskId===c.taskId&&r.kind===kind)).map(c=>c.nRuns))
+  const promote = opus!=null && sonnet!=null && opus-sonnet>=0.05
+  decision[kind] = { baseline:base, sonnet, opus, decidingN, beatsBaseline: sonnet!=null && base!=null && sonnet>base,
+                     ship: promote ? (decidingN>=3 ? 'opus' : `inconclusive: opus>sonnet but deciding axis n=${decidingN}<3 — re-run >=3x>=2 before promoting`) : 'sonnet' }
+  log(`${kind}: baseline=${base} sonnet=${sonnet} opus=${opus} n=${decidingN} -> ${decision[kind].ship}`)
 }
 
 return { decision, cells, runs }

--- a/.claude/skills/subagent-eval/routing-harness-template.js
+++ b/.claude/skills/subagent-eval/routing-harness-template.js
@@ -1,0 +1,177 @@
+// Sub-agent ROUTING-rubric harness — TEMPLATE (§6.2 pass).
+// Companion to harness-template.js (which scores §6.3 EXECUTION). This one runs NO
+// candidate — it scores the agent `description` field, the only thing the planner sees
+// when choosing a tool. Use it after you edit descriptions or add an agent, to prove the
+// description set routes real prompts to the right specialist and reads its when-not redirects.
+// Adapt the «FILL» blocks, then launch via the Workflow tool (paste inline as `script`).
+// Plain JS — no Date.now()/Math.random(). Lives under .claude/skills/ (biome-excluded; a
+// top-level `return` here is fine — never save an adapted copy under .claude/eval/, see REFERENCE.md).
+
+export const meta = {
+  name: 'routing-rubric-pass',
+  description: '§6.2 routing pass: score agent DESCRIPTIONS (no execution). Blinded Opus judges read on-disk descriptions, route probes among them (correct-invoke / non-invoke), and rate scope-clarity + verbosity.',
+  phases: [
+    { title: 'Load',  detail: 'read every candidate description from disk once' },
+    { title: 'Route', detail: 'blinded judge routes each probe among the descriptions' },
+    { title: 'Describe', detail: 'blinded judge rates each description: scope-clarity + verbosity' },
+  ],
+}
+
+const ROOT = '«/abs/path/to/repo»'                          // «FILL» repo root
+
+// «FILL» the routing pool — the agents the planner chooses among. Judges READ each file's
+// `description:` frontmatter this run (no inlined/stale text). 'none' is always an implicit
+// option = no specialist should claim it (a general-purpose/Explore agent handles it).
+const POOL = [
+  { name: 'docs-locator',      file: '.claude/agents/docs-locator.md' },
+  { name: 'docs-analyzer',     file: '.claude/agents/docs-analyzer.md' },
+  { name: 'thoughts-locator',  file: '.claude/agents/thoughts-locator.md' },
+  { name: 'thoughts-analyzer', file: '.claude/agents/thoughts-analyzer.md' },
+  { name: 'codebase-locator',  file: '.claude/agents/codebase-locator.md' },
+  { name: 'codebase-analyzer', file: '.claude/agents/codebase-analyzer.md' },
+]
+
+// «FILL» labelled probes. `expected` ∈ a POOL name or 'none'. Cover, per agent:
+//   - a POSITIVE (a prompt that agent should win) — feeds correct-invoke,
+//   - the RECIPROCAL-REDIRECT TRAPS that stress the when-not boundaries (docs⇄thoughts⇄codebase),
+//   - NEGATIVES (expected:'none') a specialist must NOT grab — feeds non-invoke.
+// Verify every `expected` against the tree NOW (the oracle is the routing decision a correct
+// description set produces). Examples below are verified against this repo 2026-06-03.
+const PROBES = [
+  // positives — one per agent
+  { id: 'POS-docs-loc',  prompt: 'Which ADR governs the transactional outbox + Inngest-delivery design?', expected: 'docs-locator' },
+  { id: 'POS-docs-an',   prompt: 'Using docs/adr/adr013-local-db-canonical-for-lead-data.md, what did we decide and what is its recorded Status?', expected: 'docs-analyzer' },
+  { id: 'POS-thx-loc',   prompt: 'Find the design doc and any research notes on the sub-agent evaluation pipeline.', expected: 'thoughts-locator' },
+  { id: 'POS-thx-an',    prompt: 'From thoughts/designs/2026-04-21-sub-agent-eval-pipeline.md, extract the key decisions and whether they still hold.', expected: 'thoughts-analyzer' },
+  { id: 'POS-code-loc',  prompt: 'Where in the code does the outbox sweep cron live?', expected: 'codebase-locator' },
+  { id: 'POS-code-an',   prompt: 'Walk through how the outbox sweep delivers events to Inngest, with file:line refs.', expected: 'codebase-analyzer' },
+  // reciprocal-redirect traps — the headline test (authoritative vs speculative boundary)
+  { id: 'TRAP-ship-vs-spec', prompt: 'What did we decide and SHIP about Lead data being the canonical store, and is that decision still current?', expected: 'docs-analyzer' },   // executed decision (adr013) → NOT thoughts-analyzer
+  { id: 'TRAP-spec-vs-ship', prompt: 'Distil the PROPOSED sub-agent eval design and whether the proposal still holds.', expected: 'thoughts-analyzer' },                          // speculative design → NOT docs-analyzer
+  { id: 'TRAP-loc-spec',     prompt: 'Find the speculative design/plan docs about the sub-agent eval pipeline.', expected: 'thoughts-locator' },                                    // thoughts/ not docs/
+  { id: 'TRAP-loc-decision', prompt: 'Which ADR is the system-of-record for the outbox-delivery decision?', expected: 'docs-locator' },                                            // docs/ not thoughts/
+  // negatives — no specialist should claim these
+  { id: 'NEG-commit', prompt: 'Write a conventional-commit message for the staged changes.', expected: 'none' },
+  { id: 'NEG-impl',   prompt: 'Refactor the outbox sweep to batch deliveries in groups of 50.', expected: 'none' },
+]
+
+const JUDGES_PER_PROBE = 2     // 1 scouts; ≥2 to trust a description CHANGE (mirrors §6.4 variance discipline)
+const clamp = x => Math.max(0, Math.min(1, x))
+
+const ROUTE_SCHEMA = {
+  type: 'object', additionalProperties: false,
+  required: ['chosen', 'readDescriptions', 'confidence', 'rationale'],
+  properties: {
+    chosen:           { type: 'string', description: "EXACT name of the one agent the planner should invoke, or 'none' if a general-purpose agent should handle it." },
+    readDescriptions: { type: 'boolean', description: 'You based the choice on the provided descriptions, not on the agent names alone.' },
+    confidence:       { type: 'string', enum: ['high', 'medium', 'low'] },
+    rationale:        { type: 'string', description: '1-2 sentences: which when/when-not clause decided it.' },
+  },
+}
+
+const DESC_SCHEMA = {
+  type: 'object', additionalProperties: false,
+  required: ['hasWhat', 'hasWhen', 'hasWhenNot', 'scopeClarity', 'wordCount', 'overSixtyWords', 'verbosityWithoutRoutingValue', 'rationale'],
+  properties: {
+    hasWhat:       { type: 'boolean', description: 'States WHAT the agent does (its surface).' },
+    hasWhen:       { type: 'boolean', description: 'States WHEN to use it (positive trigger), beyond restating the what.' },
+    hasWhenNot:    { type: 'boolean', description: 'States WHEN NOT to use it, with a reciprocal redirect to the right sibling.' },
+    scopeClarity:  { type: 'number', enum: [0, 0.5, 1], description: '§6.2 3-point: 0 = only what (or vague); 0.5 = what + when; 1.0 = what + when + a reciprocal when-not.' },
+    wordCount:     { type: 'integer', description: 'Words in the description field.' },
+    overSixtyWords:{ type: 'boolean', description: 'wordCount > 60.' },
+    verbosityWithoutRoutingValue: { type: 'boolean', description: 'PENALTY: over 60 words AND the surplus does NOT add routing value (a redirect/disambiguation IS routing value).' },
+    rationale:     { type: 'string', description: '1-2 sentences.' },
+  },
+}
+
+// ---- Phase 1: load every description from disk once (real Read; grounds the judges) ----
+phase('Load')
+const LOAD_SCHEMA = {
+  type: 'object', additionalProperties: false, required: ['descriptions'],
+  properties: { descriptions: { type: 'array', items: {
+    type: 'object', additionalProperties: false, required: ['name', 'description'],
+    properties: { name: { type: 'string' }, description: { type: 'string' } } } } },
+}
+const loaded = await agent(
+  'Repo root: ' + ROOT + '. For EACH file below, Read it and return the verbatim text of its YAML frontmatter `description:` field (the routing signal) — no other lines. Files:\n'
+    + POOL.map(a => `- ${a.name}: ${a.file}`).join('\n'),
+  { label: 'load-descriptions', phase: 'Load', schema: LOAD_SCHEMA },
+)
+const DESize = {}
+for (const d of (loaded?.descriptions || [])) DESize[d.name] = d.description
+const present = POOL.filter(a => DESize[a.name])
+if (present.length < 2) { log('FATAL: fewer than 2 descriptions loaded — check POOL paths.'); return { error: 'load-failed', loaded } }
+log(`${present.length}/${POOL.length} descriptions loaded.`)
+
+// The blinded routing menu: names + descriptions, NO ground-truth labels.
+const MENU = present.map(a => `### ${a.name}\n${DESize[a.name]}`).join('\n\n')
+
+function routePrompt(probe) {
+  return 'You are a STRICT, BLINDED router emulating the planner that picks ONE Claude Code sub-agent for a user request, seeing ONLY each agent\'s description (its routing signal). '
+    + 'Choose the single best-fitting agent, or "none" if no specialist fits and a general-purpose agent should handle it. Weigh each description\'s when / when-not clauses; respect reciprocal redirects (e.g. authoritative docs/ vs speculative thoughts/ vs code).\n\n'
+    + 'CANDIDATE AGENTS:\n' + MENU + '\n\nUSER REQUEST:\n"""\n' + probe.prompt + '\n"""\n\n'
+    + 'Return the exact chosen name (or "none"). Do not infer from the names alone — decide from the descriptions.'
+}
+function descPrompt(name) {
+  return 'You are a STRICT evaluator scoring ONE Claude Code sub-agent DESCRIPTION on the §6.2 routing rubric (you are NOT running the agent). '
+    + 'The description is the only routing signal the planner sees; good ones state what / when / when-not with reciprocal redirects, in <=60 words.\n\n'
+    + 'AGENT: ' + name + '\nDESCRIPTION:\n"""\n' + DESize[name] + '\n"""\n\n'
+    + 'Score scope-clarity (0/0.5/1.0 per schema), count the words, and decide the verbosity penalty (only if >60 words AND the surplus adds no routing value — a redirect counts as routing value).'
+}
+
+// ---- Phase 2 + 3: route every probe, and rate every description (independent, pipelined) ----
+const routeWork = []
+for (const p of PROBES) for (let j = 0; j < JUDGES_PER_PROBE; j++) routeWork.push({ probe: p, j })
+const descWork = present.map(a => a.name)
+
+const [routeScored, descScored] = await parallel([
+  () => parallel(routeWork.map(w => () =>
+    agent(routePrompt(w.probe), { label: `route:${w.probe.id}#${w.j}`, phase: 'Route', model: 'opus', schema: ROUTE_SCHEMA })
+      .then(v => ({ probe: w.probe, verdict: v })).catch(() => null))),
+  () => parallel(descWork.map(name => () =>
+    parallel(Array.from({ length: 2 }, (_, j) => () =>
+      agent(descPrompt(name), { label: `desc:${name}#${j}`, phase: 'Describe', model: 'opus', schema: DESC_SCHEMA }).catch(() => null)))
+      .then(js => ({ name, verdicts: js.filter(Boolean) })))),
+])
+
+// ---- Aggregate per agent (§6.2): score = clip(0,1, (2·correctInvoke + 2·nonInvoke + 1·scopeClarity − 0.5·verbosity)/5) ----
+// Majority-vote each probe's routing across its judges (ties → 'none').
+const probeChoice = {}
+for (const p of PROBES) {
+  const votes = routeScored.filter(Boolean).filter(r => r.probe.id === p.id).map(r => r.verdict?.chosen).filter(Boolean)
+  const tally = {}
+  for (const c of votes) tally[c] = (tally[c] || 0) + 1
+  let best = 'none', bestN = -1
+  for (const [c, n] of Object.entries(tally)) if (n > bestN) { best = c; bestN = n }
+  probeChoice[p.id] = { chosen: best, votes: tally, expected: p.expected }
+}
+
+const descAgg = {}
+for (const d of descScored.filter(Boolean)) {
+  const vs = d.verdicts
+  if (!vs.length) continue
+  const sc = vs.reduce((a, x) => a + x.scopeClarity, 0) / vs.length
+  // penalty fires only if a majority of judges saw unjustified verbosity
+  const pen = vs.filter(x => x.verbosityWithoutRoutingValue).length > vs.length / 2 ? 1 : 0
+  descAgg[d.name] = { scopeClarity: Number(sc.toFixed(3)), verbosityPenalty: pen, wordCount: vs[0].wordCount }
+}
+
+const report = present.map(a => {
+  const name = a.name
+  const positives = PROBES.filter(p => p.expected === name)
+  const negatives = PROBES.filter(p => p.expected !== name)
+  const correctInvoke = positives.length ? positives.filter(p => probeChoice[p.id].chosen === name).length / positives.length : null
+  const nonInvoke = negatives.length ? negatives.filter(p => probeChoice[p.id].chosen !== name).length / negatives.length : null
+  const d = descAgg[name] || { scopeClarity: 0, verbosityPenalty: 0, wordCount: null }
+  const ci = correctInvoke ?? 0, ni = nonInvoke ?? 0
+  const score = clamp((2 * ci + 2 * ni + 1 * d.scopeClarity - 0.5 * d.verbosityPenalty) / 5)
+  return { name, correctInvoke, nonInvoke, scopeClarity: d.scopeClarity, verbosityPenalty: d.verbosityPenalty, wordCount: d.wordCount, routingScore: Number(score.toFixed(3)) }
+})
+
+for (const r of report) log(`${r.name}: correct-invoke=${r.correctInvoke} non-invoke=${r.nonInvoke} scope=${r.scopeClarity} verbPen=${r.verbosityPenalty} -> ${r.routingScore}`)
+// Misroutes worth reading by hand (trap failures live here):
+const misroutes = PROBES.filter(p => probeChoice[p.id].chosen !== p.expected)
+  .map(p => ({ id: p.id, prompt: p.prompt, expected: p.expected, got: probeChoice[p.id].chosen, votes: probeChoice[p.id].votes }))
+log(`${misroutes.length}/${PROBES.length} probes misrouted.`)
+
+return { report, probeChoice, misroutes }


### PR DESCRIPTION
## Symptom

`main` currently ships `codebase-locator` at `model: sonnet`, where it systematically fabricates internal symbol names — renaming the `outbox` table and its exports to invented `ln`-derived tokens (`ln`, `lnSweep`, `./ln`) while keeping every file path correct, so the fabrication reads as plausible and misleads downstream design/implementation work. Separately, the three `codebase-*` descriptions are the agent suite's weakest routing signal, and two of the agent prompts (`codebase-locator`, `codebase-pattern-finder`) carry a stray `</content>` tag at end-of-file that leaks into the model's system prompt.

## Cause

PR #298 was squash-merged into `main` from an earlier branch state — before the `codebase-locator → opus` fix and the `subagent-eval` skill hardening were committed — so those changes never actually reached `main` despite being described in #298. The fabrication is model-specific: at sonnet the locator confabulates symbol names without reading file contents; the prompt-only prohibition does not hold it. The routing weakness is the original terse descriptions, which lack the what / when / when-not + reciprocal-redirect structure the `docs-*` / `thoughts-*` pairs now use (the design doc predicted this at §13.1/§14.1).

## Fix

Re-lands the fix and folds in this session's improvements, all empirically grounded by the `subagent-eval` harness:

- **`codebase-locator → opus`** + symbol-annotation prohibition. A registered-path eval (workflow `w5eus24b4`) measured opus at **0/6** symbol fabrication vs sonnet **4/4** on the outbox LOCATE — the model upgrade, not the prompt, is the fix.
- **Rewrote the `codebase-{locator,analyzer,pattern-finder}` descriptions** to the `docs-*`/`thoughts-*` standard (what/when/when-not + reciprocal redirects, <60 words). The new §6.2 routing pass (workflow `wi6s02o32`) lifted them from scope-clarity 0.25/0.50 to a clean **1.00**, with 15/15 probes routed correctly including codebase-sibling disambiguation.
- **Removed the stray `</content>` tags** from the two agent prompts.
- **`subagent-eval` skill**: carried forward the n<3 decision-rule hardening, fixed a stale AUTHORING model table, documented the `.claude/eval` biome/husky commit-trap, and added **`routing-harness-template.js`** — the §6.2 routing pass (no candidate execution; blinded judges route probes among the on-disk descriptions), closing the skill's one documented gap.

## Why not keep the prompt fix at sonnet?

The eval shows the symbol-annotation prohibition alone does not hold at sonnet — 4/4 judged runs still fabricated `ln`. Only the opus upgrade eliminated it (0/6). Cost/latency is the trade, justified for the suite's highest-stakes locator.

## Out of scope

- No application code, tests, DB schema, or migrations.
- `codebase-analyzer` (already opus) and `codebase-pattern-finder` (sonnet, verified clean 0/6) model assignments unchanged.
- The `codebase-analyzer` / `codebase-pattern-finder` `color: orange` collision (an AUTHORING-standard nit) is left as-is.
- `docs/README.md` left at `main`'s version (the diverged branch's copy was older).

## Callouts

- **Regression risk**: `codebase-locator` now runs opus (higher cost/latency). This is deliberate anti-fabrication and is the documented model floor.
- This PR **re-lands work that diverged from `main` after #298's squash-merge** — the opus fix was reviewed on #298's branch but never actually merged. Reviewers comparing against #298 should note `main` still has the sonnet/fabricating version.
- Full empirical writeup (both eval workflows, per-run JSON, caveats) is in `thoughts/research/2026-06-03-routing-and-locator-confirmation.md` (local; `thoughts/` is gitignored).
