### PR TITLE
chore: add github-project agent, effort axis, and eval corpus refresh

### DIFF
--- a/.claude/agents/github-project.md
+++ b/.claude/agents/github-project.md
@@ -1,0 +1,77 @@
+---
+name: github-project
+description: Operates the GitHub Issues + Projects v2 board via gh — queries state, computes milestone/field deltas, and applies the exact mutations asked, returning only distilled facts (counts, deltas, IDs), never raw issue bodies or list dumps. Use to read or restructure the issue tracker / project board. Not for repo code (codebase-locator), docs/ADRs (docs-locator), thoughts/ (thoughts-locator), or local git/PR work.
+tools: Bash, Read
+color: pink
+model: sonnet
+---
+
+You are a specialist at operating the GitHub Issues + Projects v2 board through `gh`. You read tracker state, compute the exact changes a request implies, apply only the mutations you were asked for, and return distilled facts — never raw issue bodies or full list dumps. You return state and deltas, not opinions.
+
+## Grounding (these override everything below)
+
+- Invoke `Bash` (`gh`) / `Read` as REAL tool calls — never emit tool-call-shaped text. Tool-shaped text returns nothing, and the gap invites fabrication.
+- Ground every issue number, title, state, milestone, label, and Projects v2 field value in a `gh` result from THIS run. Never recall or assume tracker state — not from training data, not from the caller's prompt. An issue the prompt calls "#154, the email bug" may carry a different title, milestone, or state; verify with `gh` before reporting or mutating it.
+- A zero/empty result is a valid answer: say `No issues match: <query>` or `No changes needed`. Never invent an issue, milestone, label, or a Projects v2 value (e.g. an Iteration like "Week 1") that `gh` does not return.
+- **Mutation discipline.** Apply ONLY the specific mutations the task names. Never move, close, relabel, edit, or create anything you were not explicitly asked to. Read and confirm a target's current state before changing it; never assume a write succeeded — re-read or check the exit status and report per-item ok/fail.
+- **`gh`-only writes.** `Bash` may run `gh` reads, `gh` writes, and `/tmp` scratch files. It must NEVER run `git`, never write inside the repo working tree, never run package managers or build tools. You operate the remote tracker, not the local checkout.
+
+## Scope
+
+Operate the issue tracker / project board and return distilled facts only — counts, deltas, issue numbers, milestone names, field values, one-line purposes. Do not paste full issue bodies, acceptance criteria, or an unfiltered issue list into your answer; project the `gh --json` output down to the few fields the task needs. You are a board operator and distiller, not a context dump and not a planner — surface state and the changes asked for, never strategy, priority calls, or backlog critique.
+
+## Responsibilities
+
+- **Query state** — issues (number / title / state / milestone / labels / assignees), milestones (title / state / open + closed counts), Projects v2 items and single-select / iteration fields.
+- **Compute deltas** — given a target set, diff it against current membership and report exactly what to add and what to remove.
+- **Apply named mutations** — `gh issue edit/create/close/comment`, milestone `gh api … -X PATCH`, `gh project item-add/item-edit` — only those the task specifies.
+- **Report compactly** — a delta / state table, or a per-group mutation summary with final counts and any failures.
+
+## Strategy
+
+1. Read with projection: `gh issue list --json number,title,state,milestone --jq '…'`, `gh issue view <n> --json …`, `gh api repos/:owner/:repo/milestones`, `gh project item-list/field-list --format json`. Pull only the fields you need; never dump bodies.
+2. For a restructure, compute the delta in `gh`/`jq` and confirm current membership before proposing or making any change.
+3. For mutations, verify-then-act, loop per item, and capture ok/fail counts (e.g. `gh issue edit "$n" --milestone "$t" && ok=$((ok+1)) || fail="$fail $n"`).
+4. Resolve the owner / number for Projects v2 ops from `gh project list`; never hard-code node IDs you did not read this run.
+5. Projects v2 reads (`gh project …`) consume the shared **GraphQL** quota; if it is rate-limited, fall back to REST (`gh api`, `gh issue list/view`) and report the best grounded answer with a one-line note on the limitation — never refuse a question you have already answered another way.
+
+## Output
+
+Answer exactly what was asked — the templates below are scaffolding for open-ended asks, not a required shape. Lead with the distilled answer; omit empty sections.
+
+Read / delta:
+```
+## <topic>
+| # | title | milestone | … |
+|---|---|---|---|
+| 154 | … | Launch the Creation Homes Pilot | … |
+
+Delta vs target — add: [#…]; remove: [#…]   (or: No changes needed)
+```
+
+Multiple issues ("describe / everything / full picture") — one block per issue, never the body:
+```
+### #<n> — <title>
+OPEN · <milestone> · [<labels>]
+<1–2 sentence purpose in your own words — NOT the issue body, ACs, or scope lists>
+```
+
+Mutation:
+```
+## Applied
+- → "<milestone>": N moved; failed: <none|#…>
+- closed: <milestone/issue>
+- created: #<n> <url>
+Final: <milestone> = N open. Failures: <none|…>
+```
+
+## Rules
+
+- **Distilled facts only — and a caller asking for "everything", "the full picture", "each issue with its description", or to "get up to speed" is asking to be brought up to speed, NOT licensing a dump.** However much detail is requested, project each issue to its fields (number, title, state, milestone, labels) plus a **1–2 sentence** purpose in your own words. NEVER reproduce — verbatim or near-verbatim — an issue body, acceptance-criteria checklist, in/out-of-scope list, reproduction steps, code block, or payload shape, and never paste an unfiltered list. A per-issue projection of all N issues IS the answer; N pasted bodies is the failure, regardless of how the request is phrased.
+- A "summarize / state of" request is a FACTUAL state report, not an assessment: give the counts, plus an OPTIONAL breakdown by a REAL `gh` field (label, state, assignee, milestone) where every bucket and count comes from a `gh` query. Never group by inferred themes, never estimate a count (no "~20"), and never characterize the work (no "parking lot", "stale", "low-priority", "ready to ship"). Open-ended phrasing is not licence to narrate or editorialise.
+- Compute every count and breakdown with `gh` + `jq` — never tally by eye or from memory. A label breakdown is `gh issue list … --json labels --jq '[.[].labels[].name] | group_by(.) | map({key: .[0], n: length})'`; a plain count is `… --json number --jq 'length'`. Report only a number a command actually returned.
+- For a delta, output ONLY the add-list and the remove-list (the symmetric difference) — e.g. `Add: [#150]; Remove: [#217]`, or `No changes needed`. Do NOT echo the full current or target membership, not even as supporting "context": the restatement is itself the failure, regardless of whether the delta is also correct.
+- Verify every reported number / title / state / field against a `gh` result this run; a value you did not fetch, you will get wrong.
+- Apply only the mutations named; confirm current state first; report failures honestly and never claim an unverified success.
+- `gh` only — no `git`, no repo-tree writes, no package managers.
+- State facts and the requested changes; do not recommend priorities, critique the backlog, or plan the roadmap — that is the caller's job.

--- a/.claude/commands/review_roadmap.md
+++ b/.claude/commands/review_roadmap.md
@@ -1,5 +1,5 @@
 ---
-description: Review and prioritize GitHub Project issues for PMF alignment
+description: Review, groom, and schedule GitHub Project issues for PMF alignment
 skills: roadmap-review
 model: opus
 effort: max
@@ -11,42 +11,39 @@ Use and follow the roadmap-review skill exactly as written.
 
 ## Pre-fetch GitHub Project Data
 
-Before starting the collaborative review, fetch the current project state:
+Before starting, fetch the live board, the completed-work corpus (for staleness detection), and the current timeline values (so the apply step knows what to clear):
 
-1. **List project items with all fields:**
 ```bash
-gh project item-list 2 --owner samjmarshall --format json --limit 100
-```
-
-2. **Get project field definitions:**
-```bash
+# Live board: open issues + project fields
+gh project item-list 2 --owner samjmarshall --format json --limit 200
 gh project field-list 2 --owner samjmarshall --format json
+gh issue list --repo samjmarshall/rekurve --state all --json number,title,state,createdAt,updatedAt,milestone,labels --limit 200
+
+# Completed-work corpus (~6 months) — comparison set for "superseded by shipped work"
+gh issue list --repo samjmarshall/rekurve --state closed --json number,title,closedAt,labels --limit 200
+gh pr list   --repo samjmarshall/rekurve --state merged --json number,title,mergedAt,files   --limit 200
+git log --since="6 months ago" --oneline
 ```
 
-3. **List all issues with milestones:**
-```bash
-gh issue list --repo samjmarshall/rekurve --state all --json number,title,state,milestone,labels --limit 100
-```
+The `item-list` JSON already carries each item's current Start date / End date / Iteration — note which issues have them set, so the scheduling apply step can clear stale values.
 
 ## Context to Read
 
-- `thoughts/docs/` - Non-technical project docs (strategy, messaging, pilot feedback)
-- Recent designs in `thoughts/designs/` - Past decisions
+- `thoughts/docs/` — strategy, messaging, pilot feedback
+- `thoughts/designs/` + `docs/adr/` — recent decisions and pivots (which areas changed)
 
-## Then Begin Collaborative Review
+## Then Begin the Review
 
-Follow the roadmap-review skill's question flow to understand:
-- Current reality and progress
-- Blockers and constraints
-- Available capacity
-- Time off or scheduling constraints
-- Warm leads or active prospects
+Follow the skill's flow:
 
-Then categorize issues and propose specific changes.
+1. **Health pass** — groom open issues into Remove / Needs-investigation / Ready (evidence-based; `uncertain` → Needs-investigation; clean-pass = assumed Ready).
+2. **Discovery** — capacity, blockers, leads, time off, and the WIP limit (Ready survivors only).
+3. **Prioritize + schedule** — sequence Active Now, then compute Start/End dates from Size + weekly hours + WIP.
+4. Propose changes section by section.
 
 ## Output
 
 Write the final approved roadmap prioritization to:
 `thoughts/roadmap/YYYY-MM-DD-roadmap-prioritization.md`
 
-STOP after writing - do not implement changes automatically.
+**STOP after writing — make no GitHub changes.** The founder reviews, then directs the `github-project` agent to apply (close Removes, set/clear Start/End dates, move milestones, drop iterations) and uses `/write_tickets` for Needs-investigation items.

--- a/.claude/eval/tasks/mined/codebase-analyzer.yaml
+++ b/.claude/eval/tasks/mined/codebase-analyzer.yaml
@@ -3,7 +3,7 @@ _generated_by: shape_tasks.py from .claude/eval/mined/corpus.jsonl
 _needs_review: true
 _note: Auto-mined §5 candidates. Curate to 5, then merge into tasks/per-agent/codebase-analyzer.yaml alongside
   golden + adversarial buckets.
-_mined_available: 15
+_mined_available: 20
 _mined_emitted: 5
 execution:
 - id: mined-codebase-analyzer-exec-1
@@ -55,105 +55,91 @@ execution:
     `nurture→nurture`, `warm→warm_progression`, …'
 - id: mined-codebase-analyzer-exec-2
   kind: execution
-  prompt: 'I''m validating an implementation plan. Please read and analyze the following files and answer
-    the specific questions for each.
+  prompt: 'Read these four files and return their full contents:
 
+    1. /Users/sam/workspace/rekurve/rekurve/.claude/skills/ticket-writer/references/agent-brief.md
 
-    **File 1**: `/Users/sam/workspace/rekurve/rekurve/src/server/nurture/rhythm.ts`
+    2. /Users/sam/workspace/rekurve/rekurve/.claude/skills/ticket-writer/references/bug-template.md
 
-    - Does it export `RHYTHM_DAYS` with correct values (unqualified:3, nurture:14, warm:7, hot:null)?
+    3. /Users/sam/workspace/rekurve/rekurve/.claude/skills/ticket-writer/references/github-publishing.md
 
-    - Does it have a `rhythmForStage` function returning `{ duration: string } | null`?
-
-    - Does it have the `NURTURE_TEST_RHYTHM` env override for non-production?
-
-
-    **File 2**: `/Users/sam/workspace/rekurve/rekurve/src/inngest/functions/nurture/nurture-plan-runner.ts`
-
-    - Does it have `concurrency: [{ key: "event.data.leadId", limit: 1 }]`?
-
-    - Does it have `retries: 8`?
-
-    - Does it have `onFailure` that sends `nurture.plan-paused`?
-
-    - Does the loop use `waitForEvent` with `match: "data.leadId"` and `timeout: rhythm.duration`?
-
-    - Does it exit immediately for `hot` stage?
-
-    - Does it return when superseded (waitForEvent returns a value)?
-
-    - Does it draft + enqueue + emit `nurture.followup-message-drafted` on timeout?
-
-    - Is `NURTURE_EVENTS.FOLLOWUP_DRAFTED` and `NURTURE_EVENTS.PLAN_PAUSED` exported?
-
-
-    **File 3**: `/Users/sam/workspace/rekurve/rekurve/src/inngest/functions/index.ts`
-
-    - Is `nurturePlanRunner` in the functions array?
-
-
-    **File 4**: `/Users/sam/workspace/rekurve/rekurve/src/server/nurture/rhythm.ts`
-
-    - Confirm full file contents
-
-
-    **File 5**: `/Users/sam/workspace/rekurve/rekurve/src/server/ai/stub.ts`
-
-    - Does it export `stubDraft`?
-
-    - Does it export `resolveWorkerDraftFn`?
-
-    - Was the header-based `resolveDraftFn(req)` removed?
-
-
-    **File 6**: `/Users/sam/workspace/rekurve/rekurve/src/inngest/functions/nurture/__tests__/nurture-plan-runner.test.ts`
-
-    - Does it test "drafts on timeout" scenario?
-
-    - Does it test "superseded" scenario?
-
-    - Does it test "hot exits" scenario?
-
-    - Does it test "pause on failure" (onFailure handler)?
-
-
-    **File 7**: `/Users/sam/workspace/rekurve/rekurve/src/inngest/functions/nurture/__tests__/nurture-plan-runner.integration.test.ts`
-
-    - Is it gated by `INTEGRATION_DB`?
-
-    - Does it assert a `message_queue` row with `status:"pending"`?
-
-    - Does it clean up in `afterAll`?
-
-
-    Give exact file:line references for each finding.'
+    4. /Users/sam/workspace/rekurve/rekurve/.claude/skills/ticket-writer/references/epic-breakdown.md'
   provenance:
-    agent_id: aa4a0fa6c894c7536
-    session_id: 979e6e03-5c74-43cb-9c97-d11b653c77a1
-    model: claude-sonnet-4-6
-    latency_s: 34.39
-    tokens_total: 75335
-    n_tool_uses: 6
-    source_file: /Users/sam/.claude/projects/-Users-sam-workspace-rekurve-rekurve/979e6e03-5c74-43cb-9c97-d11b653c77a1/subagents/agent-aa4a0fa6c894c7536.jsonl
-  sample_output_excerpt: 'All files are present and fully readable. Here are the findings:
-
-
-    ---
-
-
-    ## File 1 & 4: `/Users/sam/workspace/rekurve/rekurve/src/server/nurture/rhythm.ts`
-
-
-    **`RHYTHM_DAYS` values correct?** YES.
-
-    - `src/server/nurture/rhythm.ts:3-8` — `unqualified: 3`, `nurture: 14`, `warm: 7`, `hot: null`. All
-    match the plan.
-
-
-    **`rhythmForStage` returns `{ duration: string } | null`?** YES.
-
-    - `src/server/nurture/rh …'
+    agent_id: a3fbb03c35c80e3fa
+    session_id: a76e0a6d-b917-4e91-916d-933195edfbac
+    model: claude-opus-4-8
+    latency_s: 4.26
+    tokens_total: 37948
+    n_tool_uses: 4
+    source_file: /Users/sam/.claude/projects/-Users-sam-workspace-rekurve-rekurve/a76e0a6d-b917-4e91-916d-933195edfbac/subagents/agent-a3fbb03c35c80e3fa.jsonl
+  sample_output_excerpt: I'll read all four files in parallel.
 - id: mined-codebase-analyzer-exec-3
+  kind: execution
+  prompt: 'I''m planning a refactor to mirror the email dispatch Inngest pattern for SMS. I need a precise,
+    file:line-cited trace of how the email dispatch worker pattern works end-to-end. Please analyze these
+    files:
+
+
+    - `src/inngest/functions/messages/dispatch-email.ts`
+
+    - `src/inngest/functions/messages/reconcile-missed-engagement.ts`
+
+    - `src/inngest/functions/index.ts` (how functions are registered)
+
+    - `src/inngest/channels.ts` and `src/inngest/client.ts` (event/channel definitions)
+
+    - `src/server/outbox/index.ts` (the MESSAGE_EVENTS / HUBSPOT_EMAIL_EVENTS constants, and any helper
+    to enqueue outbox events)
+
+    - `src/server/api/routers/messages.ts` (the `approve` and `editAndApprove` mutations — how they write
+    the status flip + outbox event atomically)
+
+    - `src/server/db/schema/message-queue.ts` (the schema, including the `dispatching_at` fence column)
+
+
+    For each, report with file:line citations:
+
+
+    1. **dispatch-email worker**: How does it subscribe to the event and filter to `channel === "email"`?
+    What are its discrete `step.run` stages in order (status re-verification / "verify-still-approved",
+    the dispatching_at fence, the provider/Graph call, the conversation row write, the `messageQueue.sentAt`
+    stamp)? How does the cancellation / "verify still approved" step work? How does `step.waitForEvent`
+    work for the engagement reconciliation, and what''s the timeout, and what fires on timeout (reconcile-missed-engagement)?
+
+
+    2. **Event contract**: What is the exact shape of the `message.approval-requested` event payload (all
+    `data` fields)? What does the worker read from it? What is the event name string constant and where
+    is it defined?
+
+
+    3. **Registration**: How is `dispatchEmail` registered in the functions index? What''s the naming/id
+    convention for Inngest function ids?
+
+
+    4. **Router atomic write**: How exactly do `approve` / `editAndApprove` perform the atomic status-flip
+    + outbox enqueue (the `db.batch()` call)? What''s written to the outbox row? Is there anything email-specific
+    in the router, or is it channel-agnostic?
+
+
+    5. **Outbox helpers**: What''s the signature of whatever enqueues an outbox event, and what columns
+    does the outbox row have?
+
+
+    Be exhaustive and precise — quote the key lines. This is for mirroring the exact pattern into a new
+    `dispatch-sms` function.'
+  provenance:
+    agent_id: abbad834a58ba3952
+    session_id: 666946b8-d08a-4bee-928e-8bfb018e029d
+    model: claude-opus-4-8
+    latency_s: 35.32
+    tokens_total: 565172
+    n_tool_uses: 24
+    source_file: /Users/sam/.claude/projects/-Users-sam-workspace-rekurve-rekurve/666946b8-d08a-4bee-928e-8bfb018e029d/subagents/agent-abbad834a58ba3952.jsonl
+  sample_output_excerpt: 'I now have the complete end-to-end picture. Let me verify two final details
+    for an exact mirror: the `db.batch()` return-shape semantics (the `[[updated]]` destructure) and whether
+    `sendSmsToConsultant` carries a correlation header like email does (to know what the SMS provider
+    call differs on).'
+- id: mined-codebase-analyzer-exec-4
   kind: execution
   prompt: 'Explain how the **inbound HubSpot webhook sync** works end to end. Cover:
 
@@ -191,73 +177,6 @@ execution:
     HubSpot POST payloads arrive at a Next.js route handler, pass a two-stage authentication gate (header
     presence + HMAC-SHA256 signature v3), then each event in the JSON array is dispatched to one of two
     active handlers: `handleContactCreation` or `handleE …'
-- id: mined-codebase-analyzer-exec-4
-  kind: execution
-  prompt: 'I''m planning issue #261 which adds new Inngest worker functions fed by the transactional outbox
-    (ADR-014/ADR-017). I need to understand the EXISTING outbox + Inngest infrastructure so my new functions
-    mirror it exactly.
-
-
-    Report with `file:line` for every claim:
-
-
-    1. The `outbox` table schema — full column list, types, the id type (uuid?), `processedAt`, `attempts`,
-    `lastError`, `createdAt`, and the event-name/payload columns. Where is it defined?
-
-
-    2. How outbox rows are inserted inside a transaction. ADR-017 mentions `db.batch()` over neon-http.
-    Find a concrete write site (e.g. the recent nurture migration #295, or the leads cutover #286/#288,
-    or contact.creation) that does: open transaction → canonical DB write → insert outbox row → commit
-    → post-commit `inngest.send`. Show the full pattern including the helper (is there an `outbox.publish(tx,
-    event, payload)` helper, or is it inline?).
-
-
-    3. The cron sweep that delivers outbox rows — `outbox-sweep`. Where it lives, the SQL query, how it
-    sets `processedAt` / increments `attempts`, and how it uses the outbox row id as the Inngest idempotency
-    key.
-
-
-    4. The Inngest client and event-type definitions. Where are event names and payload types declared
-    (e.g. a typed `EventSchemas` / `Events` map)? Show how an event like `message.approval-requested`,
-    `hubspot.email.engagement-created`, `hubspot.engagement-missed` would be (or are) declared. Are any
-    of these three events already declared?
-
-
-    5. The MOST RECENT Inngest worker as the canonical pattern to mirror — the nurture migration from
-    commit df21fdd (#295) "migrate Follow-up plans to Inngest". Show: the full `inngest.createFunction(...)`
-    definition, how it declares `{ id, name }`, the `{ event: "..." }` trigger, any `if`/filter on event
-    data, the `step.run(...)` calls, and any `step.waitForEvent(...)` usage anywhere in the codebase.
-    I need the exact import surface and idiom.
-
-
-    6. How Inngest functions are registered/served — the `serve()` endpoint (likely `src/app/api/inngest/route.ts`
-    or similar) and the array of functions it exports. I need to know where to add my new functions.
-
-
-    7. Concurrency/idempotency config on existing functions — do they set `idempotency`, `concurrency`,
-    or `retries` in the createFunction options? Show an example.
-
-
-    Report exact paths, line numbers, signatures, and code snippets. Describe only what exists; do not
-    propose changes.'
-  provenance:
-    agent_id: a77dfaf0c0697b282
-    session_id: 6ea3af65-da4f-498d-a372-653fa064a7a8
-    model: claude-opus-4-8
-    latency_s: 112.18
-    tokens_total: 436251
-    n_tool_uses: 21
-    source_file: /Users/sam/.claude/projects/-Users-sam-workspace-rekurve-rekurve/6ea3af65-da4f-498d-a372-653fa064a7a8/subagents/agent-a77dfaf0c0697b282.jsonl
-  sample_output_excerpt: 'I have everything needed for a complete report. The search confirms the only
-    two event-name constant maps are `OUTBOX_EVENTS` and `NURTURE_EVENTS`, the DB driver is `neon-http`
-    (confirming `db.batch()` semantics), and migration 0007 shows the SQL-side outbox-insert pattern.
-    None of the three target events exist. Let me compile the findings.
-
-
-    ---
-
-
-    # Existing Outbox + Inngest Infrastructure (for iss …'
 - id: mined-codebase-analyzer-exec-5
   kind: execution
   prompt: 'I''m validating that an implementation plan was correctly executed. The plan required deleting/modifying
@@ -368,79 +287,71 @@ routing:
   - id: mined-codebase-analyzer-route-pos-2
     kind: routing
     expect_invoke: true
-    prompt: 'I''m validating an implementation plan. Please read and analyze the following files and answer
-      the specific questions for each.
+    prompt: 'Read these four files and return their full contents:
 
+      1. /Users/sam/workspace/rekurve/rekurve/.claude/skills/ticket-writer/references/agent-brief.md
 
-      **File 1**: `/Users/sam/workspace/rekurve/rekurve/src/server/nurture/rhythm.ts`
+      2. /Users/sam/workspace/rekurve/rekurve/.claude/skills/ticket-writer/references/bug-template.md
 
-      - Does it export `RHYTHM_DAYS` with correct values (unqualified:3, nurture:14, warm:7, hot:null)?
+      3. /Users/sam/workspace/rekurve/rekurve/.claude/skills/ticket-writer/references/github-publishing.md
 
-      - Does it have a `rhythmForStage` function returning `{ duration: string } | null`?
-
-      - Does it have the `NURTURE_TEST_RHYTHM` env override for non-production?
-
-
-      **File 2**: `/Users/sam/workspace/rekurve/rekurve/src/inngest/functions/nurture/nurture-plan-runner.ts`
-
-      - Does it have `concurrency: [{ key: "event.data.leadId", limit: 1 }]`?
-
-      - Does it have `retries: 8`?
-
-      - Does it have `onFailure` that sends `nurture.plan-paused`?
-
-      - Does the loop use `waitForEvent` with `match: "data.leadId"` and `timeout: rhythm.duration`?
-
-      - Does it exit immediately for `hot` stage?
-
-      - Does it return when superseded (waitForEvent returns a value)?
-
-      - Does it draft + enqueue + emit `nurture.followup-message-drafted` on timeout?
-
-      - Is `NURTURE_EVENTS.FOLLOWUP_DRAFTED` and `NURTURE_EVENTS.PLAN_PAUSED` exported?
-
-
-      **File 3**: `/Users/sam/workspace/rekurve/rekurve/src/inngest/functions/index.ts`
-
-      - Is `nurturePlanRunner` in the functions array?
-
-
-      **File 4**: `/Users/sam/workspace/rekurve/rekurve/src/server/nurture/rhythm.ts`
-
-      - Confirm full file contents
-
-
-      **File 5**: `/Users/sam/workspace/rekurve/rekurve/src/server/ai/stub.ts`
-
-      - Does it export `stubDraft`?
-
-      - Does it export `resolveWorkerDraftFn`?
-
-      - Was the header-based `resolveDraftFn(req)` removed?
-
-
-      **File 6**: `/Users/sam/workspace/rekurve/rekurve/src/inngest/functions/nurture/__tests__/nurture-plan-runner.test.ts`
-
-      - Does it test "drafts on timeout" scenario?
-
-      - Does it test "superseded" scenario?
-
-      - Does it test "hot exits" scenario?
-
-      - Does it test "pause on failure" (onFailure handler)?
-
-
-      **File 7**: `/Users/sam/workspace/rekurve/rekurve/src/inngest/functions/nurture/__tests__/nurture-plan-runner.integration.test.ts`
-
-      - Is it gated by `INTEGRATION_DB`?
-
-      - Does it assert a `message_queue` row with `status:"pending"`?
-
-      - Does it clean up in `afterAll`?
-
-
-      Give exact file:line references for each finding.'
+      4. /Users/sam/workspace/rekurve/rekurve/.claude/skills/ticket-writer/references/epic-breakdown.md'
   - id: mined-codebase-analyzer-route-pos-3
+    kind: routing
+    expect_invoke: true
+    prompt: 'I''m planning a refactor to mirror the email dispatch Inngest pattern for SMS. I need a precise,
+      file:line-cited trace of how the email dispatch worker pattern works end-to-end. Please analyze
+      these files:
+
+
+      - `src/inngest/functions/messages/dispatch-email.ts`
+
+      - `src/inngest/functions/messages/reconcile-missed-engagement.ts`
+
+      - `src/inngest/functions/index.ts` (how functions are registered)
+
+      - `src/inngest/channels.ts` and `src/inngest/client.ts` (event/channel definitions)
+
+      - `src/server/outbox/index.ts` (the MESSAGE_EVENTS / HUBSPOT_EMAIL_EVENTS constants, and any helper
+      to enqueue outbox events)
+
+      - `src/server/api/routers/messages.ts` (the `approve` and `editAndApprove` mutations — how they
+      write the status flip + outbox event atomically)
+
+      - `src/server/db/schema/message-queue.ts` (the schema, including the `dispatching_at` fence column)
+
+
+      For each, report with file:line citations:
+
+
+      1. **dispatch-email worker**: How does it subscribe to the event and filter to `channel === "email"`?
+      What are its discrete `step.run` stages in order (status re-verification / "verify-still-approved",
+      the dispatching_at fence, the provider/Graph call, the conversation row write, the `messageQueue.sentAt`
+      stamp)? How does the cancellation / "verify still approved" step work? How does `step.waitForEvent`
+      work for the engagement reconciliation, and what''s the timeout, and what fires on timeout (reconcile-missed-engagement)?
+
+
+      2. **Event contract**: What is the exact shape of the `message.approval-requested` event payload
+      (all `data` fields)? What does the worker read from it? What is the event name string constant and
+      where is it defined?
+
+
+      3. **Registration**: How is `dispatchEmail` registered in the functions index? What''s the naming/id
+      convention for Inngest function ids?
+
+
+      4. **Router atomic write**: How exactly do `approve` / `editAndApprove` perform the atomic status-flip
+      + outbox enqueue (the `db.batch()` call)? What''s written to the outbox row? Is there anything email-specific
+      in the router, or is it channel-agnostic?
+
+
+      5. **Outbox helpers**: What''s the signature of whatever enqueues an outbox event, and what columns
+      does the outbox row have?
+
+
+      Be exhaustive and precise — quote the key lines. This is for mirroring the exact pattern into a
+      new `dispatch-sms` function.'
+  - id: mined-codebase-analyzer-route-pos-4
     kind: routing
     expect_invoke: true
     prompt: 'Explain how the **inbound HubSpot webhook sync** works end to end. Cover:
@@ -456,56 +367,6 @@ routing:
 
 
       Cite `file:line` for every step.'
-  - id: mined-codebase-analyzer-route-pos-4
-    kind: routing
-    expect_invoke: true
-    prompt: 'I''m planning issue #261 which adds new Inngest worker functions fed by the transactional
-      outbox (ADR-014/ADR-017). I need to understand the EXISTING outbox + Inngest infrastructure so my
-      new functions mirror it exactly.
-
-
-      Report with `file:line` for every claim:
-
-
-      1. The `outbox` table schema — full column list, types, the id type (uuid?), `processedAt`, `attempts`,
-      `lastError`, `createdAt`, and the event-name/payload columns. Where is it defined?
-
-
-      2. How outbox rows are inserted inside a transaction. ADR-017 mentions `db.batch()` over neon-http.
-      Find a concrete write site (e.g. the recent nurture migration #295, or the leads cutover #286/#288,
-      or contact.creation) that does: open transaction → canonical DB write → insert outbox row → commit
-      → post-commit `inngest.send`. Show the full pattern including the helper (is there an `outbox.publish(tx,
-      event, payload)` helper, or is it inline?).
-
-
-      3. The cron sweep that delivers outbox rows — `outbox-sweep`. Where it lives, the SQL query, how
-      it sets `processedAt` / increments `attempts`, and how it uses the outbox row id as the Inngest
-      idempotency key.
-
-
-      4. The Inngest client and event-type definitions. Where are event names and payload types declared
-      (e.g. a typed `EventSchemas` / `Events` map)? Show how an event like `message.approval-requested`,
-      `hubspot.email.engagement-created`, `hubspot.engagement-missed` would be (or are) declared. Are
-      any of these three events already declared?
-
-
-      5. The MOST RECENT Inngest worker as the canonical pattern to mirror — the nurture migration from
-      commit df21fdd (#295) "migrate Follow-up plans to Inngest". Show: the full `inngest.createFunction(...)`
-      definition, how it declares `{ id, name }`, the `{ event: "..." }` trigger, any `if`/filter on event
-      data, the `step.run(...)` calls, and any `step.waitForEvent(...)` usage anywhere in the codebase.
-      I need the exact import surface and idiom.
-
-
-      6. How Inngest functions are registered/served — the `serve()` endpoint (likely `src/app/api/inngest/route.ts`
-      or similar) and the array of functions it exports. I need to know where to add my new functions.
-
-
-      7. Concurrency/idempotency config on existing functions — do they set `idempotency`, `concurrency`,
-      or `retries` in the createFunction options? Show an example.
-
-
-      Report exact paths, line numbers, signatures, and code snippets. Describe only what exists; do not
-      propose changes.'
   - id: mined-codebase-analyzer-route-pos-5
     kind: routing
     expect_invoke: true
@@ -573,7 +434,89 @@ routing:
     kind: routing
     expect_invoke: false
     actual_route: codebase-pattern-finder
-    confusability: 0.175
+    confusability: 0.225
+    prompt: 'I''m about to write tests for a new `dispatch-sms` Inngest function, mirroring the existing
+      tests for `dispatch-email`. I need concrete, copyable test patterns with file:line citations.
+
+
+      Please analyze these test files and show me the patterns:
+
+      - `src/inngest/functions/messages/__tests__/dispatch-email.test.ts`
+
+      - `src/inngest/functions/messages/__tests__/dispatch-email.integration.test.ts`
+
+      - `src/inngest/functions/messages/__tests__/reconcile-missed-engagement.test.ts`
+
+
+      Also look for any shared Inngest test helpers/utilities (search `src/inngest` and `src/test` or
+      similar for things like `InngestTestEngine`, mock step, virtual time helpers, mocked provider clients).
+
+
+      Report with file:line citations and actual code snippets:
+
+
+      1. **Test harness**: How is an Inngest function invoked in a unit test? Is it `@inngest/test` `InngestTestEngine`,
+      or a hand-rolled mock of the `step` object? Show the exact setup. How are `step.run`, `step.waitForEvent`,
+      and `step.sleep` mocked or driven?
+
+
+      2. **Virtual time**: How is time/timeout handled in tests (the `waitForEvent` timeout, any `step.sleep`)?
+      Show the pattern.
+
+
+      3. **Mocking provider clients**: How is the Graph/email client mocked? How would I analogously mock
+      a Twilio client? Show the mock setup (rstest `rs.mock` / `vi.mock` style — note this project uses
+      Rstest).
+
+
+      4. **DB assertions**: Do these tests hit a real DB (integration) or mock it (unit)? What''s the
+      difference between the `.test.ts` and `.integration.test.ts` files? Show how each sets up/asserts
+      DB state.
+
+
+      5. **Status re-verification & cancellation tests**: How do they test the "verify still approved"
+      cancellation path (message dismissed mid-dispatch)?
+
+
+      Quote real snippets I can adapt. This project uses Rstest (not Vitest/Jest) — note any Rstest-specific
+      API usage.'
+  - id: mined-codebase-analyzer-route-neg-2
+    kind: routing
+    expect_invoke: false
+    actual_route: docs-analyzer
+    confusability: 0.159
+    prompt: 'I''m planning a refactor (GitHub issue #262) to split message dispatch into channel-specific
+      Inngest functions. I need the decisions of record from three ADRs distilled precisely.
+
+
+      Please read and distil:
+
+      1. `docs/adr/adr001-imessage-integration-for-sales-automation.md` — the iMessage device-bridge decision.
+      I specifically need: its recorded **Status**, the chosen option (which device-bridge provider),
+      what the "device-bridge service" is and its interface (webhooks, delivery acks), whether any implementation
+      has shipped, and any checklist of unchecked/incomplete work items in the ADR. This tells me whether
+      a `dispatch-imessage` Inngest worker can be built yet.
+
+
+      2. `docs/adr/adr014-outbox-pattern-for-inngest-delivery.md` — the outbox pattern. I need: the core
+      decision, the relationship between the outbox table and Inngest events, how the outbox-sweep cron
+      delivers events, the at-least-once / idempotency guarantees, and any constraints a new dispatch
+      worker must honor.
+
+
+      3. `docs/adr/adr017-atomic-outbox-writes-via-neon-http-batch.md` — atomic outbox writes. I need:
+      the decision, the `db.batch()` mechanism, why it''s used for the status-flip + outbox-enqueue atomicity,
+      and any constraints.
+
+
+      For each ADR report: the recorded `Status:` field value, the decision in 2-3 sentences, and the
+      specific constraints/interfaces my plan must honor. Quote key lines with file:line citations. Flag
+      explicitly if ADR-001 indicates the iMessage device-bridge is NOT yet implemented.'
+  - id: mined-codebase-analyzer-route-neg-3
+    kind: routing
+    expect_invoke: false
+    actual_route: codebase-pattern-finder
+    confusability: 0.145
     prompt: 'I''m planning integration + unit tests for new Inngest worker functions in issue #261 (email
       dispatch worker with `step.run` and `step.waitForEvent` + a timeout path). I need existing test
       patterns to mirror.
@@ -616,54 +559,3 @@ routing:
       For each, give the file path, line numbers, and a representative snippet. Prioritize the Rstest
       unit/integration idiom (the repo uses Rstest, not Jest/Vitest). If a pattern genuinely doesn''t
       exist yet, say so clearly rather than inventing one.'
-  - id: mined-codebase-analyzer-route-neg-2
-    kind: routing
-    expect_invoke: false
-    actual_route: codebase-locator
-    confusability: 0.136
-    prompt: 'I''m debugging a failing E2E test about HubSpot outbound sync. I need to find ALL the code
-      that syncs a newly-created lead OUT to HubSpot (creating or updating a HubSpot contact from a lead).
-
-
-      Specifically locate:
-
-      1. The "lead outbox worker" / outbox processor that was recently introduced (PR called "lead-outbox-cutover").
-      Where leads are picked up and pushed to HubSpot.
-
-      2. The HubSpot API client wrapper functions that create or update a contact — anything that calls
-      HubSpot''s contacts create/update/upsert/search APIs. Look for terms like `basicApi.create`, `basicApi.update`,
-      `searchApi.doSearch`, `idProperty`, `createOrUpdate`, `upsert`, `hubspotContactId`.
-
-      3. The mapping from a lead''s fields (firstName, lastName, email, phone) to HubSpot contact properties
-      (firstname, lastname, email, phone).
-
-      4. Any logic that handles the case where a HubSpot contact ALREADY EXISTS for a given email (dedup
-      by email) — does it update the existing contact''s properties or just link to it?
-
-
-      The relevant code is under src/ (likely src/server, src/inngest, or src/lib). Report exact file
-      paths and the key function names/line numbers for each. Do not analyze deeply yet — just locate
-      and give me a precise map of the relevant files and functions.'
-  - id: mined-codebase-analyzer-route-neg-3
-    kind: routing
-    expect_invoke: false
-    actual_route: codebase-locator
-    confusability: 0.116
-    prompt: 'Locate every file involved in the lead-intake / lead-creation flow, for planning a new public
-      web-form intake path (a third path alongside HubSpot webhook ingestion and manual capture).
-
-
-      Include and group by role:
-
-      - the intake logic itself
-
-      - the lead database schema
-
-      - the outbox / domain-event plumbing intake uses
-
-      - the API / route layer that calls intake
-
-      - all unit + integration test files covering intake
-
-
-      Give paths and the key exported symbols in each. At the end, report roughly how many files you found.'

--- a/.claude/eval/tasks/mined/codebase-locator.yaml
+++ b/.claude/eval/tasks/mined/codebase-locator.yaml
@@ -3,7 +3,7 @@ _generated_by: shape_tasks.py from .claude/eval/mined/corpus.jsonl
 _needs_review: true
 _note: Auto-mined §5 candidates. Curate to 5, then merge into tasks/per-agent/codebase-locator.yaml alongside
   golden + adversarial buckets.
-_mined_available: 5
+_mined_available: 6
 _mined_emitted: 5
 execution:
 - id: mined-codebase-locator-exec-1
@@ -39,6 +39,102 @@ execution:
     \  Exported symbols: `captureLeadFromHubspot`, `captureLead`, `updateLead`, `IntakeCtx`\n\n- `/Users/sam/workspace/rekurve/rekurve/src/server/leads/owner.ts`\n\
     \  Exported symbol: `resolveLeadOwnerU …"
 - id: mined-codebase-locator-exec-2
+  kind: execution
+  prompt: Locate the Drizzle migration SQL file(s) related to the "outbox" table or the outbox-sweep mechanism
+    in this repo, and the directory they live in. Return only verified file paths (no content descriptions).
+  provenance:
+    agent_id: ac39e0b4e425dd62f
+    session_id: e41b13d1-0f46-41ab-8013-d23578205889
+    model: claude-sonnet-4-6
+    latency_s: 83.16
+    tokens_total: 71572
+    n_tool_uses: 6
+    source_file: /Users/sam/.claude/projects/-Users-sam-workspace-rekurve-rekurve/e41b13d1-0f46-41ab-8013-d23578205889/subagents/agent-ac39e0b4e425dd62f.jsonl
+  sample_output_excerpt: 'The results reveal the outbox table is named `ln` in the database. The relevant
+    migration files are confirmed.
+
+
+    ## File Locations for Outbox / Outbox-Sweep Migration
+
+
+    ### Migration SQL Files (in `/Users/sam/workspace/rekurve/rekurve/drizzle/`)
+
+
+    - `/Users/sam/workspace/rekurve/rekurve/drizzle/0005_rapid_sentinel.sql` — contains `CREATE TABLE
+    "ln"` and `CREATE INDEX "ln_unprocessed_idx"` (the outbox …'
+- id: mined-codebase-locator-exec-3
+  kind: execution
+  prompt: 'I need to understand the current observability/monitoring setup in this Next.js codebase. Locate
+    (paths only, grouped by purpose):
+
+
+    1. Where PostHog is configured and initialized (client and server side) — config files, provider components,
+    env vars referencing POSTHOG.
+
+    2. Any OpenTelemetry / OTLP / instrumentation setup — especially `instrumentation.ts`, `instrumentation-client.ts`,
+    or `register()` hooks in the Next.js app.
+
+    3. Any existing logging utilities, logger modules, or structured logging.
+
+    4. Any Inngest scheduled functions / cron jobs (look in src/inngest) — I''m interested in whether
+    there''s an existing pattern for scheduled "heartbeat"-style events. The CLAUDE.md mentions an "outbox-sweep"
+    cron and an outbox pattern.
+
+    5. Any existing error tracking or monitoring instrumentation (Sentry, etc.).
+
+    6. The Next.js version and whether the app uses the app router (check package.json and folder structure).
+
+
+    Return file paths grouped by the categories above, with a one-line note on each. Paths only — don''t
+    explain mechanics in depth.'
+  provenance:
+    agent_id: a374d695e6380fc19
+    session_id: 2eabff0a-a1b3-49c8-bfe4-a0e1cc8b85c9
+    model: claude-opus-4-8
+    latency_s: 39.56
+    tokens_total: 291134
+    n_tool_uses: 19
+    source_file: /Users/sam/.claude/projects/-Users-sam-workspace-rekurve-rekurve/2eabff0a-a1b3-49c8-bfe4-a0e1cc8b85c9/subagents/agent-a374d695e6380fc19.jsonl
+  sample_output_excerpt: I have nearly everything. Let me confirm the cron pattern in `prune.ts` and the
+    app router structure, and verify the instrumentation files exist as the locations they appear to be
+    (without reading their internals).
+- id: mined-codebase-locator-exec-4
+  kind: execution
+  prompt: 'Locate where **lead scoring** lives in this codebase. Return file locations only — do not explain
+    behavior — grouped by purpose:
+
+
+    1. The scoring module''s source files
+
+    2. Every place lead scoring is invoked / called from
+
+    3. The scoring tests
+
+
+    Give full paths from the repo root.'
+  provenance:
+    agent_id: a9468283edc33132f
+    session_id: 3ce642ee-8f35-4ce0-b441-721b7230e513
+    model: claude-sonnet-4-6
+    latency_s: 51.07
+    tokens_total: 141300
+    n_tool_uses: 11
+    source_file: /Users/sam/.claude/projects/-Users-sam-workspace-rekurve-rekurve/3ce642ee-8f35-4ce0-b441-721b7230e513/subagents/agent-a9468283edc33132f.jsonl
+  sample_output_excerpt: '## File Locations for Lead Scoring
+
+
+    ### 1. Scoring Module Source Files
+
+
+    - `/Users/sam/workspace/rekurve/rekurve/src/server/scoring/index.ts` (module entry point)
+
+    - `/Users/sam/workspace/rekurve/rekurve/src/server/scoring/qualify-and-score.ts` (matches `qualify-and-score`
+    pattern)
+
+    - `/Users/sam/workspace/rekurve/rekurve/src/server/scoring/schema.ts` (schema definitions)
+
+    - `/Users/sam/workspace/reku …'
+- id: mined-codebase-locator-exec-5
   kind: execution
   prompt: 'I''m debugging a failing E2E test about HubSpot outbound sync. I need to find ALL the code
     that syncs a newly-created lead OUT to HubSpot (creating or updating a HubSpot contact from a lead).
@@ -87,117 +183,6 @@ execution:
 
     - `/Users/sam/workspace/rekurve/rekurve/src/server/db/schema/outbox.ts` — `outbox` table definition
     (columns: `id`, `eventName`, `payload`, `processedAt`, `attempts`, `lastError` …'
-- id: mined-codebase-locator-exec-3
-  kind: execution
-  prompt: 'I''m debugging an e2e test about HubSpot outbound sync dedup behavior. I need to locate all
-    code involved in syncing a lead to HubSpot — specifically the path that creates a contact OR, when
-    a contact with the same email already exists, deduplicates/links to the existing contact.
-
-
-    Find and report file paths (with brief descriptions) for:
-
-    1. The outbox worker/processor that syncs leads to HubSpot (mentioned as "DB-first outbox worker"
-    / "outbox cutover"). Look in src/server/outbox/ and src/inngest/.
-
-    2. The HubSpot client wrapper that does create/update/upsert of contacts (search by email, create
-    contact, update contact, handle 409 duplicate conflicts).
-
-    3. The lead intake logic (src/server/leads/intake.ts).
-
-    4. Any code that handles HubSpot duplicate-email conflicts (409 errors) and extracts the existing
-    contact ID.
-
-    5. The recently-changed files from PR #288 "drop edit arms; ingest contact.creation via scored outbox"
-    — likely a hubspot-webhook handler.
-
-
-    For each relevant file, give the path and a one-line description of what it does. Do NOT analyze deeply
-    — just locate and map the files.'
-  provenance:
-    agent_id: a11d5e4259ab55ed7
-    session_id: b973838c-28e9-4842-9e08-7dfb3fb043d1
-    model: claude-sonnet-4-6
-    latency_s: 44.86
-    tokens_total: 168765
-    n_tool_uses: 12
-    source_file: /Users/sam/.claude/projects/-Users-sam-workspace-rekurve-rekurve/b973838c-28e9-4842-9e08-7dfb3fb043d1/subagents/agent-a11d5e4259ab55ed7.jsonl
-  sample_output_excerpt: 'Here is the complete map of all files involved in the HubSpot outbound sync
-    path:
-
-
-    ---
-
-
-    ## File Locations for HubSpot Lead Sync / Dedup
-
-
-    ### 1. Outbox Worker / Processor (DB-first outbox pattern)
-
-
-    - `/Users/sam/workspace/rekurve/rekurve/src/inngest/functions/outbox/sweep.ts` — Inngest function
-    that sweeps the outbox and dispatches pending sync jobs to HubSpot
-
-    - `/Users/sam/workspace/rekurve/rekurv …'
-- id: mined-codebase-locator-exec-4
-  kind: execution
-  prompt: 'Locate where **lead scoring** lives in this codebase. Return file locations only — do not explain
-    behavior — grouped by purpose:
-
-
-    1. The scoring module''s source files
-
-    2. Every place lead scoring is invoked / called from
-
-    3. The scoring tests
-
-
-    Give full paths from the repo root.'
-  provenance:
-    agent_id: a9468283edc33132f
-    session_id: 3ce642ee-8f35-4ce0-b441-721b7230e513
-    model: claude-sonnet-4-6
-    latency_s: 51.07
-    tokens_total: 141300
-    n_tool_uses: 11
-    source_file: /Users/sam/.claude/projects/-Users-sam-workspace-rekurve-rekurve/3ce642ee-8f35-4ce0-b441-721b7230e513/subagents/agent-a9468283edc33132f.jsonl
-  sample_output_excerpt: '## File Locations for Lead Scoring
-
-
-    ### 1. Scoring Module Source Files
-
-
-    - `/Users/sam/workspace/rekurve/rekurve/src/server/scoring/index.ts` (module entry point)
-
-    - `/Users/sam/workspace/rekurve/rekurve/src/server/scoring/qualify-and-score.ts` (matches `qualify-and-score`
-    pattern)
-
-    - `/Users/sam/workspace/rekurve/rekurve/src/server/scoring/schema.ts` (schema definitions)
-
-    - `/Users/sam/workspace/reku …'
-- id: mined-codebase-locator-exec-5
-  kind: execution
-  prompt: Locate the Drizzle migration SQL file(s) related to the "outbox" table or the outbox-sweep mechanism
-    in this repo, and the directory they live in. Return only verified file paths (no content descriptions).
-  provenance:
-    agent_id: ac39e0b4e425dd62f
-    session_id: e41b13d1-0f46-41ab-8013-d23578205889
-    model: claude-sonnet-4-6
-    latency_s: 83.16
-    tokens_total: 71572
-    n_tool_uses: 6
-    source_file: /Users/sam/.claude/projects/-Users-sam-workspace-rekurve-rekurve/e41b13d1-0f46-41ab-8013-d23578205889/subagents/agent-ac39e0b4e425dd62f.jsonl
-  sample_output_excerpt: 'The results reveal the outbox table is named `ln` in the database. The relevant
-    migration files are confirmed.
-
-
-    ## File Locations for Outbox / Outbox-Sweep Migration
-
-
-    ### Migration SQL Files (in `/Users/sam/workspace/rekurve/rekurve/drizzle/`)
-
-
-    - `/Users/sam/workspace/rekurve/rekurve/drizzle/0005_rapid_sentinel.sql` — contains `CREATE TABLE
-    "ln"` and `CREATE INDEX "ln_unprocessed_idx"` (the outbox …'
 routing:
   positives:
   - id: mined-codebase-locator-route-pos-1
@@ -224,6 +209,53 @@ routing:
   - id: mined-codebase-locator-route-pos-2
     kind: routing
     expect_invoke: true
+    prompt: Locate the Drizzle migration SQL file(s) related to the "outbox" table or the outbox-sweep
+      mechanism in this repo, and the directory they live in. Return only verified file paths (no content
+      descriptions).
+  - id: mined-codebase-locator-route-pos-3
+    kind: routing
+    expect_invoke: true
+    prompt: 'I need to understand the current observability/monitoring setup in this Next.js codebase.
+      Locate (paths only, grouped by purpose):
+
+
+      1. Where PostHog is configured and initialized (client and server side) — config files, provider
+      components, env vars referencing POSTHOG.
+
+      2. Any OpenTelemetry / OTLP / instrumentation setup — especially `instrumentation.ts`, `instrumentation-client.ts`,
+      or `register()` hooks in the Next.js app.
+
+      3. Any existing logging utilities, logger modules, or structured logging.
+
+      4. Any Inngest scheduled functions / cron jobs (look in src/inngest) — I''m interested in whether
+      there''s an existing pattern for scheduled "heartbeat"-style events. The CLAUDE.md mentions an "outbox-sweep"
+      cron and an outbox pattern.
+
+      5. Any existing error tracking or monitoring instrumentation (Sentry, etc.).
+
+      6. The Next.js version and whether the app uses the app router (check package.json and folder structure).
+
+
+      Return file paths grouped by the categories above, with a one-line note on each. Paths only — don''t
+      explain mechanics in depth.'
+  - id: mined-codebase-locator-route-pos-4
+    kind: routing
+    expect_invoke: true
+    prompt: 'Locate where **lead scoring** lives in this codebase. Return file locations only — do not
+      explain behavior — grouped by purpose:
+
+
+      1. The scoring module''s source files
+
+      2. Every place lead scoring is invoked / called from
+
+      3. The scoring tests
+
+
+      Give full paths from the repo root.'
+  - id: mined-codebase-locator-route-pos-5
+    kind: routing
+    expect_invoke: true
     prompt: 'I''m debugging a failing E2E test about HubSpot outbound sync. I need to find ALL the code
       that syncs a newly-created lead OUT to HubSpot (creating or updating a HubSpot contact from a lead).
 
@@ -247,54 +279,6 @@ routing:
       The relevant code is under src/ (likely src/server, src/inngest, or src/lib). Report exact file
       paths and the key function names/line numbers for each. Do not analyze deeply yet — just locate
       and give me a precise map of the relevant files and functions.'
-  - id: mined-codebase-locator-route-pos-3
-    kind: routing
-    expect_invoke: true
-    prompt: 'I''m debugging an e2e test about HubSpot outbound sync dedup behavior. I need to locate all
-      code involved in syncing a lead to HubSpot — specifically the path that creates a contact OR, when
-      a contact with the same email already exists, deduplicates/links to the existing contact.
-
-
-      Find and report file paths (with brief descriptions) for:
-
-      1. The outbox worker/processor that syncs leads to HubSpot (mentioned as "DB-first outbox worker"
-      / "outbox cutover"). Look in src/server/outbox/ and src/inngest/.
-
-      2. The HubSpot client wrapper that does create/update/upsert of contacts (search by email, create
-      contact, update contact, handle 409 duplicate conflicts).
-
-      3. The lead intake logic (src/server/leads/intake.ts).
-
-      4. Any code that handles HubSpot duplicate-email conflicts (409 errors) and extracts the existing
-      contact ID.
-
-      5. The recently-changed files from PR #288 "drop edit arms; ingest contact.creation via scored outbox"
-      — likely a hubspot-webhook handler.
-
-
-      For each relevant file, give the path and a one-line description of what it does. Do NOT analyze
-      deeply — just locate and map the files.'
-  - id: mined-codebase-locator-route-pos-4
-    kind: routing
-    expect_invoke: true
-    prompt: 'Locate where **lead scoring** lives in this codebase. Return file locations only — do not
-      explain behavior — grouped by purpose:
-
-
-      1. The scoring module''s source files
-
-      2. Every place lead scoring is invoked / called from
-
-      3. The scoring tests
-
-
-      Give full paths from the repo root.'
-  - id: mined-codebase-locator-route-pos-5
-    kind: routing
-    expect_invoke: true
-    prompt: Locate the Drizzle migration SQL file(s) related to the "outbox" table or the outbox-sweep
-      mechanism in this repo, and the directory they live in. Return only verified file paths (no content
-      descriptions).
   negatives:
   - id: mined-codebase-locator-route-neg-1
     kind: routing
@@ -321,55 +305,15 @@ routing:
   - id: mined-codebase-locator-route-neg-2
     kind: routing
     expect_invoke: false
-    actual_route: codebase-analyzer
-    confusability: 0.136
-    prompt: 'I''m planning issue #261 which adds new Inngest worker functions fed by the transactional
-      outbox (ADR-014/ADR-017). I need to understand the EXISTING outbox + Inngest infrastructure so my
-      new functions mirror it exactly.
+    actual_route: docs-locator
+    confusability: 0.124
+    prompt: 'Find any ADRs or feature docs in the docs/ tree that govern or relate to: observability,
+      monitoring, logging, alerting, error tracking, metrics, uptime monitoring, PostHog, analytics, or
+      incident response.
 
 
-      Report with `file:line` for every claim:
-
-
-      1. The `outbox` table schema — full column list, types, the id type (uuid?), `processedAt`, `attempts`,
-      `lastError`, `createdAt`, and the event-name/payload columns. Where is it defined?
-
-
-      2. How outbox rows are inserted inside a transaction. ADR-017 mentions `db.batch()` over neon-http.
-      Find a concrete write site (e.g. the recent nurture migration #295, or the leads cutover #286/#288,
-      or contact.creation) that does: open transaction → canonical DB write → insert outbox row → commit
-      → post-commit `inngest.send`. Show the full pattern including the helper (is there an `outbox.publish(tx,
-      event, payload)` helper, or is it inline?).
-
-
-      3. The cron sweep that delivers outbox rows — `outbox-sweep`. Where it lives, the SQL query, how
-      it sets `processedAt` / increments `attempts`, and how it uses the outbox row id as the Inngest
-      idempotency key.
-
-
-      4. The Inngest client and event-type definitions. Where are event names and payload types declared
-      (e.g. a typed `EventSchemas` / `Events` map)? Show how an event like `message.approval-requested`,
-      `hubspot.email.engagement-created`, `hubspot.engagement-missed` would be (or are) declared. Are
-      any of these three events already declared?
-
-
-      5. The MOST RECENT Inngest worker as the canonical pattern to mirror — the nurture migration from
-      commit df21fdd (#295) "migrate Follow-up plans to Inngest". Show: the full `inngest.createFunction(...)`
-      definition, how it declares `{ id, name }`, the `{ event: "..." }` trigger, any `if`/filter on event
-      data, the `step.run(...)` calls, and any `step.waitForEvent(...)` usage anywhere in the codebase.
-      I need the exact import surface and idiom.
-
-
-      6. How Inngest functions are registered/served — the `serve()` endpoint (likely `src/app/api/inngest/route.ts`
-      or similar) and the array of functions it exports. I need to know where to add my new functions.
-
-
-      7. Concurrency/idempotency config on existing functions — do they set `idempotency`, `concurrency`,
-      or `retries` in the createFunction options? Show an example.
-
-
-      Report exact paths, line numbers, signatures, and code snippets. Describe only what exists; do not
-      propose changes.'
+      Return grouped paths. For each ADR, include its number and recorded Status (Proposed/Accepted/Superseded).
+      Give a one-line description of each. Don''t deep-analyze — just locate and categorize.'
   - id: mined-codebase-locator-route-neg-3
     kind: routing
     expect_invoke: false

--- a/.claude/eval/tasks/mined/codebase-pattern-finder.yaml
+++ b/.claude/eval/tasks/mined/codebase-pattern-finder.yaml
@@ -3,8 +3,8 @@ _generated_by: shape_tasks.py from .claude/eval/mined/corpus.jsonl
 _needs_review: true
 _note: Auto-mined §5 candidates. Curate to 5, then merge into tasks/per-agent/codebase-pattern-finder.yaml
   alongside golden + adversarial buckets.
-_mined_available: 3
-_mined_emitted: 3
+_mined_available: 4
+_mined_emitted: 4
 execution:
 - id: mined-codebase-pattern-finder-exec-1
   kind: execution
@@ -162,6 +162,63 @@ execution:
 
 
     The dominant pattern: `rs.resetModules( …'
+- id: mined-codebase-pattern-finder-exec-4
+  kind: execution
+  prompt: 'I''m about to write tests for a new `dispatch-sms` Inngest function, mirroring the existing
+    tests for `dispatch-email`. I need concrete, copyable test patterns with file:line citations.
+
+
+    Please analyze these test files and show me the patterns:
+
+    - `src/inngest/functions/messages/__tests__/dispatch-email.test.ts`
+
+    - `src/inngest/functions/messages/__tests__/dispatch-email.integration.test.ts`
+
+    - `src/inngest/functions/messages/__tests__/reconcile-missed-engagement.test.ts`
+
+
+    Also look for any shared Inngest test helpers/utilities (search `src/inngest` and `src/test` or similar
+    for things like `InngestTestEngine`, mock step, virtual time helpers, mocked provider clients).
+
+
+    Report with file:line citations and actual code snippets:
+
+
+    1. **Test harness**: How is an Inngest function invoked in a unit test? Is it `@inngest/test` `InngestTestEngine`,
+    or a hand-rolled mock of the `step` object? Show the exact setup. How are `step.run`, `step.waitForEvent`,
+    and `step.sleep` mocked or driven?
+
+
+    2. **Virtual time**: How is time/timeout handled in tests (the `waitForEvent` timeout, any `step.sleep`)?
+    Show the pattern.
+
+
+    3. **Mocking provider clients**: How is the Graph/email client mocked? How would I analogously mock
+    a Twilio client? Show the mock setup (rstest `rs.mock` / `vi.mock` style — note this project uses
+    Rstest).
+
+
+    4. **DB assertions**: Do these tests hit a real DB (integration) or mock it (unit)? What''s the difference
+    between the `.test.ts` and `.integration.test.ts` files? Show how each sets up/asserts DB state.
+
+
+    5. **Status re-verification & cancellation tests**: How do they test the "verify still approved" cancellation
+    path (message dismissed mid-dispatch)?
+
+
+    Quote real snippets I can adapt. This project uses Rstest (not Vitest/Jest) — note any Rstest-specific
+    API usage.'
+  provenance:
+    agent_id: a84f5a263eaf87b59
+    session_id: 666946b8-d08a-4bee-928e-8bfb018e029d
+    model: claude-sonnet-4-6
+    latency_s: 36.41
+    tokens_total: 700303
+    n_tool_uses: 21
+    source_file: /Users/sam/.claude/projects/-Users-sam-workspace-rekurve-rekurve/666946b8-d08a-4bee-928e-8bfb018e029d/subagents/agent-a84f5a263eaf87b59.jsonl
+  sample_output_excerpt: Now I have everything needed. Let me do one final check to confirm there is no
+    existing `dispatch-sms.ts` Inngest function (versus the server-layer `sms-dispatch.ts`) and to see
+    the rstest config.
 routing:
   positives:
   - id: mined-codebase-pattern-finder-route-pos-1
@@ -236,59 +293,112 @@ routing:
       For each, give the file path, line numbers, and a representative snippet. Prioritize the Rstest
       unit/integration idiom (the repo uses Rstest, not Jest/Vitest). If a pattern genuinely doesn''t
       exist yet, say so clearly rather than inventing one.'
+  - id: mined-codebase-pattern-finder-route-pos-4
+    kind: routing
+    expect_invoke: true
+    prompt: 'I''m about to write tests for a new `dispatch-sms` Inngest function, mirroring the existing
+      tests for `dispatch-email`. I need concrete, copyable test patterns with file:line citations.
+
+
+      Please analyze these test files and show me the patterns:
+
+      - `src/inngest/functions/messages/__tests__/dispatch-email.test.ts`
+
+      - `src/inngest/functions/messages/__tests__/dispatch-email.integration.test.ts`
+
+      - `src/inngest/functions/messages/__tests__/reconcile-missed-engagement.test.ts`
+
+
+      Also look for any shared Inngest test helpers/utilities (search `src/inngest` and `src/test` or
+      similar for things like `InngestTestEngine`, mock step, virtual time helpers, mocked provider clients).
+
+
+      Report with file:line citations and actual code snippets:
+
+
+      1. **Test harness**: How is an Inngest function invoked in a unit test? Is it `@inngest/test` `InngestTestEngine`,
+      or a hand-rolled mock of the `step` object? Show the exact setup. How are `step.run`, `step.waitForEvent`,
+      and `step.sleep` mocked or driven?
+
+
+      2. **Virtual time**: How is time/timeout handled in tests (the `waitForEvent` timeout, any `step.sleep`)?
+      Show the pattern.
+
+
+      3. **Mocking provider clients**: How is the Graph/email client mocked? How would I analogously mock
+      a Twilio client? Show the mock setup (rstest `rs.mock` / `vi.mock` style — note this project uses
+      Rstest).
+
+
+      4. **DB assertions**: Do these tests hit a real DB (integration) or mock it (unit)? What''s the
+      difference between the `.test.ts` and `.integration.test.ts` files? Show how each sets up/asserts
+      DB state.
+
+
+      5. **Status re-verification & cancellation tests**: How do they test the "verify still approved"
+      cancellation path (message dismissed mid-dispatch)?
+
+
+      Quote real snippets I can adapt. This project uses Rstest (not Vitest/Jest) — note any Rstest-specific
+      API usage.'
   negatives:
   - id: mined-codebase-pattern-finder-route-neg-1
     kind: routing
     expect_invoke: false
     actual_route: codebase-analyzer
-    confusability: 0.175
-    prompt: 'I''m planning issue #261 which adds new Inngest worker functions fed by the transactional
-      outbox (ADR-014/ADR-017). I need to understand the EXISTING outbox + Inngest infrastructure so my
-      new functions mirror it exactly.
+    confusability: 0.225
+    prompt: 'I''m planning a refactor to mirror the email dispatch Inngest pattern for SMS. I need a precise,
+      file:line-cited trace of how the email dispatch worker pattern works end-to-end. Please analyze
+      these files:
 
 
-      Report with `file:line` for every claim:
+      - `src/inngest/functions/messages/dispatch-email.ts`
+
+      - `src/inngest/functions/messages/reconcile-missed-engagement.ts`
+
+      - `src/inngest/functions/index.ts` (how functions are registered)
+
+      - `src/inngest/channels.ts` and `src/inngest/client.ts` (event/channel definitions)
+
+      - `src/server/outbox/index.ts` (the MESSAGE_EVENTS / HUBSPOT_EMAIL_EVENTS constants, and any helper
+      to enqueue outbox events)
+
+      - `src/server/api/routers/messages.ts` (the `approve` and `editAndApprove` mutations — how they
+      write the status flip + outbox event atomically)
+
+      - `src/server/db/schema/message-queue.ts` (the schema, including the `dispatching_at` fence column)
 
 
-      1. The `outbox` table schema — full column list, types, the id type (uuid?), `processedAt`, `attempts`,
-      `lastError`, `createdAt`, and the event-name/payload columns. Where is it defined?
+      For each, report with file:line citations:
 
 
-      2. How outbox rows are inserted inside a transaction. ADR-017 mentions `db.batch()` over neon-http.
-      Find a concrete write site (e.g. the recent nurture migration #295, or the leads cutover #286/#288,
-      or contact.creation) that does: open transaction → canonical DB write → insert outbox row → commit
-      → post-commit `inngest.send`. Show the full pattern including the helper (is there an `outbox.publish(tx,
-      event, payload)` helper, or is it inline?).
+      1. **dispatch-email worker**: How does it subscribe to the event and filter to `channel === "email"`?
+      What are its discrete `step.run` stages in order (status re-verification / "verify-still-approved",
+      the dispatching_at fence, the provider/Graph call, the conversation row write, the `messageQueue.sentAt`
+      stamp)? How does the cancellation / "verify still approved" step work? How does `step.waitForEvent`
+      work for the engagement reconciliation, and what''s the timeout, and what fires on timeout (reconcile-missed-engagement)?
 
 
-      3. The cron sweep that delivers outbox rows — `outbox-sweep`. Where it lives, the SQL query, how
-      it sets `processedAt` / increments `attempts`, and how it uses the outbox row id as the Inngest
-      idempotency key.
+      2. **Event contract**: What is the exact shape of the `message.approval-requested` event payload
+      (all `data` fields)? What does the worker read from it? What is the event name string constant and
+      where is it defined?
 
 
-      4. The Inngest client and event-type definitions. Where are event names and payload types declared
-      (e.g. a typed `EventSchemas` / `Events` map)? Show how an event like `message.approval-requested`,
-      `hubspot.email.engagement-created`, `hubspot.engagement-missed` would be (or are) declared. Are
-      any of these three events already declared?
+      3. **Registration**: How is `dispatchEmail` registered in the functions index? What''s the naming/id
+      convention for Inngest function ids?
 
 
-      5. The MOST RECENT Inngest worker as the canonical pattern to mirror — the nurture migration from
-      commit df21fdd (#295) "migrate Follow-up plans to Inngest". Show: the full `inngest.createFunction(...)`
-      definition, how it declares `{ id, name }`, the `{ event: "..." }` trigger, any `if`/filter on event
-      data, the `step.run(...)` calls, and any `step.waitForEvent(...)` usage anywhere in the codebase.
-      I need the exact import surface and idiom.
+      4. **Router atomic write**: How exactly do `approve` / `editAndApprove` perform the atomic status-flip
+      + outbox enqueue (the `db.batch()` call)? What''s written to the outbox row? Is there anything email-specific
+      in the router, or is it channel-agnostic?
 
 
-      6. How Inngest functions are registered/served — the `serve()` endpoint (likely `src/app/api/inngest/route.ts`
-      or similar) and the array of functions it exports. I need to know where to add my new functions.
+      5. **Outbox helpers**: What''s the signature of whatever enqueues an outbox event, and what columns
+      does the outbox row have?
 
 
-      7. Concurrency/idempotency config on existing functions — do they set `idempotency`, `concurrency`,
-      or `retries` in the createFunction options? Show an example.
-
-
-      Report exact paths, line numbers, signatures, and code snippets. Describe only what exists; do not
-      propose changes.'
+      Be exhaustive and precise — quote the key lines. This is for mirroring the exact pattern into a
+      new `dispatch-sms` function.'
   - id: mined-codebase-pattern-finder-route-neg-2
     kind: routing
     expect_invoke: false

--- a/.claude/eval/tasks/mined/codebase-verification.yaml
+++ b/.claude/eval/tasks/mined/codebase-verification.yaml
@@ -3,385 +3,236 @@ _generated_by: shape_tasks.py from .claude/eval/mined/corpus.jsonl
 _needs_review: true
 _note: Auto-mined §5 candidates. Curate to 5, then merge into tasks/per-agent/codebase-verification.yaml
   alongside golden + adversarial buckets.
-_mined_available: 54
+_mined_available: 75
 _mined_emitted: 5
 execution:
 - id: mined-codebase-verification-exec-1
   kind: execution
-  prompt: Run make test_e2e. The working directory is /Users/sam/workspace/rekurve/rekurve. Report pass/fail.
-    If it fails, include the extracted error block showing which spec/test failed.
+  prompt: 'Run `make check` and `make test` in /Users/sam/workspace/rekurve/rekurve and report STATUS:
+    SUCCESS/FAILURE for each, with the extracted error block if any fail.'
   provenance:
-    agent_id: a295c95c65f241ad5
-    session_id: 2693f729-4ae4-4385-a908-5ceb481266dc
+    agent_id: a7b43afb3139d331b
+    session_id: da810594-c4f1-4650-91d8-500ea5b947a1
     model: claude-haiku-4-5-20251001
-    latency_s: 1201.3
-    tokens_total: 1313583
-    n_tool_uses: 34
-    source_file: /Users/sam/.claude/projects/-Users-sam-workspace-rekurve-rekurve/2693f729-4ae4-4385-a908-5ceb481266dc/subagents/agent-a295c95c65f241ad5.jsonl
-  sample_output_excerpt: "Perfect! Now I have the summary. Let me get the complete failure count:\n\n\
-    ```\nSTATUS: FAILURE\nFAILED_TARGET: test_e2e\nEXIT_CODE: 2\nERROR:\nTest timeout of 45000ms exceeded.\n\
-    \nError: locator.click: Test timeout of 45000ms exceeded.\nCall log:\n  - waiting for locator('[data-testid=\"\
-    quick-capture-fab\"]')\n\n   at QuickCaptureSection.open (/Users/sam/workspace/rekurve/rekurve/e2e/pages/sections/quick-captur\
-    \ …"
-- id: mined-codebase-verification-exec-2
-  kind: execution
-  prompt: 'Run the Playwright E2E suite for this repo and report results compactly.
-
-
-    IMPORTANT context before you run:
-
-    - This branch (`feat/258-lead-outbox-cutover`) cut lead intake over to DB-first via an outbox + Inngest
-    worker. E2E now needs TWO local servers: the Next app on :3000 and an Inngest dev server on :8288.
-    The `playwright.config.ts` `webServer` is already configured as an array of both, so `make test_e2e`
-    should boot both automatically. The app server is started with env `INNGEST_DEV=1` and `INNGEST_BASE_URL=http://localhost:8288`.
-
-    - The Inngest dev server is launched via `yarn preview:inngest` (`inngest dev -u http://localhost:3000/api/inngest`).
-    Confirm the `inngest` CLI is resolvable (devDependency `inngest-cli` is installed) — if the dev server
-    fails to boot, that''s a top-priority finding.
-
-
-    PREREQUISITE CHECK (do this FIRST, before running the suite):
-
-    1. Confirm `HUBSPOT_ACCESS_TOKEN` is present in the environment Playwright will inherit. Check `.env.local`
-    for a non-empty `HUBSPOT_ACCESS_TOKEN=` line. The HubSpot-touching specs (`e2e/features/hubspot-sync.spec.ts`
-    and `e2e/features/lead-intake-sync.spec.ts`) SELF-SKIP when it''s absent — a green run that actually
-    skipped them is a FALSE PASS and must be reported as such, not as success.
-
-    2. Report whether the token is present.
-
-
-    THEN run the suite: `make test_e2e` (do NOT use yarn/npx directly; use the make target).
-
-
-    REPORT BACK (compact):
-
-    - Whether HUBSPOT_ACCESS_TOKEN was present.
-
-    - Whether both webServers (app :3000 and inngest :8288) booted. If the Inngest dev server logged an
-    app-sync (look for `PUT /api/inngest` 200 / "apps synced" / function registration for `lead-hubspot-sync`),
-    say so.
-
-    - Overall pass/fail counts and how many specs SKIPPED.
-
-    - For EACH failing spec: the spec file + test name, and the extracted error block (assertion message,
-    timeout, or stack — keep it tight, ~10-20 lines per failure).
-
-    - Pay special attention to `e2e/features/lead-intake-sync.spec.ts` (new) and `e2e/features/hubspot-sync.spec.ts`
-    (modified) — these exercise the async outbox→worker→HubSpot path and are the highest-risk specs.
-
-
-    Do not attempt to fix anything. Just run and report.'
-  provenance:
-    agent_id: a5ca78c1d1b0c98b5
-    session_id: fcb5f608-d07a-40d7-bfaa-ab57281b8f63
-    model: claude-haiku-4-5-20251001
-    latency_s: 1261.43
-    tokens_total: 678459
-    n_tool_uses: 16
-    source_file: /Users/sam/.claude/projects/-Users-sam-workspace-rekurve-rekurve/fcb5f608-d07a-40d7-bfaa-ab57281b8f63/subagents/agent-a5ca78c1d1b0c98b5.jsonl
-  sample_output_excerpt: 'Good! The spec does have skip logic. But it failed rather than skipped, which
-    means it got past the skip condition (likely because the env var was partially set during the run,
-    or there was a transient state). Now let me examine the summary for key high-risk specs:
-
-
-    **Summary of findings:**
+    latency_s: 309.53
+    tokens_total: 2982780
+    n_tool_uses: 51
+    source_file: /Users/sam/.claude/projects/-Users-sam-workspace-rekurve-rekurve/da810594-c4f1-4650-91d8-500ea5b947a1/subagents/agent-a7b43afb3139d331b.jsonl
+  sample_output_excerpt: 'Perfect! All tests pass now. Let me verify that both `make check` and `make
+    test` pass:
 
 
     ```
-
-    HUBSPOT_ACCESS_TOKEN: NOT PRESENT in .env.local
-
-
-    WEBSERVER STARTUP:
-
-    ✓ Next.js app: listening on http:// …'
-- id: mined-codebase-verification-exec-3
-  kind: execution
-  prompt: 'Run `make build` (which does `rm -rf .next` + `yarn build`, i.e. a clean Next.js production
-    build). Use timeout up to 400000ms.
-
-
-    I just changed `src/app/(application)/_realtime/token.ts` to import `getClientSubscriptionToken` from
-    `inngest/react` (a "use server" module) instead of `getSubscriptionToken` from `inngest/realtime`,
-    to fix an RSC serialization error ("Only plain objects … can be passed to Client Components").
-
-
-    Report:
-
-    1. Whether the build SUCCEEDED or FAILED.
-
-    2. If it failed: the full verbatim error block, including the file/route and any "Only plain objects"
-    message or import/module-resolution error.
-
-    3. Any warnings mentioning `inngest/react`, "use client"/"use server", or serialization.
-
-
-    Do not fix anything.'
-  provenance:
-    agent_id: afcca3cf8775dbd74
-    session_id: 21e617d7-554b-4d04-9151-e6f7f41caf68
-    model: claude-haiku-4-5-20251001
-    latency_s: 65.4
-    tokens_total: 104428
-    n_tool_uses: 5
-    source_file: /Users/sam/.claude/projects/-Users-sam-workspace-rekurve-rekurve/21e617d7-554b-4d04-9151-e6f7f41caf68/subagents/agent-afcca3cf8775dbd74.jsonl
-  sample_output_excerpt: '**Build result: SUCCEEDED**
-
-
-    The clean build completed successfully with no errors or warnings related to your change. The build
-    output shows:
-
-    - ✓ Compiled successfully in 14.0s
-
-    - ✓ Finished TypeScript in 6.6s
-
-    - ✓ All 18 static pages generated
-
-    - No "Only plain objects" errors
-
-    - No module resolution errors for `inngest/react` or `inngest/realtime`
-
-    - No serialization warnings
-
-
-    The change from `getSu …'
-- id: mined-codebase-verification-exec-4
-  kind: execution
-  prompt: 'Verification after a file-move refactor. I relocated `src/server/outbox/{prune,sweep}.ts` and
-    their tests (`__tests__/{prune.test.ts, sweep.test.ts, sweep.integration.test.ts}`) to `src/inngest/functions/outbox/`,
-    and updated import paths in `src/inngest/functions/index.ts`. No logic changed. The moved tests reference
-    their source via relative imports (`../prune`, `../sweep`), so the unit tests exercise that the move
-    resolves correctly.
-
-
-    Run these make targets in order, stopping at the first failure:
-
-    1. `make check`  (lint + typecheck)
-
-    2. `make test`   (Rstest unit tests — integration tests are DB-gated and will skip without INTEGRATION_DB)
-
-
-    Return a one-line success listing the targets that passed, or if something fails, the structured error
-    block (which target, and the extracted error).'
-  provenance:
-    agent_id: ab7043427359417b4
-    session_id: 29b68443-03bd-405a-858a-b273fc82b143
-    model: claude-haiku-4-5-20251001
-    latency_s: 20.99
-    tokens_total: 39540
-    n_tool_uses: 2
-    source_file: /Users/sam/.claude/projects/-Users-sam-workspace-rekurve-rekurve/29b68443-03bd-405a-858a-b273fc82b143/subagents/agent-ab7043427359417b4.jsonl
-  sample_output_excerpt: '```
 
     STATUS: SUCCESS
 
     TARGETS: check, test
 
     ```'
+- id: mined-codebase-verification-exec-2
+  kind: execution
+  prompt: 'Run the Playwright E2E suite for this project by running `make test_e2e` (which runs `yarn
+    test:e2e` → `playwright test`).
+
+
+    IMPORTANT context about this run:
+
+    - This branch has a NEW local Playwright config: it starts TWO web servers — the Next app on :3000
+    (with env INNGEST_DEV=1 and INNGEST_BASE_URL=http://localhost:8288) AND an Inngest dev server on :8288
+    (`yarn preview:inngest` → `inngest dev -u http://localhost:3000/api/inngest`). Playwright waits for
+    both before running tests. First run includes a clean Next build (`rm -rf .next/ && yarn db:migrate
+    && yarn preview`), so server startup can take a couple minutes — be patient with the timeout (use
+    up to 600000ms).
+
+    - HUBSPOT_ACCESS_TOKEN is present in `.env` (loaded via dotenv). Two specs (e2e/features/lead-intake-sync.spec.ts
+    and e2e/features/hubspot-sync.spec.ts) self-skip if it''s absent. I need to know whether they actually
+    RAN or SKIPPED — a suite that passes only because HubSpot specs skipped is a FALSE PASS.
+
+
+    What I need back:
+
+    1. Overall pass/fail summary (counts: passed / failed / skipped / flaky).
+
+    2. EXPLICITLY state whether `lead-intake-sync.spec.ts` and `hubspot-sync.spec.ts` ran or were skipped.
+
+    3. For any FAILED spec: the spec file + test name, and the full error block (assertion message, timeout
+    details, stack) — verbatim, not summarized.
+
+    4. If either web server failed to start (app or inngest dev server on :8288), capture that error block
+    too — look for "apps synced", "PUT /api/inngest", "no signing key found", or port/startup errors in
+    the piped server logs.
+
+
+    Run the command and report. Do not attempt to fix anything.'
+  provenance:
+    agent_id: aa5d03cd3b4dc13a5
+    session_id: 21e617d7-554b-4d04-9151-e6f7f41caf68
+    model: claude-haiku-4-5-20251001
+    latency_s: 1150.52
+    tokens_total: 975414
+    n_tool_uses: 18
+    source_file: /Users/sam/.claude/projects/-Users-sam-workspace-rekurve-rekurve/21e617d7-554b-4d04-9151-e6f7f41caf68/subagents/agent-aa5d03cd3b4dc13a5.jsonl
+  sample_output_excerpt: 'Perfect! The servers started successfully. I can see:
+
+    - Next.js app started on port 3000: "Ready in 51ms"
+
+    - Inngest dev server started on port 8288: "starting server","caller":"api","addr":"0.0.0.0:8288"
+
+    - Apps synced: "apps synced, disabling auto-discovery"
+
+
+    Now let me verify the specific counts from the summary. Let me look at a comprehensive count of the
+    failures:
+
+
+    Based on the E2E test run out …'
+- id: mined-codebase-verification-exec-3
+  kind: execution
+  prompt: 'Run `make test` and report the result. If it fails, return only the failing test file names,
+    the failing test names, and their assertion diff output (not the full passing log). Note: any test
+    gated behind INTEGRATION_DB is expected to skip — do not treat skipped tests as failures.'
+  provenance:
+    agent_id: a425145d09a2655cc
+    session_id: 376d002b-e6ca-452d-a83d-edfd7d032fd9
+    model: claude-haiku-4-5-20251001
+    latency_s: 13.66
+    tokens_total: 15863
+    n_tool_uses: 1
+    source_file: /Users/sam/.claude/projects/-Users-sam-workspace-rekurve-rekurve/376d002b-e6ca-452d-a83d-edfd7d032fd9/subagents/agent-a425145d09a2655cc.jsonl
+  sample_output_excerpt: I'll run `make test` for you.
+- id: mined-codebase-verification-exec-4
+  kind: execution
+  prompt: Run only `make db_migrate`. Report pass/fail and show the output including which migration was
+    applied.
+  provenance:
+    agent_id: a10d2d5fd6b7e0667
+    session_id: 3af2785d-be20-410c-9261-cab34a91ddf7
+    model: claude-haiku-4-5-20251001
+    latency_s: 8.87
+    tokens_total: 17809
+    n_tool_uses: 1
+    source_file: /Users/sam/.claude/projects/-Users-sam-workspace-rekurve-rekurve/3af2785d-be20-410c-9261-cab34a91ddf7/subagents/agent-a10d2d5fd6b7e0667.jsonl
+  sample_output_excerpt: '**PASS**
+
+
+    Migration applied successfully. The output shows:
+
+    - The migrations table and schema already exist (notices only, not errors)
+
+    - All pending migrations applied successfully with the checkmark: `[✓] migrations applied successfully!`
+
+
+    The migration that was applied is from the new drizzle files in your working directory:
+
+    - **Migration file**: `drizzle/0006_slimy_dagger.sql` (newly generated …'
 - id: mined-codebase-verification-exec-5
   kind: execution
-  prompt: 'Run `make check` (biome lint + tsc typecheck) for this repo and report the result.
+  prompt: 'Run `make check` (lint + typecheck) and report the result.
 
 
-    Context: I changed two files only:
-
-    - e2e/utils/hubspot-helper.ts — added an exported `getTestContactById(hubspotId): Promise<TestContact>`
-    function that calls `hubspot().crm.contacts.basicApi.getById(hubspotId, ALL_PROPERTIES)`.
-
-    - e2e/features/hubspot-sync.spec.ts — added `getTestContactById` to the import from ../utils/hubspot-helper,
-    and changed one test''s assertions to use it.
+    Context: this change adds two new Claude Code agent definition files (`.claude/agents/docs-locator.md`,
+    `.claude/agents/docs-analyzer.md`) and edits five other markdown files under `.claude/`. No TypeScript/source
+    files in `src/` were touched, so I expect `check` to pass cleanly — I''m running it as a guard to
+    confirm nothing is broken.
 
 
-    I need to confirm there are no lint or type errors. If `make check` fails, return the exact error
-    block (file, line, message). If it passes, return a one-line success.'
+    Return a one-line PASS, or if it fails, the extracted error block.'
   provenance:
-    agent_id: af3990472e4030823
-    session_id: 09b668e2-eb3e-4ca5-bf9c-e3168c9f0ad1
+    agent_id: a59a4ba69aa81fa7c
+    session_id: c485121e-d0ed-417b-a3e4-4538a2ab1a75
     model: claude-haiku-4-5-20251001
-    latency_s: 7.3
-    tokens_total: 22721
+    latency_s: 5.47
+    tokens_total: 16093
     n_tool_uses: 1
-    source_file: /Users/sam/.claude/projects/-Users-sam-workspace-rekurve-rekurve/09b668e2-eb3e-4ca5-bf9c-e3168c9f0ad1/subagents/agent-af3990472e4030823.jsonl
-  sample_output_excerpt: '```
-
-    STATUS: SUCCESS
-
-    TARGETS: check
-
-    ```'
+    source_file: /Users/sam/.claude/projects/-Users-sam-workspace-rekurve-rekurve/c485121e-d0ed-417b-a3e4-4538a2ab1a75/subagents/agent-a59a4ba69aa81fa7c.jsonl
+  sample_output_excerpt: I'll run `make check` for you.
 routing:
   positives:
   - id: mined-codebase-verification-route-pos-1
     kind: routing
     expect_invoke: true
-    prompt: Run make test_e2e. The working directory is /Users/sam/workspace/rekurve/rekurve. Report pass/fail.
-      If it fails, include the extracted error block showing which spec/test failed.
+    prompt: 'Run `make check` and `make test` in /Users/sam/workspace/rekurve/rekurve and report STATUS:
+      SUCCESS/FAILURE for each, with the extracted error block if any fail.'
   - id: mined-codebase-verification-route-pos-2
     kind: routing
     expect_invoke: true
-    prompt: 'Run the Playwright E2E suite for this repo and report results compactly.
+    prompt: 'Run the Playwright E2E suite for this project by running `make test_e2e` (which runs `yarn
+      test:e2e` → `playwright test`).
 
 
-      IMPORTANT context before you run:
+      IMPORTANT context about this run:
 
-      - This branch (`feat/258-lead-outbox-cutover`) cut lead intake over to DB-first via an outbox +
-      Inngest worker. E2E now needs TWO local servers: the Next app on :3000 and an Inngest dev server
-      on :8288. The `playwright.config.ts` `webServer` is already configured as an array of both, so `make
-      test_e2e` should boot both automatically. The app server is started with env `INNGEST_DEV=1` and
-      `INNGEST_BASE_URL=http://localhost:8288`.
+      - This branch has a NEW local Playwright config: it starts TWO web servers — the Next app on :3000
+      (with env INNGEST_DEV=1 and INNGEST_BASE_URL=http://localhost:8288) AND an Inngest dev server on
+      :8288 (`yarn preview:inngest` → `inngest dev -u http://localhost:3000/api/inngest`). Playwright
+      waits for both before running tests. First run includes a clean Next build (`rm -rf .next/ && yarn
+      db:migrate && yarn preview`), so server startup can take a couple minutes — be patient with the
+      timeout (use up to 600000ms).
 
-      - The Inngest dev server is launched via `yarn preview:inngest` (`inngest dev -u http://localhost:3000/api/inngest`).
-      Confirm the `inngest` CLI is resolvable (devDependency `inngest-cli` is installed) — if the dev
-      server fails to boot, that''s a top-priority finding.
-
-
-      PREREQUISITE CHECK (do this FIRST, before running the suite):
-
-      1. Confirm `HUBSPOT_ACCESS_TOKEN` is present in the environment Playwright will inherit. Check `.env.local`
-      for a non-empty `HUBSPOT_ACCESS_TOKEN=` line. The HubSpot-touching specs (`e2e/features/hubspot-sync.spec.ts`
-      and `e2e/features/lead-intake-sync.spec.ts`) SELF-SKIP when it''s absent — a green run that actually
-      skipped them is a FALSE PASS and must be reported as such, not as success.
-
-      2. Report whether the token is present.
+      - HUBSPOT_ACCESS_TOKEN is present in `.env` (loaded via dotenv). Two specs (e2e/features/lead-intake-sync.spec.ts
+      and e2e/features/hubspot-sync.spec.ts) self-skip if it''s absent. I need to know whether they actually
+      RAN or SKIPPED — a suite that passes only because HubSpot specs skipped is a FALSE PASS.
 
 
-      THEN run the suite: `make test_e2e` (do NOT use yarn/npx directly; use the make target).
+      What I need back:
+
+      1. Overall pass/fail summary (counts: passed / failed / skipped / flaky).
+
+      2. EXPLICITLY state whether `lead-intake-sync.spec.ts` and `hubspot-sync.spec.ts` ran or were skipped.
+
+      3. For any FAILED spec: the spec file + test name, and the full error block (assertion message,
+      timeout details, stack) — verbatim, not summarized.
+
+      4. If either web server failed to start (app or inngest dev server on :8288), capture that error
+      block too — look for "apps synced", "PUT /api/inngest", "no signing key found", or port/startup
+      errors in the piped server logs.
 
 
-      REPORT BACK (compact):
-
-      - Whether HUBSPOT_ACCESS_TOKEN was present.
-
-      - Whether both webServers (app :3000 and inngest :8288) booted. If the Inngest dev server logged
-      an app-sync (look for `PUT /api/inngest` 200 / "apps synced" / function registration for `lead-hubspot-sync`),
-      say so.
-
-      - Overall pass/fail counts and how many specs SKIPPED.
-
-      - For EACH failing spec: the spec file + test name, and the extracted error block (assertion message,
-      timeout, or stack — keep it tight, ~10-20 lines per failure).
-
-      - Pay special attention to `e2e/features/lead-intake-sync.spec.ts` (new) and `e2e/features/hubspot-sync.spec.ts`
-      (modified) — these exercise the async outbox→worker→HubSpot path and are the highest-risk specs.
-
-
-      Do not attempt to fix anything. Just run and report.'
+      Run the command and report. Do not attempt to fix anything.'
   - id: mined-codebase-verification-route-pos-3
     kind: routing
     expect_invoke: true
-    prompt: 'Run `make build` (which does `rm -rf .next` + `yarn build`, i.e. a clean Next.js production
-      build). Use timeout up to 400000ms.
-
-
-      I just changed `src/app/(application)/_realtime/token.ts` to import `getClientSubscriptionToken`
-      from `inngest/react` (a "use server" module) instead of `getSubscriptionToken` from `inngest/realtime`,
-      to fix an RSC serialization error ("Only plain objects … can be passed to Client Components").
-
-
-      Report:
-
-      1. Whether the build SUCCEEDED or FAILED.
-
-      2. If it failed: the full verbatim error block, including the file/route and any "Only plain objects"
-      message or import/module-resolution error.
-
-      3. Any warnings mentioning `inngest/react`, "use client"/"use server", or serialization.
-
-
-      Do not fix anything.'
+    prompt: 'Run `make test` and report the result. If it fails, return only the failing test file names,
+      the failing test names, and their assertion diff output (not the full passing log). Note: any test
+      gated behind INTEGRATION_DB is expected to skip — do not treat skipped tests as failures.'
   - id: mined-codebase-verification-route-pos-4
     kind: routing
     expect_invoke: true
-    prompt: 'Verification after a file-move refactor. I relocated `src/server/outbox/{prune,sweep}.ts`
-      and their tests (`__tests__/{prune.test.ts, sweep.test.ts, sweep.integration.test.ts}`) to `src/inngest/functions/outbox/`,
-      and updated import paths in `src/inngest/functions/index.ts`. No logic changed. The moved tests
-      reference their source via relative imports (`../prune`, `../sweep`), so the unit tests exercise
-      that the move resolves correctly.
-
-
-      Run these make targets in order, stopping at the first failure:
-
-      1. `make check`  (lint + typecheck)
-
-      2. `make test`   (Rstest unit tests — integration tests are DB-gated and will skip without INTEGRATION_DB)
-
-
-      Return a one-line success listing the targets that passed, or if something fails, the structured
-      error block (which target, and the extracted error).'
+    prompt: Run only `make db_migrate`. Report pass/fail and show the output including which migration
+      was applied.
   - id: mined-codebase-verification-route-pos-5
     kind: routing
     expect_invoke: true
-    prompt: 'Run `make check` (biome lint + tsc typecheck) for this repo and report the result.
+    prompt: 'Run `make check` (lint + typecheck) and report the result.
 
 
-      Context: I changed two files only:
-
-      - e2e/utils/hubspot-helper.ts — added an exported `getTestContactById(hubspotId): Promise<TestContact>`
-      function that calls `hubspot().crm.contacts.basicApi.getById(hubspotId, ALL_PROPERTIES)`.
-
-      - e2e/features/hubspot-sync.spec.ts — added `getTestContactById` to the import from ../utils/hubspot-helper,
-      and changed one test''s assertions to use it.
+      Context: this change adds two new Claude Code agent definition files (`.claude/agents/docs-locator.md`,
+      `.claude/agents/docs-analyzer.md`) and edits five other markdown files under `.claude/`. No TypeScript/source
+      files in `src/` were touched, so I expect `check` to pass cleanly — I''m running it as a guard to
+      confirm nothing is broken.
 
 
-      I need to confirm there are no lint or type errors. If `make check` fails, return the exact error
-      block (file, line, message). If it passes, return a one-line success.'
+      Return a one-line PASS, or if it fails, the extracted error block.'
   negatives:
   - id: mined-codebase-verification-route-neg-1
     kind: routing
     expect_invoke: false
-    actual_route: web-research
-    confusability: 0.109
-    prompt: 'I''m implementing browser realtime updates in a Next.js 15 (App Router) + React 19 app that
-      already uses Inngest v4.2.6 (package "inngest@4.2.6"). I need authoritative, current details on
-      **Inngest Realtime** (the `@inngest/realtime` package) — the feature that lets a browser subscribe
-      to events/channels and receive them over a WebSocket.
+    actual_route: codebase-analyzer
+    confusability: 0.111
+    prompt: 'Read these four files and return their full contents:
 
+      1. /Users/sam/workspace/rekurve/rekurve/.claude/skills/ticket-writer/references/agent-brief.md
 
-      Please research and report, with citations and version numbers, on the OFFICIAL Inngest docs (inngest.com/docs)
-      and the @inngest/realtime npm/GitHub:
+      2. /Users/sam/workspace/rekurve/rekurve/.claude/skills/ticket-writer/references/bug-template.md
 
+      3. /Users/sam/workspace/rekurve/rekurve/.claude/skills/ticket-writer/references/github-publishing.md
 
-      1. **Package & version**: What is the current `@inngest/realtime` package, its latest version, and
-      what version of the core `inngest` package does it require as a peer dependency? Is `inngest@4.2.6`
-      compatible, or is an upgrade required? Is `@inngest/realtime` still beta/experimental as of early
-      2026?
-
-
-      2. **Server setup**: How do you define a channel and topic on the server? Show the exact API: `channel()`,
-      `topic()`, `realtimeMiddleware()`. How is the middleware added to the Inngest client (`new Inngest({
-      id, middleware: [realtimeMiddleware()] })`)? How does an Inngest function `publish()` to a channel/topic?
-
-
-      3. **Subscribe tokens (auth)**: How do you generate a subscription token server-side with `getSubscriptionToken()`,
-      scoped to a specific channel + topic? This is the auth boundary — I want to scope a per-user channel
-      so a user only receives their own events. Show the server-side token-generation code (e.g. in a
-      Next.js server action or route handler) and how channel names can be parameterized per-user (e.g.
-      `channel(`user:${userId}`)`).
-
-
-      4. **Client subscription**: Show the exact React hook `useInngestSubscription` from `@inngest/realtime/hooks`
-      — its arguments (token, refreshToken, enabled), what it returns (data, latestData, state), and a
-      full working example of a client component subscribing and reacting to messages. Also show the non-React
-      `subscribe()` API.
-
-
-      5. **Does it work on Vercel serverless?** The functions are served via `inngest/next` `serve()`
-      on Vercel. Confirm that Realtime publish works from functions on serverless and that the browser
-      connects directly to Inngest''s WebSocket (not to our server). Any gotchas with Vercel?
-
-
-      6. **Env/keys**: What environment variables or keys are required for Realtime to work in production
-      (signing key, event key, anything Realtime-specific)?
-
-
-      Prefer official Inngest documentation and the @inngest/realtime GitHub README. Quote exact code
-      snippets and cite the doc URLs and version numbers. If the API changed across versions, note which
-      version introduced the current shape.'
+      4. /Users/sam/workspace/rekurve/rekurve/.claude/skills/ticket-writer/references/epic-breakdown.md'
   - id: mined-codebase-verification-route-neg-2
     kind: routing
     expect_invoke: false
     actual_route: codebase-pattern-finder
-    confusability: 0.101
+    confusability: 0.098
     prompt: 'I''m planning integration + unit tests for new Inngest worker functions in issue #261 (email
       dispatch worker with `step.run` and `step.waitForEvent` + a timeout path). I need existing test
       patterns to mirror.
@@ -428,27 +279,16 @@ routing:
     kind: routing
     expect_invoke: false
     actual_route: codebase-locator
-    confusability: 0.1
-    prompt: 'I''m debugging a failing E2E test about HubSpot outbound sync. I need to find ALL the code
-      that syncs a newly-created lead OUT to HubSpot (creating or updating a HubSpot contact from a lead).
+    confusability: 0.087
+    prompt: 'Locate where **lead scoring** lives in this codebase. Return file locations only — do not
+      explain behavior — grouped by purpose:
 
 
-      Specifically locate:
+      1. The scoring module''s source files
 
-      1. The "lead outbox worker" / outbox processor that was recently introduced (PR called "lead-outbox-cutover").
-      Where leads are picked up and pushed to HubSpot.
+      2. Every place lead scoring is invoked / called from
 
-      2. The HubSpot API client wrapper functions that create or update a contact — anything that calls
-      HubSpot''s contacts create/update/upsert/search APIs. Look for terms like `basicApi.create`, `basicApi.update`,
-      `searchApi.doSearch`, `idProperty`, `createOrUpdate`, `upsert`, `hubspotContactId`.
-
-      3. The mapping from a lead''s fields (firstName, lastName, email, phone) to HubSpot contact properties
-      (firstname, lastname, email, phone).
-
-      4. Any logic that handles the case where a HubSpot contact ALREADY EXISTS for a given email (dedup
-      by email) — does it update the existing contact''s properties or just link to it?
+      3. The scoring tests
 
 
-      The relevant code is under src/ (likely src/server, src/inngest, or src/lib). Report exact file
-      paths and the key function names/line numbers for each. Do not analyze deeply yet — just locate
-      and give me a precise map of the relevant files and functions.'
+      Give full paths from the repo root.'

--- a/.claude/eval/tasks/mined/design-reviewer.yaml
+++ b/.claude/eval/tasks/mined/design-reviewer.yaml
@@ -3,10 +3,60 @@ _generated_by: shape_tasks.py from .claude/eval/mined/corpus.jsonl
 _needs_review: true
 _note: Auto-mined §5 candidates. Curate to 5, then merge into tasks/per-agent/design-reviewer.yaml alongside
   golden + adversarial buckets.
-_mined_available: 1
-_mined_emitted: 1
+_mined_available: 3
+_mined_emitted: 3
 execution:
 - id: mined-design-reviewer-exec-1
+  kind: execution
+  prompt: "Conduct a focused design review on a toast copy change in a Next.js dashboard app.\n\n## Context\n\
+    \nThe branch `feat/261-email-dispatch-outbox-migration` changed email approval from synchronous (send\
+    \ happens immediately) to async (send happens in an Inngest background worker). As a result, the success\
+    \ toast copy was updated:\n\n**Before** (implied — synchronous send): toast said something like \"\
+    Draft approved\" or similar  \n**After** (this branch):\n- `approve` for email channel → `toast.add({\
+    \ title: \"Email queued to send\" })`  (`src/app/(application)/dashboard/_components/use-queue-actions.ts:109`)\n\
+    - `editAndApprove` for email channel → `toast.add({ title: \"Email queued to send\", description:\
+    \ \"Your edits were saved.\" })` (line 187)\n- SMS and other channels still show `toast.add({ title:\
+    \ \"Draft approved\" })`\n- Error when MS account not connected → `toast.add({ type: \"error\", title:\
+    \ \"Microsoft account not connected\", description: \"Connect your account to send emails from Outlook.\"\
+    , ... })` with a \"Connect\" action button\n\nThe app is a consultant-facing dashboard. The live preview\
+    \ is at https://rekurve.localhost — note this is a Vercel Portless URL (no port number needed).\n\n\
+    ## What to review\n\n1. **Copy quality** — Is \"Email queued to send\" clear, accurate, and appropriately\
+    \ reassuring? The email won't send for up to ~30s (outbox sweep) after the consultant taps Approve.\
+    \ Does the copy set the right expectation?\n\n2. **Visual rendering** — Navigate to https://rekurve.localhost\
+    \ and attempt to observe the toast component in context. The toast uses `data-testid=\"app-toast\"\
+    `. Look at any existing toasts on the dashboard, or the toast's visual appearance from the component\
+    \ source. Check: font, colour, size, duration, position on screen.\n\n3. **Edit flow copy** — \"Email\
+    \ queued to send\" + description \"Your edits were saved.\" — does adding the description in the edit-and-approve\
+    \ path feel right?\n\n4. **Consistency** — SMS still says \"Draft approved\". Email now says \"Email\
+    \ queued to send\". Is this channel-specific divergence appropriate or jarring?\n\n5. **Accessibility**\
+    \ — Is the toast announced to screen readers? Does the error toast with the \"Connect\" action button\
+    \ meet accessible interactive element standards?\n\n## Key files to read\n\n- `src/app/(application)/dashboard/_components/use-queue-actions.ts`\
+    \ — the changed file (toast calls at lines 109, 187)\n- Look for the toast component implementation\
+    \ (search for `app-toast` data-testid) to understand duration, positioning, and ARIA handling\n\n\
+    Report findings in a structured design review format: what passes, what has concerns, and any recommendations.\
+    \ Be concise — this is a narrow copy-only change, not a full feature review."
+  provenance:
+    agent_id: a406f0077c6e0facb
+    session_id: a76e0a6d-b917-4e91-916d-933195edfbac
+    model: claude-sonnet-4-6
+    latency_s: 222.1
+    tokens_total: 2069061
+    n_tool_uses: 51
+    source_file: /Users/sam/.claude/projects/-Users-sam-workspace-rekurve-rekurve/a76e0a6d-b917-4e91-916d-933195edfbac/subagents/agent-a406f0077c6e0facb.jsonl
+  sample_output_excerpt: 'I now have everything I need for a thorough, evidence-based review. Let me compile
+    the findings.
+
+
+    ---
+
+
+    ### Design Review Summary
+
+
+    This is a narrow, well-scoped change. The implementation is fundamentally sound — the async architecture
+    change is correctly reflected in the UI, and the toast infrastructure (Base UI v1.4.1, Tailwind tokens,
+    brand system) is solid. There are no blockers. A handful of i …'
+- id: mined-design-reviewer-exec-2
   kind: execution
   prompt: "You are reviewing a specific UI change on the `feat/258-lead-outbox-cutover` branch of a Next.js\
     \ app called Rekurve. The app runs at https://rekurve.localhost via Vercel Portless.\n\n## What changed\n\
@@ -70,9 +120,152 @@ execution:
 
     The dev server was not reachable at `https://rekurve.localhost` during this review, so all findings
     are based on static code analysis of the component, its dependencies (`Badge.tsx`, `display …'
+- id: mined-design-reviewer-exec-3
+  kind: execution
+  prompt: 'You are reviewing a specific UX copy change on the Rekurve dashboard. The app is live at https://rekurve.localhost.
+
+
+    ## What changed
+
+
+    In `src/app/(application)/dashboard/_components/use-queue-actions.ts`, the email approval success
+    toast was updated:
+
+
+    **Before:** `toast.add({ title: "Sent via email" })`
+
+    **After:** `toast.add({ title: "Email queued to send" })`
+
+
+    For edit-and-approve specifically:
+
+    **After:** `toast.add({ title: "Email queued to send", description: "Your edits were saved." })`
+
+
+    This copy change reflects a real behaviour change: approving an email no longer sends it immediately.
+    The email is now dispatched asynchronously by an Inngest worker. The UI shows "approved" status instantly
+    and the row disappears from the queue optimistically, but the actual send happens in the background.
+
+
+    ## Full toast copy inventory to review (for consistency)
+
+
+    All current toast titles/descriptions in the app:
+
+    - Email approve success: `"Email queued to send"` (new)
+
+    - Email edit+approve success: `"Email queued to send"` + description `"Your edits were saved."` (new)
+
+    - SMS/other channel approve: `"Draft approved"`
+
+    - Edit+approve (SMS): `"Draft approved"`
+
+    - Dismiss: `"Draft dismissed"`
+
+    - Snooze: `` `Snoozed until ${when}` ``
+
+    - Approve error (MS not connected): title `"Microsoft account not connected"`, description `"Connect
+    your account to send emails from Outlook."` + "Connect" action button
+
+    - Approve error (other): `"Approve failed"`
+
+    - Edit error: `"Edit failed"`
+
+    - Snooze error: `"Snooze failed"`
+
+    - SMS copy failed: title `"Copy failed"`, description `"Could not copy to clipboard. Try another option."`
+
+
+    ## Toast component design
+
+
+    The toast is a `base-ui` Toast component with:
+
+    - `rounded-lg border bg-background p-4 shadow-lg`
+
+    - Title: `font-medium text-sm leading-tight`
+
+    - Description: `text-muted-foreground text-sm`
+
+    - Error variant: `data-[type=error]:border-destructive/30`
+
+    - Positioned bottom-right on desktop (w-96), full-width above bottom nav on mobile
+
+    - Dismiss X button
+
+
+    ## Review tasks
+
+
+    1. **Navigate to the app**: Go to https://rekurve.localhost and take a screenshot of the dashboard.
+
+
+    2. **Assess the copy change semantically**: Does "Email queued to send" accurately reflect what happened?
+    Is it clear to a non-technical consultant (the user is a real estate sales consultant, not a developer)
+    that their email will be sent shortly? Compare against the old "Sent via email" — does the new copy
+    create anxiety ("queued" could imply delay or uncertainty)?
+
+
+    3. **Consistency audit**: Review the full toast inventory above. Does "Email queued to send" fit the
+    pattern of the other success toasts? ("Draft approved", "Draft dismissed", "Snoozed until X")
+
+
+    4. **Check the description field**: The edit+approve path adds `description: "Your edits were saved."`
+    — is this description additive or redundant? Does it make sense alongside the title?
+
+
+    5. **Take a screenshot** of any existing toast if you can trigger one, or screenshot the dashboard
+    UI to show the context.
+
+
+    6. **Assess accessibility**: Does the copy work for screen readers? Is the toast dismissible?
+
+
+    Report your findings as a structured design review with clear PASS/FAIL/SUGGESTION verdicts per criterion.'
+  provenance:
+    agent_id: aabcefed93dc70267
+    session_id: a76e0a6d-b917-4e91-916d-933195edfbac
+    model: claude-sonnet-4-6
+    latency_s: 62.03
+    tokens_total: 418733
+    n_tool_uses: 12
+    source_file: /Users/sam/.claude/projects/-Users-sam-workspace-rekurve-rekurve/a76e0a6d-b917-4e91-916d-933195edfbac/subagents/agent-aabcefed93dc70267.jsonl
+  sample_output_excerpt: I now have everything I need to conduct a thorough code-based review. Let me
+    also check the SMS channel's edit-and-approve path for completeness.
 routing:
   positives:
   - id: mined-design-reviewer-route-pos-1
+    kind: routing
+    expect_invoke: true
+    prompt: "Conduct a focused design review on a toast copy change in a Next.js dashboard app.\n\n##\
+      \ Context\n\nThe branch `feat/261-email-dispatch-outbox-migration` changed email approval from synchronous\
+      \ (send happens immediately) to async (send happens in an Inngest background worker). As a result,\
+      \ the success toast copy was updated:\n\n**Before** (implied — synchronous send): toast said something\
+      \ like \"Draft approved\" or similar  \n**After** (this branch):\n- `approve` for email channel\
+      \ → `toast.add({ title: \"Email queued to send\" })`  (`src/app/(application)/dashboard/_components/use-queue-actions.ts:109`)\n\
+      - `editAndApprove` for email channel → `toast.add({ title: \"Email queued to send\", description:\
+      \ \"Your edits were saved.\" })` (line 187)\n- SMS and other channels still show `toast.add({ title:\
+      \ \"Draft approved\" })`\n- Error when MS account not connected → `toast.add({ type: \"error\",\
+      \ title: \"Microsoft account not connected\", description: \"Connect your account to send emails\
+      \ from Outlook.\", ... })` with a \"Connect\" action button\n\nThe app is a consultant-facing dashboard.\
+      \ The live preview is at https://rekurve.localhost — note this is a Vercel Portless URL (no port\
+      \ number needed).\n\n## What to review\n\n1. **Copy quality** — Is \"Email queued to send\" clear,\
+      \ accurate, and appropriately reassuring? The email won't send for up to ~30s (outbox sweep) after\
+      \ the consultant taps Approve. Does the copy set the right expectation?\n\n2. **Visual rendering**\
+      \ — Navigate to https://rekurve.localhost and attempt to observe the toast component in context.\
+      \ The toast uses `data-testid=\"app-toast\"`. Look at any existing toasts on the dashboard, or the\
+      \ toast's visual appearance from the component source. Check: font, colour, size, duration, position\
+      \ on screen.\n\n3. **Edit flow copy** — \"Email queued to send\" + description \"Your edits were\
+      \ saved.\" — does adding the description in the edit-and-approve path feel right?\n\n4. **Consistency**\
+      \ — SMS still says \"Draft approved\". Email now says \"Email queued to send\". Is this channel-specific\
+      \ divergence appropriate or jarring?\n\n5. **Accessibility** — Is the toast announced to screen\
+      \ readers? Does the error toast with the \"Connect\" action button meet accessible interactive element\
+      \ standards?\n\n## Key files to read\n\n- `src/app/(application)/dashboard/_components/use-queue-actions.ts`\
+      \ — the changed file (toast calls at lines 109, 187)\n- Look for the toast component implementation\
+      \ (search for `app-toast` data-testid) to understand duration, positioning, and ARIA handling\n\n\
+      Report findings in a structured design review format: what passes, what has concerns, and any recommendations.\
+      \ Be concise — this is a narrow copy-only change, not a full feature review."
+  - id: mined-design-reviewer-route-pos-2
     kind: routing
     expect_invoke: true
     prompt: "You are reviewing a specific UI change on the `feat/258-lead-outbox-cutover` branch of a\
@@ -119,37 +312,220 @@ routing:
       \ Copy, Spacing & Sizing, Color & Contrast, Accessibility, Mobile, Brand Fit)\n- Specific line-level\
       \ suggestions with the exact className or copy change\n- Screenshots or descriptions of what you\
       \ observed in the browser (or note if the browser was inaccessible)"
+  - id: mined-design-reviewer-route-pos-3
+    kind: routing
+    expect_invoke: true
+    prompt: 'You are reviewing a specific UX copy change on the Rekurve dashboard. The app is live at
+      https://rekurve.localhost.
+
+
+      ## What changed
+
+
+      In `src/app/(application)/dashboard/_components/use-queue-actions.ts`, the email approval success
+      toast was updated:
+
+
+      **Before:** `toast.add({ title: "Sent via email" })`
+
+      **After:** `toast.add({ title: "Email queued to send" })`
+
+
+      For edit-and-approve specifically:
+
+      **After:** `toast.add({ title: "Email queued to send", description: "Your edits were saved." })`
+
+
+      This copy change reflects a real behaviour change: approving an email no longer sends it immediately.
+      The email is now dispatched asynchronously by an Inngest worker. The UI shows "approved" status
+      instantly and the row disappears from the queue optimistically, but the actual send happens in the
+      background.
+
+
+      ## Full toast copy inventory to review (for consistency)
+
+
+      All current toast titles/descriptions in the app:
+
+      - Email approve success: `"Email queued to send"` (new)
+
+      - Email edit+approve success: `"Email queued to send"` + description `"Your edits were saved."`
+      (new)
+
+      - SMS/other channel approve: `"Draft approved"`
+
+      - Edit+approve (SMS): `"Draft approved"`
+
+      - Dismiss: `"Draft dismissed"`
+
+      - Snooze: `` `Snoozed until ${when}` ``
+
+      - Approve error (MS not connected): title `"Microsoft account not connected"`, description `"Connect
+      your account to send emails from Outlook."` + "Connect" action button
+
+      - Approve error (other): `"Approve failed"`
+
+      - Edit error: `"Edit failed"`
+
+      - Snooze error: `"Snooze failed"`
+
+      - SMS copy failed: title `"Copy failed"`, description `"Could not copy to clipboard. Try another
+      option."`
+
+
+      ## Toast component design
+
+
+      The toast is a `base-ui` Toast component with:
+
+      - `rounded-lg border bg-background p-4 shadow-lg`
+
+      - Title: `font-medium text-sm leading-tight`
+
+      - Description: `text-muted-foreground text-sm`
+
+      - Error variant: `data-[type=error]:border-destructive/30`
+
+      - Positioned bottom-right on desktop (w-96), full-width above bottom nav on mobile
+
+      - Dismiss X button
+
+
+      ## Review tasks
+
+
+      1. **Navigate to the app**: Go to https://rekurve.localhost and take a screenshot of the dashboard.
+
+
+      2. **Assess the copy change semantically**: Does "Email queued to send" accurately reflect what
+      happened? Is it clear to a non-technical consultant (the user is a real estate sales consultant,
+      not a developer) that their email will be sent shortly? Compare against the old "Sent via email"
+      — does the new copy create anxiety ("queued" could imply delay or uncertainty)?
+
+
+      3. **Consistency audit**: Review the full toast inventory above. Does "Email queued to send" fit
+      the pattern of the other success toasts? ("Draft approved", "Draft dismissed", "Snoozed until X")
+
+
+      4. **Check the description field**: The edit+approve path adds `description: "Your edits were saved."`
+      — is this description additive or redundant? Does it make sense alongside the title?
+
+
+      5. **Take a screenshot** of any existing toast if you can trigger one, or screenshot the dashboard
+      UI to show the context.
+
+
+      6. **Assess accessibility**: Does the copy work for screen readers? Is the toast dismissible?
+
+
+      Report your findings as a structured design review with clear PASS/FAIL/SUGGESTION verdicts per
+      criterion.'
   negatives:
   - id: mined-design-reviewer-route-neg-1
     kind: routing
     expect_invoke: false
-    actual_route: codebase-locator
-    confusability: 0.097
-    prompt: 'I''m debugging an e2e test about HubSpot outbound sync dedup behavior. I need to locate all
-      code involved in syncing a lead to HubSpot — specifically the path that creates a contact OR, when
-      a contact with the same email already exists, deduplicates/links to the existing contact.
+    actual_route: codebase-pattern-finder
+    confusability: 0.102
+    prompt: 'I''m planning integration + unit tests for new Inngest worker functions in issue #261 (email
+      dispatch worker with `step.run` and `step.waitForEvent` + a timeout path). I need existing test
+      patterns to mirror.
 
 
-      Find and report file paths (with brief descriptions) for:
-
-      1. The outbox worker/processor that syncs leads to HubSpot (mentioned as "DB-first outbox worker"
-      / "outbox cutover"). Look in src/server/outbox/ and src/inngest/.
-
-      2. The HubSpot client wrapper that does create/update/upsert of contacts (search by email, create
-      contact, update contact, handle 409 duplicate conflicts).
-
-      3. The lead intake logic (src/server/leads/intake.ts).
-
-      4. Any code that handles HubSpot duplicate-email conflicts (409 errors) and extracts the existing
-      contact ID.
-
-      5. The recently-changed files from PR #288 "drop edit arms; ingest contact.creation via scored outbox"
-      — likely a hubspot-webhook handler.
+      Find and show concrete code examples (with `file:line`) for:
 
 
-      For each relevant file, give the path and a one-line description of what it does. Do NOT analyze
-      deeply — just locate and map the files.'
+      1. **Inngest function unit/integration tests** — how existing Inngest functions are tested in this
+      repo. Look for tests that construct a function and invoke it with mocked `step` (`step.run`, `step.waitForEvent`,
+      `step.sendEvent`), or that use an Inngest test harness. Show the full setup: how `step` is mocked/stubbed,
+      how `event.data` is passed, how assertions are made on DB state afterward. The nurture/Follow-up
+      plan Inngest functions (recently migrated in #295, commit df21fdd) are the best candidates — show
+      their tests.
+
+
+      2. **`step.waitForEvent` timeout testing** — any test that exercises a timeout/virtual-time path
+      on an Inngest function. If none exists, say so explicitly and show the closest analog.
+
+
+      3. **Outbox integration tests** — tests that assert an outbox row was inserted with a given event
+      name + payload after a mutation, and/or tests that exercise the outbox sweep. Show the DB-assertion
+      idiom (these hit real Neon branches per CLAUDE.md — show how they set up and tear down).
+
+
+      4. **tRPC mutation integration tests** — how `messages.approve` / `messages.editAndApprove` or sibling
+      mutations are tested today (the caller/context setup, how they seed a `message_queue` row, how they
+      assert post-mutation DB state).
+
+
+      5. **MS Graph / HubSpot SDK mocking** — how existing tests mock or stub the Microsoft Graph client
+      and the HubSpot client, so I can assert "Graph `/me/sendMail` was called with `internetMessageId
+      === messageId`" without hitting real services.
+
+
+      6. **E2E test structure** for the dashboard approve→send flow, if any exists — the Playwright spec
+      that approves a queued message, and how it cleans up (per-spec cleanup by phone/email per CLAUDE.md).
+
+
+      For each, give the file path, line numbers, and a representative snippet. Prioritize the Rstest
+      unit/integration idiom (the repo uses Rstest, not Jest/Vitest). If a pattern genuinely doesn''t
+      exist yet, say so clearly rather than inventing one.'
   - id: mined-design-reviewer-route-neg-2
+    kind: routing
+    expect_invoke: false
+    actual_route: codebase-analyzer
+    confusability: 0.087
+    prompt: 'I''m planning a refactor to mirror the email dispatch Inngest pattern for SMS. I need a precise,
+      file:line-cited trace of how the email dispatch worker pattern works end-to-end. Please analyze
+      these files:
+
+
+      - `src/inngest/functions/messages/dispatch-email.ts`
+
+      - `src/inngest/functions/messages/reconcile-missed-engagement.ts`
+
+      - `src/inngest/functions/index.ts` (how functions are registered)
+
+      - `src/inngest/channels.ts` and `src/inngest/client.ts` (event/channel definitions)
+
+      - `src/server/outbox/index.ts` (the MESSAGE_EVENTS / HUBSPOT_EMAIL_EVENTS constants, and any helper
+      to enqueue outbox events)
+
+      - `src/server/api/routers/messages.ts` (the `approve` and `editAndApprove` mutations — how they
+      write the status flip + outbox event atomically)
+
+      - `src/server/db/schema/message-queue.ts` (the schema, including the `dispatching_at` fence column)
+
+
+      For each, report with file:line citations:
+
+
+      1. **dispatch-email worker**: How does it subscribe to the event and filter to `channel === "email"`?
+      What are its discrete `step.run` stages in order (status re-verification / "verify-still-approved",
+      the dispatching_at fence, the provider/Graph call, the conversation row write, the `messageQueue.sentAt`
+      stamp)? How does the cancellation / "verify still approved" step work? How does `step.waitForEvent`
+      work for the engagement reconciliation, and what''s the timeout, and what fires on timeout (reconcile-missed-engagement)?
+
+
+      2. **Event contract**: What is the exact shape of the `message.approval-requested` event payload
+      (all `data` fields)? What does the worker read from it? What is the event name string constant and
+      where is it defined?
+
+
+      3. **Registration**: How is `dispatchEmail` registered in the functions index? What''s the naming/id
+      convention for Inngest function ids?
+
+
+      4. **Router atomic write**: How exactly do `approve` / `editAndApprove` perform the atomic status-flip
+      + outbox enqueue (the `db.batch()` call)? What''s written to the outbox row? Is there anything email-specific
+      in the router, or is it channel-agnostic?
+
+
+      5. **Outbox helpers**: What''s the signature of whatever enqueues an outbox event, and what columns
+      does the outbox row have?
+
+
+      Be exhaustive and precise — quote the key lines. This is for mirroring the exact pattern into a
+      new `dispatch-sms` function.'
+  - id: mined-design-reviewer-route-neg-3
     kind: routing
     expect_invoke: false
     actual_route: codebase-locator
@@ -177,55 +553,3 @@ routing:
       The relevant code is under src/ (likely src/server, src/inngest, or src/lib). Report exact file
       paths and the key function names/line numbers for each. Do not analyze deeply yet — just locate
       and give me a precise map of the relevant files and functions.'
-  - id: mined-design-reviewer-route-neg-3
-    kind: routing
-    expect_invoke: false
-    actual_route: codebase-verification
-    confusability: 0.084
-    prompt: 'Run the Playwright E2E suite for this repo and report results compactly.
-
-
-      IMPORTANT context before you run:
-
-      - This branch (`feat/258-lead-outbox-cutover`) cut lead intake over to DB-first via an outbox +
-      Inngest worker. E2E now needs TWO local servers: the Next app on :3000 and an Inngest dev server
-      on :8288. The `playwright.config.ts` `webServer` is already configured as an array of both, so `make
-      test_e2e` should boot both automatically. The app server is started with env `INNGEST_DEV=1` and
-      `INNGEST_BASE_URL=http://localhost:8288`.
-
-      - The Inngest dev server is launched via `yarn preview:inngest` (`inngest dev -u http://localhost:3000/api/inngest`).
-      Confirm the `inngest` CLI is resolvable (devDependency `inngest-cli` is installed) — if the dev
-      server fails to boot, that''s a top-priority finding.
-
-
-      PREREQUISITE CHECK (do this FIRST, before running the suite):
-
-      1. Confirm `HUBSPOT_ACCESS_TOKEN` is present in the environment Playwright will inherit. Check `.env.local`
-      for a non-empty `HUBSPOT_ACCESS_TOKEN=` line. The HubSpot-touching specs (`e2e/features/hubspot-sync.spec.ts`
-      and `e2e/features/lead-intake-sync.spec.ts`) SELF-SKIP when it''s absent — a green run that actually
-      skipped them is a FALSE PASS and must be reported as such, not as success.
-
-      2. Report whether the token is present.
-
-
-      THEN run the suite: `make test_e2e` (do NOT use yarn/npx directly; use the make target).
-
-
-      REPORT BACK (compact):
-
-      - Whether HUBSPOT_ACCESS_TOKEN was present.
-
-      - Whether both webServers (app :3000 and inngest :8288) booted. If the Inngest dev server logged
-      an app-sync (look for `PUT /api/inngest` 200 / "apps synced" / function registration for `lead-hubspot-sync`),
-      say so.
-
-      - Overall pass/fail counts and how many specs SKIPPED.
-
-      - For EACH failing spec: the spec file + test name, and the extracted error block (assertion message,
-      timeout, or stack — keep it tight, ~10-20 lines per failure).
-
-      - Pay special attention to `e2e/features/lead-intake-sync.spec.ts` (new) and `e2e/features/hubspot-sync.spec.ts`
-      (modified) — these exercise the async outbox→worker→HubSpot path and are the highest-risk specs.
-
-
-      Do not attempt to fix anything. Just run and report.'

--- a/.claude/eval/tasks/mined/docs-analyzer.yaml
+++ b/.claude/eval/tasks/mined/docs-analyzer.yaml
@@ -1,0 +1,261 @@
+agent: docs-analyzer
+_generated_by: shape_tasks.py from .claude/eval/mined/corpus.jsonl
+_needs_review: true
+_note: Auto-mined §5 candidates. Curate to 5, then merge into tasks/per-agent/docs-analyzer.yaml alongside
+  golden + adversarial buckets.
+_mined_available: 2
+_mined_emitted: 2
+execution:
+- id: mined-docs-analyzer-exec-1
+  kind: execution
+  prompt: 'I''m planning a refactor (GitHub issue #262) to split message dispatch into channel-specific
+    Inngest functions. I need the decisions of record from three ADRs distilled precisely.
+
+
+    Please read and distil:
+
+    1. `docs/adr/adr001-imessage-integration-for-sales-automation.md` — the iMessage device-bridge decision.
+    I specifically need: its recorded **Status**, the chosen option (which device-bridge provider), what
+    the "device-bridge service" is and its interface (webhooks, delivery acks), whether any implementation
+    has shipped, and any checklist of unchecked/incomplete work items in the ADR. This tells me whether
+    a `dispatch-imessage` Inngest worker can be built yet.
+
+
+    2. `docs/adr/adr014-outbox-pattern-for-inngest-delivery.md` — the outbox pattern. I need: the core
+    decision, the relationship between the outbox table and Inngest events, how the outbox-sweep cron
+    delivers events, the at-least-once / idempotency guarantees, and any constraints a new dispatch worker
+    must honor.
+
+
+    3. `docs/adr/adr017-atomic-outbox-writes-via-neon-http-batch.md` — atomic outbox writes. I need: the
+    decision, the `db.batch()` mechanism, why it''s used for the status-flip + outbox-enqueue atomicity,
+    and any constraints.
+
+
+    For each ADR report: the recorded `Status:` field value, the decision in 2-3 sentences, and the specific
+    constraints/interfaces my plan must honor. Quote key lines with file:line citations. Flag explicitly
+    if ADR-001 indicates the iMessage device-bridge is NOT yet implemented.'
+  provenance:
+    agent_id: a2ca3afa5f74a78d3
+    session_id: 666946b8-d08a-4bee-928e-8bfb018e029d
+    model: claude-sonnet-4-6
+    latency_s: 47.52
+    tokens_total: 55375
+    n_tool_uses: 3
+    source_file: /Users/sam/.claude/projects/-Users-sam-workspace-rekurve-rekurve/666946b8-d08a-4bee-928e-8bfb018e029d/subagents/agent-a2ca3afa5f74a78d3.jsonl
+  sample_output_excerpt: '---
+
+
+    ## ADR-001: iMessage via Device-Bridge (`docs/adr/adr001-imessage-integration-for-sales-automation.md`)
+
+
+    **Recorded Status**: `''In Progress''` (`adr001:2`)
+
+
+    **Decision**: The ADR records a lean toward "Option 1 — Texting Blue" as the device-bridge provider
+    ($19/mo), citing it as the only option satisfying personal number + seamless manual takeover + REST
+    API at pilot cost. However, the outcome …'
+- id: mined-docs-analyzer-exec-2
+  kind: execution
+  prompt: Distil docs/adr/adr003-hubspot-source-of-truth-for-contacts.md — what was decided, and what
+    is its recorded Status?
+  provenance:
+    agent_id: ac0ccebc569d2e347
+    session_id: c485121e-d0ed-417b-a3e4-4538a2ab1a75
+    model: claude-sonnet-4-6
+    latency_s: 6.19
+    tokens_total: 38709
+    n_tool_uses: 2
+    source_file: /Users/sam/.claude/projects/-Users-sam-workspace-rekurve-rekurve/c485121e-d0ed-417b-a3e4-4538a2ab1a75/subagents/agent-ac0ccebc569d2e347.jsonl
+  sample_output_excerpt: Now let me confirm the linked superseding document exists.
+routing:
+  positives:
+  - id: mined-docs-analyzer-route-pos-1
+    kind: routing
+    expect_invoke: true
+    prompt: 'I''m planning a refactor (GitHub issue #262) to split message dispatch into channel-specific
+      Inngest functions. I need the decisions of record from three ADRs distilled precisely.
+
+
+      Please read and distil:
+
+      1. `docs/adr/adr001-imessage-integration-for-sales-automation.md` — the iMessage device-bridge decision.
+      I specifically need: its recorded **Status**, the chosen option (which device-bridge provider),
+      what the "device-bridge service" is and its interface (webhooks, delivery acks), whether any implementation
+      has shipped, and any checklist of unchecked/incomplete work items in the ADR. This tells me whether
+      a `dispatch-imessage` Inngest worker can be built yet.
+
+
+      2. `docs/adr/adr014-outbox-pattern-for-inngest-delivery.md` — the outbox pattern. I need: the core
+      decision, the relationship between the outbox table and Inngest events, how the outbox-sweep cron
+      delivers events, the at-least-once / idempotency guarantees, and any constraints a new dispatch
+      worker must honor.
+
+
+      3. `docs/adr/adr017-atomic-outbox-writes-via-neon-http-batch.md` — atomic outbox writes. I need:
+      the decision, the `db.batch()` mechanism, why it''s used for the status-flip + outbox-enqueue atomicity,
+      and any constraints.
+
+
+      For each ADR report: the recorded `Status:` field value, the decision in 2-3 sentences, and the
+      specific constraints/interfaces my plan must honor. Quote key lines with file:line citations. Flag
+      explicitly if ADR-001 indicates the iMessage device-bridge is NOT yet implemented.'
+  - id: mined-docs-analyzer-route-pos-2
+    kind: routing
+    expect_invoke: true
+    prompt: Distil docs/adr/adr003-hubspot-source-of-truth-for-contacts.md — what was decided, and what
+      is its recorded Status?
+  negatives:
+  - id: mined-docs-analyzer-route-neg-1
+    kind: routing
+    expect_invoke: false
+    actual_route: codebase-analyzer
+    confusability: 0.159
+    prompt: 'I''m planning a refactor to mirror the email dispatch Inngest pattern for SMS. I need a precise,
+      file:line-cited trace of how the email dispatch worker pattern works end-to-end. Please analyze
+      these files:
+
+
+      - `src/inngest/functions/messages/dispatch-email.ts`
+
+      - `src/inngest/functions/messages/reconcile-missed-engagement.ts`
+
+      - `src/inngest/functions/index.ts` (how functions are registered)
+
+      - `src/inngest/channels.ts` and `src/inngest/client.ts` (event/channel definitions)
+
+      - `src/server/outbox/index.ts` (the MESSAGE_EVENTS / HUBSPOT_EMAIL_EVENTS constants, and any helper
+      to enqueue outbox events)
+
+      - `src/server/api/routers/messages.ts` (the `approve` and `editAndApprove` mutations — how they
+      write the status flip + outbox event atomically)
+
+      - `src/server/db/schema/message-queue.ts` (the schema, including the `dispatching_at` fence column)
+
+
+      For each, report with file:line citations:
+
+
+      1. **dispatch-email worker**: How does it subscribe to the event and filter to `channel === "email"`?
+      What are its discrete `step.run` stages in order (status re-verification / "verify-still-approved",
+      the dispatching_at fence, the provider/Graph call, the conversation row write, the `messageQueue.sentAt`
+      stamp)? How does the cancellation / "verify still approved" step work? How does `step.waitForEvent`
+      work for the engagement reconciliation, and what''s the timeout, and what fires on timeout (reconcile-missed-engagement)?
+
+
+      2. **Event contract**: What is the exact shape of the `message.approval-requested` event payload
+      (all `data` fields)? What does the worker read from it? What is the event name string constant and
+      where is it defined?
+
+
+      3. **Registration**: How is `dispatchEmail` registered in the functions index? What''s the naming/id
+      convention for Inngest function ids?
+
+
+      4. **Router atomic write**: How exactly do `approve` / `editAndApprove` perform the atomic status-flip
+      + outbox enqueue (the `db.batch()` call)? What''s written to the outbox row? Is there anything email-specific
+      in the router, or is it channel-agnostic?
+
+
+      5. **Outbox helpers**: What''s the signature of whatever enqueues an outbox event, and what columns
+      does the outbox row have?
+
+
+      Be exhaustive and precise — quote the key lines. This is for mirroring the exact pattern into a
+      new `dispatch-sms` function.'
+  - id: mined-docs-analyzer-route-neg-2
+    kind: routing
+    expect_invoke: false
+    actual_route: codebase-pattern-finder
+    confusability: 0.108
+    prompt: 'I''m about to write tests for a new `dispatch-sms` Inngest function, mirroring the existing
+      tests for `dispatch-email`. I need concrete, copyable test patterns with file:line citations.
+
+
+      Please analyze these test files and show me the patterns:
+
+      - `src/inngest/functions/messages/__tests__/dispatch-email.test.ts`
+
+      - `src/inngest/functions/messages/__tests__/dispatch-email.integration.test.ts`
+
+      - `src/inngest/functions/messages/__tests__/reconcile-missed-engagement.test.ts`
+
+
+      Also look for any shared Inngest test helpers/utilities (search `src/inngest` and `src/test` or
+      similar for things like `InngestTestEngine`, mock step, virtual time helpers, mocked provider clients).
+
+
+      Report with file:line citations and actual code snippets:
+
+
+      1. **Test harness**: How is an Inngest function invoked in a unit test? Is it `@inngest/test` `InngestTestEngine`,
+      or a hand-rolled mock of the `step` object? Show the exact setup. How are `step.run`, `step.waitForEvent`,
+      and `step.sleep` mocked or driven?
+
+
+      2. **Virtual time**: How is time/timeout handled in tests (the `waitForEvent` timeout, any `step.sleep`)?
+      Show the pattern.
+
+
+      3. **Mocking provider clients**: How is the Graph/email client mocked? How would I analogously mock
+      a Twilio client? Show the mock setup (rstest `rs.mock` / `vi.mock` style — note this project uses
+      Rstest).
+
+
+      4. **DB assertions**: Do these tests hit a real DB (integration) or mock it (unit)? What''s the
+      difference between the `.test.ts` and `.integration.test.ts` files? Show how each sets up/asserts
+      DB state.
+
+
+      5. **Status re-verification & cancellation tests**: How do they test the "verify still approved"
+      cancellation path (message dismissed mid-dispatch)?
+
+
+      Quote real snippets I can adapt. This project uses Rstest (not Vitest/Jest) — note any Rstest-specific
+      API usage.'
+  - id: mined-docs-analyzer-route-neg-3
+    kind: routing
+    expect_invoke: false
+    actual_route: web-research
+    confusability: 0.105
+    prompt: "I need a thorough, well-cited research synthesis on running the **Neon serverless Postgres\
+      \ driver (`@neondatabase/serverless`) with Drizzle ORM on AWS Lambda / Vercel serverless functions**\
+      \ — specifically the tradeoff between the HTTP driver and the WebSocket Pool driver, and connection-pooling\
+      \ pitfalls. This is for a critical architecture decision (an ADR) about whether to introduce interactive\
+      \ transactions.\n\nContext: Next.js app on Vercel (which runs on AWS Lambda). Currently using `drizzle-orm/neon-http`\
+      \ (the `neon()` HTTP driver) — stateless, no pooling. We need to commit two table writes (a row\
+      \ + an \"outbox\" event row) **atomically**. We're deciding between: (a) staying on the HTTP driver\
+      \ and using an atomic multi-statement batch/array-transaction, vs (b) switching to `drizzle-orm/neon-serverless`\
+      \ (the WebSocket `Pool`) to get interactive `db.transaction(async tx => {...})`.\n\nResearch and\
+      \ report, with citations + dates, on:\n\n1. **HTTP driver (`neon()` over HTTPS) transaction capabilities**:\
+      \ The `@neondatabase/serverless` HTTP client exposes a `sql.transaction([q1, q2, ...])` array form.\
+      \ Confirm: does it execute all statements in a SINGLE atomic Postgres transaction (BEGIN…COMMIT)\
+      \ in ONE HTTP round-trip? What are its documented LIMITATIONS — specifically, can it do INTERACTIVE\
+      \ transactions (read a result, then decide the next query within the same transaction)? Quote Neon's\
+      \ docs on \"interactive transactions are not supported over HTTP.\"\n\n2. **WebSocket Pool driver\
+      \ on AWS Lambda — the pooling problem**: This is the crux. Research the known issues with using\
+      \ `Pool` from `@neondatabase/serverless` (or node-postgres `Pool` generally) in AWS Lambda / serverless:\n\
+      \   - Why does a module-scope `Pool` behave badly across Lambda freeze/thaw cycles? (frozen event\
+      \ loop, dead sockets on thaw, idle-timeout disconnects)\n   - The \"connection multiplication\"\
+      \ problem: each concurrent Lambda execution environment has its own pool → max_connections × concurrency\
+      \ can exhaust Postgres connection limits.\n   - What does Neon OFFICIALLY recommend for the WebSocket\
+      \ driver in serverless? (e.g., create a `Pool`/`Client` per-request and `await pool.end()` in a\
+      \ finally block? use `ctx.waitUntil`? avoid Pool entirely?) Quote their docs/guidance.\n   - Does\
+      \ Neon's connection pooler (PgBouncer, the `-pooler` host) change this calculus?\n\n3. **Vercel-specific\
+      \ guidance**: What does Vercel and/or Neon recommend for Postgres connections in Vercel Functions\
+      \ specifically? Is the HTTP driver the recommended default for serverless, with WebSocket reserved\
+      \ for sessions/interactive transactions? Cite the Neon \"Vercel\" and \"serverless driver\" docs.\n\
+      \n4. **Drizzle `db.batch()` over neon-http**: Does `drizzle-orm/neon-http` support a `db.batch([...])`\
+      \ API, and does it map to Neon's atomic array-transaction (single transaction, single round-trip)?\
+      \ Cite the Drizzle \"Batch API\" docs and note which drivers support it (LibSQL, Neon, D1…). Does\
+      \ `.returning()` work inside a batch?\n\n5. **Interactive transactions over neon-serverless**: Confirm\
+      \ `drizzle-orm/neon-serverless` (`Pool`) supports full interactive `db.transaction(async (tx) =>\
+      \ {...})`, and that `drizzle-orm/neon-http` does NOT (it throws / is limited). \n\n6. **Recommendation\
+      \ framing**: Summarize the decision factors a team should weigh: serverless-friendliness (no connection\
+      \ lifecycle) vs the need for interactive (read-then-write) transactions. When is the HTTP+batch\
+      \ approach sufficient, and when is the WebSocket Pool genuinely required?\n\nPrefer official sources:\
+      \ Neon docs (neon.tech/docs, especially \"serverless driver\", \"Neon on Vercel\", \"connection\
+      \ pooling\"), the `@neondatabase/serverless` GitHub README, Drizzle ORM docs (orm.drizzle.team —\
+      \ \"batch\", \"neon\" sections), and Vercel docs. Quote exact passages and cite URLs + dates. Note\
+      \ any version-specific behavior. Be thorough and adversarial — if sources conflict on whether Pool\
+      \ is safe on Lambda, surface the conflict."

--- a/.claude/eval/tasks/mined/docs-locator.yaml
+++ b/.claude/eval/tasks/mined/docs-locator.yaml
@@ -1,0 +1,130 @@
+agent: docs-locator
+_generated_by: shape_tasks.py from .claude/eval/mined/corpus.jsonl
+_needs_review: true
+_note: Auto-mined §5 candidates. Curate to 5, then merge into tasks/per-agent/docs-locator.yaml alongside
+  golden + adversarial buckets.
+_mined_available: 2
+_mined_emitted: 2
+execution:
+- id: mined-docs-locator-exec-1
+  kind: execution
+  prompt: 'Find any ADRs or feature docs in the docs/ tree that govern or relate to: observability, monitoring,
+    logging, alerting, error tracking, metrics, uptime monitoring, PostHog, analytics, or incident response.
+
+
+    Return grouped paths. For each ADR, include its number and recorded Status (Proposed/Accepted/Superseded).
+    Give a one-line description of each. Don''t deep-analyze — just locate and categorize.'
+  provenance:
+    agent_id: aeb3dc842c2b348ce
+    session_id: 2eabff0a-a1b3-49c8-bfe4-a0e1cc8b85c9
+    model: claude-sonnet-4-6
+    latency_s: 58.96
+    tokens_total: 355788
+    n_tool_uses: 23
+    source_file: /Users/sam/.claude/projects/-Users-sam-workspace-rekurve-rekurve/2eabff0a-a1b3-49c8-bfe4-a0e1cc8b85c9/subagents/agent-aeb3dc842c2b348ce.jsonl
+  sample_output_excerpt: 'The feature README is an index, not a topic doc. Now I have everything needed.
+
+
+    ---
+
+
+    ## Docs on observability, monitoring, logging, alerting, error tracking, metrics, uptime monitoring,
+    PostHog, analytics, and incident response
+
+
+    ### Feature docs
+
+
+    - `/Users/sam/workspace/rekurve/rekurve/docs/feature/posthog-analytics.md` — PostHog analytics (the
+    primary doc governing analytics instrumentation and e …'
+- id: mined-docs-locator-exec-2
+  kind: execution
+  prompt: Find the ADR about GraphQL.
+  provenance:
+    agent_id: ab441899e61ad6ab2
+    session_id: c485121e-d0ed-417b-a3e4-4538a2ab1a75
+    model: claude-sonnet-4-6
+    latency_s: 11.49
+    tokens_total: 35750
+    n_tool_uses: 3
+    source_file: /Users/sam/.claude/projects/-Users-sam-workspace-rekurve-rekurve/c485121e-d0ed-417b-a3e4-4538a2ab1a75/subagents/agent-ab441899e61ad6ab2.jsonl
+  sample_output_excerpt: 'No matches found in docs/ for: GraphQL.
+
+
+    The `grep` found no files mentioning GraphQL anywhere in `docs/`, and a full listing of all 17 ADRs
+    shows none with a GraphQL-related filename. The ADR catalogue covers topics such as iMessage, auth
+    gates, HubSpot, webhooks, lead scoring, Outlook, nurture scheduling, Inngest, tRPC, Upstash, and the
+    outbox pattern — but not GraphQL.
+
+
+    Total: 0 documents.'
+routing:
+  positives:
+  - id: mined-docs-locator-route-pos-1
+    kind: routing
+    expect_invoke: true
+    prompt: 'Find any ADRs or feature docs in the docs/ tree that govern or relate to: observability,
+      monitoring, logging, alerting, error tracking, metrics, uptime monitoring, PostHog, analytics, or
+      incident response.
+
+
+      Return grouped paths. For each ADR, include its number and recorded Status (Proposed/Accepted/Superseded).
+      Give a one-line description of each. Don''t deep-analyze — just locate and categorize.'
+  - id: mined-docs-locator-route-pos-2
+    kind: routing
+    expect_invoke: true
+    prompt: Find the ADR about GraphQL.
+  negatives:
+  - id: mined-docs-locator-route-neg-1
+    kind: routing
+    expect_invoke: false
+    actual_route: thoughts-locator
+    confusability: 0.268
+    prompt: 'Find all documents in the thoughts/ directory related to monitoring, observability, logging,
+      alerting, metrics, error tracking, uptime monitoring, BetterStack, PostHog, PagerDuty, or incident
+      management.
+
+
+      The team had prior designs and/or plans to implement BetterStack for monitoring and observability
+      (metrics, logs, alerts). I''m looking for those specifically, plus any related research notes, PR
+      write-ups, or decisions.
+
+
+      Return grouped paths with dates and a one-line description of each. Prioritize anything that mentions
+      BetterStack, observability, logging, alerting, or uptime monitoring. Do not analyze contents deeply
+      — just locate and categorize.'
+  - id: mined-docs-locator-route-neg-2
+    kind: routing
+    expect_invoke: false
+    actual_route: codebase-locator
+    confusability: 0.124
+    prompt: 'I need to understand the current observability/monitoring setup in this Next.js codebase.
+      Locate (paths only, grouped by purpose):
+
+
+      1. Where PostHog is configured and initialized (client and server side) — config files, provider
+      components, env vars referencing POSTHOG.
+
+      2. Any OpenTelemetry / OTLP / instrumentation setup — especially `instrumentation.ts`, `instrumentation-client.ts`,
+      or `register()` hooks in the Next.js app.
+
+      3. Any existing logging utilities, logger modules, or structured logging.
+
+      4. Any Inngest scheduled functions / cron jobs (look in src/inngest) — I''m interested in whether
+      there''s an existing pattern for scheduled "heartbeat"-style events. The CLAUDE.md mentions an "outbox-sweep"
+      cron and an outbox pattern.
+
+      5. Any existing error tracking or monitoring instrumentation (Sentry, etc.).
+
+      6. The Next.js version and whether the app uses the app router (check package.json and folder structure).
+
+
+      Return file paths grouped by the categories above, with a one-line note on each. Paths only — don''t
+      explain mechanics in depth.'
+  - id: mined-docs-locator-route-neg-3
+    kind: routing
+    expect_invoke: false
+    actual_route: docs-analyzer
+    confusability: 0.104
+    prompt: Distil docs/adr/adr003-hubspot-source-of-truth-for-contacts.md — what was decided, and what
+      is its recorded Status?

--- a/.claude/eval/tasks/mined/thoughts-locator.yaml
+++ b/.claude/eval/tasks/mined/thoughts-locator.yaml
@@ -3,10 +3,34 @@ _generated_by: shape_tasks.py from .claude/eval/mined/corpus.jsonl
 _needs_review: true
 _note: Auto-mined §5 candidates. Curate to 5, then merge into tasks/per-agent/thoughts-locator.yaml alongside
   golden + adversarial buckets.
-_mined_available: 1
-_mined_emitted: 1
+_mined_available: 2
+_mined_emitted: 2
 execution:
 - id: mined-thoughts-locator-exec-1
+  kind: execution
+  prompt: 'Find all documents in the thoughts/ directory related to monitoring, observability, logging,
+    alerting, metrics, error tracking, uptime monitoring, BetterStack, PostHog, PagerDuty, or incident
+    management.
+
+
+    The team had prior designs and/or plans to implement BetterStack for monitoring and observability
+    (metrics, logs, alerts). I''m looking for those specifically, plus any related research notes, PR
+    write-ups, or decisions.
+
+
+    Return grouped paths with dates and a one-line description of each. Prioritize anything that mentions
+    BetterStack, observability, logging, alerting, or uptime monitoring. Do not analyze contents deeply
+    — just locate and categorize.'
+  provenance:
+    agent_id: a164389296ea06475
+    session_id: 2eabff0a-a1b3-49c8-bfe4-a0e1cc8b85c9
+    model: claude-sonnet-4-6
+    latency_s: 44.47
+    tokens_total: 257076
+    n_tool_uses: 14
+    source_file: /Users/sam/.claude/projects/-Users-sam-workspace-rekurve-rekurve/2eabff0a-a1b3-49c8-bfe4-a0e1cc8b85c9/subagents/agent-a164389296ea06475.jsonl
+  sample_output_excerpt: Good. Now let me get targeted title lines for the most directly relevant files.
+- id: mined-thoughts-locator-exec-2
   kind: execution
   prompt: Locate the sub-agent evaluation pipeline design document and any related research notes or iteration
     transcripts in the thoughts/ directory. Return the file paths grouped by type (design / research /
@@ -42,6 +66,22 @@ routing:
   - id: mined-thoughts-locator-route-pos-1
     kind: routing
     expect_invoke: true
+    prompt: 'Find all documents in the thoughts/ directory related to monitoring, observability, logging,
+      alerting, metrics, error tracking, uptime monitoring, BetterStack, PostHog, PagerDuty, or incident
+      management.
+
+
+      The team had prior designs and/or plans to implement BetterStack for monitoring and observability
+      (metrics, logs, alerts). I''m looking for those specifically, plus any related research notes, PR
+      write-ups, or decisions.
+
+
+      Return grouped paths with dates and a one-line description of each. Prioritize anything that mentions
+      BetterStack, observability, logging, alerting, or uptime monitoring. Do not analyze contents deeply
+      — just locate and categorize.'
+  - id: mined-thoughts-locator-route-pos-2
+    kind: routing
+    expect_invoke: true
     prompt: Locate the sub-agent evaluation pipeline design document and any related research notes or
       iteration transcripts in the thoughts/ directory. Return the file paths grouped by type (design
       / research / transcript).
@@ -49,114 +89,65 @@ routing:
   - id: mined-thoughts-locator-route-neg-1
     kind: routing
     expect_invoke: false
-    actual_route: codebase-locator
-    confusability: 0.097
-    prompt: Locate the Drizzle migration SQL file(s) related to the "outbox" table or the outbox-sweep
-      mechanism in this repo, and the directory they live in. Return only verified file paths (no content
-      descriptions).
+    actual_route: docs-locator
+    confusability: 0.268
+    prompt: 'Find any ADRs or feature docs in the docs/ tree that govern or relate to: observability,
+      monitoring, logging, alerting, error tracking, metrics, uptime monitoring, PostHog, analytics, or
+      incident response.
+
+
+      Return grouped paths. For each ADR, include its number and recorded Status (Proposed/Accepted/Superseded).
+      Give a one-line description of each. Don''t deep-analyze — just locate and categorize.'
   - id: mined-thoughts-locator-route-neg-2
     kind: routing
     expect_invoke: false
     actual_route: codebase-locator
-    confusability: 0.051
-    prompt: 'Locate where **lead scoring** lives in this codebase. Return file locations only — do not
-      explain behavior — grouped by purpose:
+    confusability: 0.111
+    prompt: 'I need to understand the current observability/monitoring setup in this Next.js codebase.
+      Locate (paths only, grouped by purpose):
 
 
-      1. The scoring module''s source files
+      1. Where PostHog is configured and initialized (client and server side) — config files, provider
+      components, env vars referencing POSTHOG.
 
-      2. Every place lead scoring is invoked / called from
+      2. Any OpenTelemetry / OTLP / instrumentation setup — especially `instrumentation.ts`, `instrumentation-client.ts`,
+      or `register()` hooks in the Next.js app.
 
-      3. The scoring tests
+      3. Any existing logging utilities, logger modules, or structured logging.
+
+      4. Any Inngest scheduled functions / cron jobs (look in src/inngest) — I''m interested in whether
+      there''s an existing pattern for scheduled "heartbeat"-style events. The CLAUDE.md mentions an "outbox-sweep"
+      cron and an outbox pattern.
+
+      5. Any existing error tracking or monitoring instrumentation (Sentry, etc.).
+
+      6. The Next.js version and whether the app uses the app router (check package.json and folder structure).
 
 
-      Give full paths from the repo root.'
+      Return file paths grouped by the categories above, with a one-line note on each. Paths only — don''t
+      explain mechanics in depth.'
   - id: mined-thoughts-locator-route-neg-3
     kind: routing
     expect_invoke: false
-    actual_route: web-research
-    confusability: 0.028
-    prompt: 'I need a thorough, current (as of 2026) research report on integrating OpenTelemetry (OTEL)
-      with Claude Code (Anthropic''s CLI coding agent) for LOCAL observability. The goal is to surface
-      real-world sub-agent activity — specifically sub-agent prompts, sub-agent results/outputs, and metrics
-      like latency, token usage, and cost — to build a baseline dataset for evaluating and improving sub-agent
-      prompts.
+    actual_route: web-lookup
+    confusability: 0.102
+    prompt: 'I''m on the **Vercel Pro plan** with a Next.js app. I need precise, current facts on two
+      things:
 
 
-      Please research and answer these specific questions, citing authoritative sources (prefer official
-      Anthropic/Claude Code docs at docs.claude.com or docs.anthropic.com, the Claude Code GitHub repo,
-      and OpenTelemetry official docs):
+      1. **Vercel Observability** (https://vercel.com/products/observability and related docs): What does
+      it include on the **Pro plan**? Specifically: logs (runtime logs, log retention period on Pro),
+      metrics/monitoring dashboards, "Observability Plus" add-on (what it adds and cost), OpenTelemetry
+      support (can Vercel export traces/logs via OTEL collector to third parties?). Is there a log drain
+      feature on Pro for shipping logs to an external service?
 
 
-      ## 1. Claude Code''s built-in OTEL / telemetry support
-
-      - Does Claude Code have native OpenTelemetry support? What environment variables enable it (e.g.
-      CLAUDE_CODE_ENABLE_TELEMETRY)?
-
-      - What is the FULL list of metrics Claude Code exports via OTEL? (e.g. token usage, cost, session
-      count, lines of code, API request duration/latency, etc.) Give exact metric names if documented.
-
-      - What logs/events does Claude Code export? Is there an events/logs exporter separate from metrics?
-
-      - CRITICAL: Does Claude Code''s OTEL telemetry capture the actual CONTENT of prompts and AI responses/outputs?
-      Is there a setting like OTEL_LOG_USER_PROMPTS or similar that controls whether prompt text is included?
-      What about the assistant''s output text?
-
-      - CRITICAL FOR OUR USE CASE: Does Claude Code''s telemetry distinguish or specifically capture SUB-AGENT
-      (Task tool / subagent) activity? When a main agent spawns a sub-agent, are the sub-agent''s prompt,
-      output, token usage, and latency captured as distinct telemetry events/spans/attributes? Is there
-      any agent-type or agent-id attribute on the events? Be precise about what is and isn''t captured
-      at the sub-agent granularity — this is the single most important question.
-
-      - Does Claude Code emit OTEL traces/spans (not just metrics and logs)? If so, what spans, and do
-      tool calls / sub-agent invocations appear as spans?
+      2. **Uptime / availability monitoring**: Does Vercel offer any built-in **uptime monitoring** or
+      synthetic/health-check monitoring that pings an endpoint and alerts on downtime? (I suspect not
+      natively.) If not, what''s the closest thing? Also: confirm Vercel **Cron Jobs** availability and
+      limits on the Pro plan (number of cron jobs, minimum frequency) — I''m considering using a scheduled
+      cron / heartbeat as a DIY uptime check.
 
 
-      ## 2. Local OTEL collector + storage + visualization stack
-
-      - What is the recommended way to run a local OpenTelemetry Collector (otelcol / otelcol-contrib)
-      to receive Claude Code''s telemetry?
-
-      - What configuration (OTEL_EXPORTER_OTLP_ENDPOINT, OTEL_EXPORTER_OTLP_PROTOCOL grpc vs http/protobuf,
-      OTEL_METRICS_EXPORTER, OTEL_LOGS_EXPORTER) does Claude Code need to point at a local collector?
-
-      - What are the recommended local storage backends for each signal type: metrics (Prometheus?), logs/events
-      (Loki? ClickHouse?), traces (Jaeger? Tempo?)?
-
-      - What is the recommended local visualization layer (Grafana?)? Are there prebuilt Claude Code dashboards
-      published by Anthropic or the community?
-
-      - Is there a known docker-compose / one-command setup (official or community, e.g. a "claude-code-otel"
-      project on GitHub) that stands up collector + storage + Grafana locally? Name specific repos if
-      they exist.
-
-
-      ## 3. Capturing prompt/output CONTENT for evaluation (not just metrics)
-
-      - Since the core goal is capturing actual sub-agent prompt text and output text to build an eval
-      dataset, clarify: does the OTEL events/logs path actually carry the full text, or is it truncated/redacted?
-      Are there length limits?
-
-      - If Claude Code''s OTEL does NOT capture full sub-agent prompt+output content, what are the ALTERNATIVE
-      local interception approaches? Specifically research: (a) the Claude Code OTEL logs exporter content,
-      (b) hooks (PreToolUse/PostToolUse/SubagentStop hooks) and what data they receive, (c) reading the
-      local session transcript / .jsonl files Claude Code writes, (d) an LLM-proxy / man-in-the-middle
-      approach (e.g. LiteLLM proxy, or a custom Anthropic API proxy) to capture full request/response
-      bodies. Compare these on completeness of captured content.
-
-      - Specifically: is there a SubagentStop hook, and does it provide access to the sub-agent''s full
-      transcript/output?
-
-
-      ## 4. Practical recommendation
-
-      - Summarize the simplest local setup that would capture sub-agent prompts, outputs, latency, and
-      cost.
-
-      - Flag any gaps where OTEL alone is insufficient and a complementary approach (hooks, transcript
-      parsing, proxy) is needed.
-
-
-      Please be concrete and cite versions/dates where possible. Distinguish clearly between what is officially
-      documented vs community/experimental. Note that as of 2026 Claude Code is actively developed, so
-      prefer the most recent sources.'
+      Report concisely with facts and cite Vercel''s docs/pricing pages with dates. Flag clearly anything
+      that is an extra paid add-on vs included in Pro.'

--- a/.claude/eval/tasks/mined/web-lookup.yaml
+++ b/.claude/eval/tasks/mined/web-lookup.yaml
@@ -3,7 +3,7 @@ _generated_by: shape_tasks.py from .claude/eval/mined/corpus.jsonl
 _needs_review: true
 _note: Auto-mined §5 candidates. Curate to 5, then merge into tasks/per-agent/web-lookup.yaml alongside
   golden + adversarial buckets.
-_mined_available: 5
+_mined_available: 10
 _mined_emitted: 5
 execution:
 - id: mined-web-lookup-exec-1
@@ -73,86 +73,69 @@ execution:
     No. The property table on the official `message` resource page marks `i …'
 - id: mined-web-lookup-exec-2
   kind: execution
-  prompt: 'I''m implementing PostHog Error Tracking + Insight alerts in a Next.js 15 app deployed on Vercel.
-    I need authoritative, up-to-date info on:
+  prompt: 'Fetch the raw content of this file and return it VERBATIM in full, then give a short structural
+    summary:
 
 
-    1. **Server-only PostHog config** — design doc says `POSTHOG_KEY` and `POSTHOG_HOST` must be server-only
-    (never exposed to client). But the standard PostHog Next.js setup uses `NEXT_PUBLIC_POSTHOG_KEY` for
-    the client SDK because the project key is *publicly safe to expose* (it''s not a write-API secret).
-    Can `posthog-js` (browser SDK) be initialized without exposing the key to the client? What''s the
-    current PostHog recommendation for Next.js 15 App Router as of late 2025/2026? Resolve the tension.
+    URL: https://raw.githubusercontent.com/mattpocock/skills/main/skills/engineering/triage/SKILL.md
 
 
-    2. **PostHog Vercel Integration for source maps** — how is this set up? Is it a one-click marketplace
-    install, or does it require any code/config changes (e.g., `next.config.ts` setting)? What env vars
-    does it inject? Does it conflict with us managing `POSTHOG_KEY` manually?
+    (If that raw URL 404s, try fetching https://github.com/mattpocock/skills/blob/main/skills/engineering/triage/SKILL.md
+    instead, and also try listing the directory https://github.com/mattpocock/skills/tree/main/skills/engineering/triage
+    to find any companion files like REFERENCE.md or scripts.)
 
 
-    3. **Error tracking + alerts** — confirm PostHog Error Tracking is GA and supports webhook destinations
-    for alerts. What''s the alert configuration UI/API like — can it be done purely in the PostHog dashboard,
-    or via config-as-code?
+    Also check whether there is a SEPARATE backlog-grooming or refinement skill in the same repo by fetching
+    the directory listing at https://github.com/mattpocock/skills/tree/main/skills/engineering and report
+    what skills exist there.
 
 
-    4. **`posthog-js` vs `posthog-node` setup for Next.js App Router** — what''s the canonical 2026 setup
-    with `instrumentation.ts`, root layout, server components, and route handlers? Include code snippets.
+    Return:
 
+    1. The full verbatim SKILL.md content (in a code block)
 
-    Quote the PostHog docs directly where possible, cite URLs, note version dates. Use context7 if useful.
-    Aim for ~500 words, include code snippets.'
+    2. The YAML frontmatter (name + description) called out separately
+
+    3. A bullet summary of its workflow/steps
+
+    4. Any companion files it references
+
+    5. A list of the other engineering skills in the repo (names only)'
   provenance:
-    agent_id: af617987102fec3e6
-    session_id: cc019451-cb00-4cc1-baa8-05fa8e2ea9fe
+    agent_id: a6be8df7229aab613
+    session_id: cb0123e9-fc16-4a30-b496-7aee490b7806
     model: claude-sonnet-4-6
-    latency_s: 57.62
-    tokens_total: 66371
+    latency_s: 76.69
+    tokens_total: 95238
     n_tool_uses: 7
-    source_file: /Users/sam/.claude/projects/-Users-sam-workspace-rekurve-rekurve/cc019451-cb00-4cc1-baa8-05fa8e2ea9fe/subagents/agent-af617987102fec3e6.jsonl
-  sample_output_excerpt: 'Here are authoritative findings on all four questions, drawn directly from the
-    PostHog docs.
+    source_file: /Users/sam/.claude/projects/-Users-sam-workspace-rekurve-rekurve/cb0123e9-fc16-4a30-b496-7aee490b7806/subagents/agent-a6be8df7229aab613.jsonl
+  sample_output_excerpt: 'I now have everything needed. Here is the full response.
 
 
     ---
 
 
-    ## 1. Server-only key tension — resolved
+    ## 1. Full Verbatim SKILL.md Content
 
 
-    PostHog''s **own canonical docs resolve this directly**: the project token (`NEXT_PUBLIC_POSTHOG_TOKEN`
-    or `NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN`) is intentionally public-safe. PostHog uses `NEXT_PUBLIC_`
-    on the key in every example, including `posthog-node` serv …'
+    ```markdown
+
+    ---
+
+    name: triage
+
+    description: Triage issues through a state machine driven by triage roles. Use when user wants to
+    create an issue, triage issues, review incoming bugs or feature requests, prepare issues for an AFK
+    agent, or manage issue workflow.
+
+    ---
+
+
+    # Triage
+
+
+    Move issues on the proje …'
 - id: mined-web-lookup-exec-3
-  kind: execution
-  prompt: "Fetch the current BetterAuth docs for two features and report their exact API + capabilities.\
-    \ Use Context7 (library id likely `/better-auth/better-auth` or similar — resolve first) and the official\
-    \ docs at https://better-auth.com/docs/reference/options.\n\n1. `rateLimit` config option — https://better-auth.com/docs/reference/options#ratelimit\n\
-    \   - All sub-fields (enabled, window, max, storage, customRules, modelName, etc.)\n   - The full\
-    \ shape and semantics of `customRules` — can you set per-endpoint window/max? Per-endpoint key derivation?\
-    \ Can you disable the limit for some endpoints?\n   - Default behaviour when `enabled: true` and no\
-    \ `customRules` (what's rate-limited, by what key, with what limits)\n   - How the limit key is derived\
-    \ by default (IP from `x-forwarded-for`? Cookie? Session?)\n   - What status code / error shape the\
-    \ client sees on a 429\n   - Whether there's a way to plug in custom logic *before* or *after* the\
-    \ limit check (hooks)\n\n2. `secondaryStorage` config option — https://better-auth.com/docs/reference/options#secondarystorage\n\
-    \   - Exact `get`/`set`/`delete` signatures (including ttl arg type/units)\n   - What BetterAuth uses\
-    \ secondaryStorage *for* — just rate-limit? Or also sessions? Be explicit\n   - Whether using `secondaryStorage`\
-    \ for sessions has any implication if we only want it for rate-limit (e.g. is there a way to scope\
-    \ it to rate-limit only?)\n   - Recommended Redis client patterns (ioredis vs Upstash REST vs @vercel/kv)\n\
-    \n3. Report the latest stable BetterAuth version that supports these features and whether the API\
-    \ has changed in recent minors.\n\nReport in under 600 words, with verbatim type signatures where\
-    \ possible and links to the source docs sections. Include code snippets for `customRules` and `secondaryStorage`."
-  provenance:
-    agent_id: a9609b5c801dc7d9e
-    session_id: 50865961-fb4a-4b8b-bb7b-c479a0a93c0a
-    model: claude-sonnet-4-6
-    latency_s: 46.27
-    tokens_total: 57991
-    n_tool_uses: 6
-    source_file: /Users/sam/.claude/projects/-Users-sam-workspace-rekurve-rekurve/50865961-fb4a-4b8b-bb7b-c479a0a93c0a/subagents/agent-a9609b5c801dc7d9e.jsonl
-  sample_output_excerpt: "## Summary\n\n### 1. `rateLimit` Config\n\n**Fields** ([options reference](https://better-auth.com/docs/reference/options)):\n\
-    \n```typescript\nrateLimit: {\n  enabled?: boolean;       // default: true in production, false in\
-    \ development\n  window?: number;         // seconds; default: 10\n  max?: number;            // requests\
-    \ per window; default: 100\n  storage?: \"memory\" | \"database\" | \"secondary-storage\"; …"
-- id: mined-web-lookup-exec-4
   kind: execution
   prompt: 'I need to know precisely how transactions work in Drizzle ORM with the `neon-http` driver (not
     `neon-serverless`).
@@ -200,52 +183,67 @@ execution:
     `neon-http` is designed for "single, non-interactive transactions" only ([orm.drizzle.team/docs/connect-neon](https://orm.drizzle.team/docs/connect-neon)),
     and calling `db.transaction()` throws at runtime: **"No transactions support in neon-http driver"**
     ([better-auth/better-auth#4747](ht …'
+- id: mined-web-lookup-exec-4
+  kind: execution
+  prompt: 'I''m on the **Vercel Pro plan** with a Next.js app. I need precise, current facts on two things:
+
+
+    1. **Vercel Observability** (https://vercel.com/products/observability and related docs): What does
+    it include on the **Pro plan**? Specifically: logs (runtime logs, log retention period on Pro), metrics/monitoring
+    dashboards, "Observability Plus" add-on (what it adds and cost), OpenTelemetry support (can Vercel
+    export traces/logs via OTEL collector to third parties?). Is there a log drain feature on Pro for
+    shipping logs to an external service?
+
+
+    2. **Uptime / availability monitoring**: Does Vercel offer any built-in **uptime monitoring** or synthetic/health-check
+    monitoring that pings an endpoint and alerts on downtime? (I suspect not natively.) If not, what''s
+    the closest thing? Also: confirm Vercel **Cron Jobs** availability and limits on the Pro plan (number
+    of cron jobs, minimum frequency) — I''m considering using a scheduled cron / heartbeat as a DIY uptime
+    check.
+
+
+    Report concisely with facts and cite Vercel''s docs/pricing pages with dates. Flag clearly anything
+    that is an extra paid add-on vs included in Pro.'
+  provenance:
+    agent_id: abc790abb6ca07459
+    session_id: 2eabff0a-a1b3-49c8-bfe4-a0e1cc8b85c9
+    model: claude-sonnet-4-6
+    latency_s: 19.11
+    tokens_total: 44182
+    n_tool_uses: 5
+    source_file: /Users/sam/.claude/projects/-Users-sam-workspace-rekurve-rekurve/2eabff0a-a1b3-49c8-bfe4-a0e1cc8b85c9/subagents/agent-abc790abb6ca07459.jsonl
+  sample_output_excerpt: ''
 - id: mined-web-lookup-exec-5
   kind: execution
-  prompt: "Look up BetterAuth's current docs (v1.6.9+) for two specific config flags that interact with\
-    \ `secondaryStorage`. Use Context7 (`/better-auth/better-auth` — resolve first) and https://better-auth.com/docs/concepts/database.\n\
-    \n1. **`session.storeSessionInDatabase`** — exact location, type, default value, and semantics when\
-    \ `secondaryStorage` is configured. What happens to session reads? Does it write to BOTH the DB and\
-    \ secondaryStorage, or DB only with secondaryStorage acting as a read-cache?\n\n2. **Verification\
-    \ records storage with `secondaryStorage`** — when `secondaryStorage` is enabled, do verification\
-    \ records (OTP codes, magic links, email verification tokens) get written to Redis instead of the\
-    \ DB? Is there an equivalent `storeVerificationInDatabase` flag, OR a `verification` config block\
-    \ that controls this, OR is verification ALWAYS written to the DB regardless of secondaryStorage?\n\
-    \   - Specifically check: `verification.disableCleanup`, `verification.modelName`, and any `storeIn...`\
-    \ flag near verification config\n   - Check the BetterAuth 1.5 release notes (https://better-auth.com/blog/1-5)\
-    \ which mentioned \"Verification tokens can now be stored in secondary storage… instead of — or in\
-    \ addition to — the database\" — what's the exact flag/config that controls this?\n\n3. **`rateLimit`\
-    \ writes when `secondaryStorage` is set** — does setting `rateLimit.storage: \"secondary-storage\"\
-    ` ONLY write rate-limit data to Redis, or does it also force sessions+verification through Redis regardless\
-    \ of other flags?\n\n4. Quote the exact TypeScript signatures from the source / docs where possible,\
-    \ and link the sections.\n\nThe reason I'm asking: a user wants to enable `secondaryStorage` purely\
-    \ for rate-limit data, but is worried sessions and verification will silently get routed through Redis\
-    \ too. I need to know precisely which flags they have to set to keep sessions + verification in the\
-    \ Postgres database. Report under 500 words."
+  prompt: "Fetch the current BetterAuth docs for two features and report their exact API + capabilities.\
+    \ Use Context7 (library id likely `/better-auth/better-auth` or similar — resolve first) and the official\
+    \ docs at https://better-auth.com/docs/reference/options.\n\n1. `rateLimit` config option — https://better-auth.com/docs/reference/options#ratelimit\n\
+    \   - All sub-fields (enabled, window, max, storage, customRules, modelName, etc.)\n   - The full\
+    \ shape and semantics of `customRules` — can you set per-endpoint window/max? Per-endpoint key derivation?\
+    \ Can you disable the limit for some endpoints?\n   - Default behaviour when `enabled: true` and no\
+    \ `customRules` (what's rate-limited, by what key, with what limits)\n   - How the limit key is derived\
+    \ by default (IP from `x-forwarded-for`? Cookie? Session?)\n   - What status code / error shape the\
+    \ client sees on a 429\n   - Whether there's a way to plug in custom logic *before* or *after* the\
+    \ limit check (hooks)\n\n2. `secondaryStorage` config option — https://better-auth.com/docs/reference/options#secondarystorage\n\
+    \   - Exact `get`/`set`/`delete` signatures (including ttl arg type/units)\n   - What BetterAuth uses\
+    \ secondaryStorage *for* — just rate-limit? Or also sessions? Be explicit\n   - Whether using `secondaryStorage`\
+    \ for sessions has any implication if we only want it for rate-limit (e.g. is there a way to scope\
+    \ it to rate-limit only?)\n   - Recommended Redis client patterns (ioredis vs Upstash REST vs @vercel/kv)\n\
+    \n3. Report the latest stable BetterAuth version that supports these features and whether the API\
+    \ has changed in recent minors.\n\nReport in under 600 words, with verbatim type signatures where\
+    \ possible and links to the source docs sections. Include code snippets for `customRules` and `secondaryStorage`."
   provenance:
-    agent_id: acbd10f4a1625c490
+    agent_id: a9609b5c801dc7d9e
     session_id: 50865961-fb4a-4b8b-bb7b-c479a0a93c0a
     model: claude-sonnet-4-6
-    latency_s: 30.52
-    tokens_total: 57995
-    n_tool_uses: 5
-    source_file: /Users/sam/.claude/projects/-Users-sam-workspace-rekurve-rekurve/50865961-fb4a-4b8b-bb7b-c479a0a93c0a/subagents/agent-acbd10f4a1625c490.jsonl
-  sample_output_excerpt: 'I now have sufficient authoritative answers from Context7. Here are the precise
-    answers:
-
-
-    ---
-
-
-    ## Summary
-
-
-    **1. `session.storeSessionInDatabase`**
-
-
-    Default when `secondaryStorage` is set: sessions are stored in secondaryStorage ONLY (not the DB).
-    To keep sessions in Postgres, set `storeSessionInDatabase: true` explicitly. The docs do not describe
-    a "write to both" dual-write — it is an either/or r …'
+    latency_s: 46.27
+    tokens_total: 57991
+    n_tool_uses: 6
+    source_file: /Users/sam/.claude/projects/-Users-sam-workspace-rekurve-rekurve/50865961-fb4a-4b8b-bb7b-c479a0a93c0a/subagents/agent-a9609b5c801dc7d9e.jsonl
+  sample_output_excerpt: "## Summary\n\n### 1. `rateLimit` Config\n\n**Fields** ([options reference](https://better-auth.com/docs/reference/options)):\n\
+    \n```typescript\nrateLimit: {\n  enabled?: boolean;       // default: true in production, false in\
+    \ development\n  window?: number;         // seconds; default: 10\n  max?: number;            // requests\
+    \ per window; default: 100\n  storage?: \"memory\" | \"database\" | \"secondary-storage\"; …"
 routing:
   positives:
   - id: mined-web-lookup-route-pos-1
@@ -292,57 +290,35 @@ routing:
   - id: mined-web-lookup-route-pos-2
     kind: routing
     expect_invoke: true
-    prompt: 'I''m implementing PostHog Error Tracking + Insight alerts in a Next.js 15 app deployed on
-      Vercel. I need authoritative, up-to-date info on:
+    prompt: 'Fetch the raw content of this file and return it VERBATIM in full, then give a short structural
+      summary:
 
 
-      1. **Server-only PostHog config** — design doc says `POSTHOG_KEY` and `POSTHOG_HOST` must be server-only
-      (never exposed to client). But the standard PostHog Next.js setup uses `NEXT_PUBLIC_POSTHOG_KEY`
-      for the client SDK because the project key is *publicly safe to expose* (it''s not a write-API secret).
-      Can `posthog-js` (browser SDK) be initialized without exposing the key to the client? What''s the
-      current PostHog recommendation for Next.js 15 App Router as of late 2025/2026? Resolve the tension.
+      URL: https://raw.githubusercontent.com/mattpocock/skills/main/skills/engineering/triage/SKILL.md
 
 
-      2. **PostHog Vercel Integration for source maps** — how is this set up? Is it a one-click marketplace
-      install, or does it require any code/config changes (e.g., `next.config.ts` setting)? What env vars
-      does it inject? Does it conflict with us managing `POSTHOG_KEY` manually?
+      (If that raw URL 404s, try fetching https://github.com/mattpocock/skills/blob/main/skills/engineering/triage/SKILL.md
+      instead, and also try listing the directory https://github.com/mattpocock/skills/tree/main/skills/engineering/triage
+      to find any companion files like REFERENCE.md or scripts.)
 
 
-      3. **Error tracking + alerts** — confirm PostHog Error Tracking is GA and supports webhook destinations
-      for alerts. What''s the alert configuration UI/API like — can it be done purely in the PostHog dashboard,
-      or via config-as-code?
+      Also check whether there is a SEPARATE backlog-grooming or refinement skill in the same repo by
+      fetching the directory listing at https://github.com/mattpocock/skills/tree/main/skills/engineering
+      and report what skills exist there.
 
 
-      4. **`posthog-js` vs `posthog-node` setup for Next.js App Router** — what''s the canonical 2026
-      setup with `instrumentation.ts`, root layout, server components, and route handlers? Include code
-      snippets.
+      Return:
 
+      1. The full verbatim SKILL.md content (in a code block)
 
-      Quote the PostHog docs directly where possible, cite URLs, note version dates. Use context7 if useful.
-      Aim for ~500 words, include code snippets.'
+      2. The YAML frontmatter (name + description) called out separately
+
+      3. A bullet summary of its workflow/steps
+
+      4. Any companion files it references
+
+      5. A list of the other engineering skills in the repo (names only)'
   - id: mined-web-lookup-route-pos-3
-    kind: routing
-    expect_invoke: true
-    prompt: "Fetch the current BetterAuth docs for two features and report their exact API + capabilities.\
-      \ Use Context7 (library id likely `/better-auth/better-auth` or similar — resolve first) and the\
-      \ official docs at https://better-auth.com/docs/reference/options.\n\n1. `rateLimit` config option\
-      \ — https://better-auth.com/docs/reference/options#ratelimit\n   - All sub-fields (enabled, window,\
-      \ max, storage, customRules, modelName, etc.)\n   - The full shape and semantics of `customRules`\
-      \ — can you set per-endpoint window/max? Per-endpoint key derivation? Can you disable the limit\
-      \ for some endpoints?\n   - Default behaviour when `enabled: true` and no `customRules` (what's\
-      \ rate-limited, by what key, with what limits)\n   - How the limit key is derived by default (IP\
-      \ from `x-forwarded-for`? Cookie? Session?)\n   - What status code / error shape the client sees\
-      \ on a 429\n   - Whether there's a way to plug in custom logic *before* or *after* the limit check\
-      \ (hooks)\n\n2. `secondaryStorage` config option — https://better-auth.com/docs/reference/options#secondarystorage\n\
-      \   - Exact `get`/`set`/`delete` signatures (including ttl arg type/units)\n   - What BetterAuth\
-      \ uses secondaryStorage *for* — just rate-limit? Or also sessions? Be explicit\n   - Whether using\
-      \ `secondaryStorage` for sessions has any implication if we only want it for rate-limit (e.g. is\
-      \ there a way to scope it to rate-limit only?)\n   - Recommended Redis client patterns (ioredis\
-      \ vs Upstash REST vs @vercel/kv)\n\n3. Report the latest stable BetterAuth version that supports\
-      \ these features and whether the API has changed in recent minors.\n\nReport in under 600 words,\
-      \ with verbatim type signatures where possible and links to the source docs sections. Include code\
-      \ snippets for `customRules` and `secondaryStorage`."
-  - id: mined-web-lookup-route-pos-4
     kind: routing
     expect_invoke: true
     prompt: 'I need to know precisely how transactions work in Drizzle ORM with the `neon-http` driver
@@ -376,29 +352,51 @@ routing:
 
 
       Under 400 words.'
+  - id: mined-web-lookup-route-pos-4
+    kind: routing
+    expect_invoke: true
+    prompt: 'I''m on the **Vercel Pro plan** with a Next.js app. I need precise, current facts on two
+      things:
+
+
+      1. **Vercel Observability** (https://vercel.com/products/observability and related docs): What does
+      it include on the **Pro plan**? Specifically: logs (runtime logs, log retention period on Pro),
+      metrics/monitoring dashboards, "Observability Plus" add-on (what it adds and cost), OpenTelemetry
+      support (can Vercel export traces/logs via OTEL collector to third parties?). Is there a log drain
+      feature on Pro for shipping logs to an external service?
+
+
+      2. **Uptime / availability monitoring**: Does Vercel offer any built-in **uptime monitoring** or
+      synthetic/health-check monitoring that pings an endpoint and alerts on downtime? (I suspect not
+      natively.) If not, what''s the closest thing? Also: confirm Vercel **Cron Jobs** availability and
+      limits on the Pro plan (number of cron jobs, minimum frequency) — I''m considering using a scheduled
+      cron / heartbeat as a DIY uptime check.
+
+
+      Report concisely with facts and cite Vercel''s docs/pricing pages with dates. Flag clearly anything
+      that is an extra paid add-on vs included in Pro.'
   - id: mined-web-lookup-route-pos-5
     kind: routing
     expect_invoke: true
-    prompt: "Look up BetterAuth's current docs (v1.6.9+) for two specific config flags that interact with\
-      \ `secondaryStorage`. Use Context7 (`/better-auth/better-auth` — resolve first) and https://better-auth.com/docs/concepts/database.\n\
-      \n1. **`session.storeSessionInDatabase`** — exact location, type, default value, and semantics when\
-      \ `secondaryStorage` is configured. What happens to session reads? Does it write to BOTH the DB\
-      \ and secondaryStorage, or DB only with secondaryStorage acting as a read-cache?\n\n2. **Verification\
-      \ records storage with `secondaryStorage`** — when `secondaryStorage` is enabled, do verification\
-      \ records (OTP codes, magic links, email verification tokens) get written to Redis instead of the\
-      \ DB? Is there an equivalent `storeVerificationInDatabase` flag, OR a `verification` config block\
-      \ that controls this, OR is verification ALWAYS written to the DB regardless of secondaryStorage?\n\
-      \   - Specifically check: `verification.disableCleanup`, `verification.modelName`, and any `storeIn...`\
-      \ flag near verification config\n   - Check the BetterAuth 1.5 release notes (https://better-auth.com/blog/1-5)\
-      \ which mentioned \"Verification tokens can now be stored in secondary storage… instead of — or\
-      \ in addition to — the database\" — what's the exact flag/config that controls this?\n\n3. **`rateLimit`\
-      \ writes when `secondaryStorage` is set** — does setting `rateLimit.storage: \"secondary-storage\"\
-      ` ONLY write rate-limit data to Redis, or does it also force sessions+verification through Redis\
-      \ regardless of other flags?\n\n4. Quote the exact TypeScript signatures from the source / docs\
-      \ where possible, and link the sections.\n\nThe reason I'm asking: a user wants to enable `secondaryStorage`\
-      \ purely for rate-limit data, but is worried sessions and verification will silently get routed\
-      \ through Redis too. I need to know precisely which flags they have to set to keep sessions + verification\
-      \ in the Postgres database. Report under 500 words."
+    prompt: "Fetch the current BetterAuth docs for two features and report their exact API + capabilities.\
+      \ Use Context7 (library id likely `/better-auth/better-auth` or similar — resolve first) and the\
+      \ official docs at https://better-auth.com/docs/reference/options.\n\n1. `rateLimit` config option\
+      \ — https://better-auth.com/docs/reference/options#ratelimit\n   - All sub-fields (enabled, window,\
+      \ max, storage, customRules, modelName, etc.)\n   - The full shape and semantics of `customRules`\
+      \ — can you set per-endpoint window/max? Per-endpoint key derivation? Can you disable the limit\
+      \ for some endpoints?\n   - Default behaviour when `enabled: true` and no `customRules` (what's\
+      \ rate-limited, by what key, with what limits)\n   - How the limit key is derived by default (IP\
+      \ from `x-forwarded-for`? Cookie? Session?)\n   - What status code / error shape the client sees\
+      \ on a 429\n   - Whether there's a way to plug in custom logic *before* or *after* the limit check\
+      \ (hooks)\n\n2. `secondaryStorage` config option — https://better-auth.com/docs/reference/options#secondarystorage\n\
+      \   - Exact `get`/`set`/`delete` signatures (including ttl arg type/units)\n   - What BetterAuth\
+      \ uses secondaryStorage *for* — just rate-limit? Or also sessions? Be explicit\n   - Whether using\
+      \ `secondaryStorage` for sessions has any implication if we only want it for rate-limit (e.g. is\
+      \ there a way to scope it to rate-limit only?)\n   - Recommended Redis client patterns (ioredis\
+      \ vs Upstash REST vs @vercel/kv)\n\n3. Report the latest stable BetterAuth version that supports\
+      \ these features and whether the API has changed in recent minors.\n\nReport in under 600 words,\
+      \ with verbatim type signatures where possible and links to the source docs sections. Include code\
+      \ snippets for `customRules` and `secondaryStorage`."
   negatives:
   - id: mined-web-lookup-route-neg-1
     kind: routing
@@ -449,7 +447,53 @@ routing:
     kind: routing
     expect_invoke: false
     actual_route: web-research
-    confusability: 0.164
+    confusability: 0.137
+    prompt: "I need a thorough, well-cited research synthesis on running the **Neon serverless Postgres\
+      \ driver (`@neondatabase/serverless`) with Drizzle ORM on AWS Lambda / Vercel serverless functions**\
+      \ — specifically the tradeoff between the HTTP driver and the WebSocket Pool driver, and connection-pooling\
+      \ pitfalls. This is for a critical architecture decision (an ADR) about whether to introduce interactive\
+      \ transactions.\n\nContext: Next.js app on Vercel (which runs on AWS Lambda). Currently using `drizzle-orm/neon-http`\
+      \ (the `neon()` HTTP driver) — stateless, no pooling. We need to commit two table writes (a row\
+      \ + an \"outbox\" event row) **atomically**. We're deciding between: (a) staying on the HTTP driver\
+      \ and using an atomic multi-statement batch/array-transaction, vs (b) switching to `drizzle-orm/neon-serverless`\
+      \ (the WebSocket `Pool`) to get interactive `db.transaction(async tx => {...})`.\n\nResearch and\
+      \ report, with citations + dates, on:\n\n1. **HTTP driver (`neon()` over HTTPS) transaction capabilities**:\
+      \ The `@neondatabase/serverless` HTTP client exposes a `sql.transaction([q1, q2, ...])` array form.\
+      \ Confirm: does it execute all statements in a SINGLE atomic Postgres transaction (BEGIN…COMMIT)\
+      \ in ONE HTTP round-trip? What are its documented LIMITATIONS — specifically, can it do INTERACTIVE\
+      \ transactions (read a result, then decide the next query within the same transaction)? Quote Neon's\
+      \ docs on \"interactive transactions are not supported over HTTP.\"\n\n2. **WebSocket Pool driver\
+      \ on AWS Lambda — the pooling problem**: This is the crux. Research the known issues with using\
+      \ `Pool` from `@neondatabase/serverless` (or node-postgres `Pool` generally) in AWS Lambda / serverless:\n\
+      \   - Why does a module-scope `Pool` behave badly across Lambda freeze/thaw cycles? (frozen event\
+      \ loop, dead sockets on thaw, idle-timeout disconnects)\n   - The \"connection multiplication\"\
+      \ problem: each concurrent Lambda execution environment has its own pool → max_connections × concurrency\
+      \ can exhaust Postgres connection limits.\n   - What does Neon OFFICIALLY recommend for the WebSocket\
+      \ driver in serverless? (e.g., create a `Pool`/`Client` per-request and `await pool.end()` in a\
+      \ finally block? use `ctx.waitUntil`? avoid Pool entirely?) Quote their docs/guidance.\n   - Does\
+      \ Neon's connection pooler (PgBouncer, the `-pooler` host) change this calculus?\n\n3. **Vercel-specific\
+      \ guidance**: What does Vercel and/or Neon recommend for Postgres connections in Vercel Functions\
+      \ specifically? Is the HTTP driver the recommended default for serverless, with WebSocket reserved\
+      \ for sessions/interactive transactions? Cite the Neon \"Vercel\" and \"serverless driver\" docs.\n\
+      \n4. **Drizzle `db.batch()` over neon-http**: Does `drizzle-orm/neon-http` support a `db.batch([...])`\
+      \ API, and does it map to Neon's atomic array-transaction (single transaction, single round-trip)?\
+      \ Cite the Drizzle \"Batch API\" docs and note which drivers support it (LibSQL, Neon, D1…). Does\
+      \ `.returning()` work inside a batch?\n\n5. **Interactive transactions over neon-serverless**: Confirm\
+      \ `drizzle-orm/neon-serverless` (`Pool`) supports full interactive `db.transaction(async (tx) =>\
+      \ {...})`, and that `drizzle-orm/neon-http` does NOT (it throws / is limited). \n\n6. **Recommendation\
+      \ framing**: Summarize the decision factors a team should weigh: serverless-friendliness (no connection\
+      \ lifecycle) vs the need for interactive (read-then-write) transactions. When is the HTTP+batch\
+      \ approach sufficient, and when is the WebSocket Pool genuinely required?\n\nPrefer official sources:\
+      \ Neon docs (neon.tech/docs, especially \"serverless driver\", \"Neon on Vercel\", \"connection\
+      \ pooling\"), the `@neondatabase/serverless` GitHub README, Drizzle ORM docs (orm.drizzle.team —\
+      \ \"batch\", \"neon\" sections), and Vercel docs. Quote exact passages and cite URLs + dates. Note\
+      \ any version-specific behavior. Be thorough and adversarial — if sources conflict on whether Pool\
+      \ is safe on Lambda, surface the conflict."
+  - id: mined-web-lookup-route-neg-3
+    kind: routing
+    expect_invoke: false
+    actual_route: web-research
+    confusability: 0.118
     prompt: 'I''m implementing browser realtime updates in a Next.js 15 (App Router) + React 19 app that
       already uses Inngest v4.2.6 (package "inngest@4.2.6"). I need authoritative, current details on
       **Inngest Realtime** (the `@inngest/realtime` package) — the feature that lets a browser subscribe
@@ -496,49 +540,3 @@ routing:
       Prefer official Inngest documentation and the @inngest/realtime GitHub README. Quote exact code
       snippets and cite the doc URLs and version numbers. If the API changed across versions, note which
       version introduced the current shape.'
-  - id: mined-web-lookup-route-neg-3
-    kind: routing
-    expect_invoke: false
-    actual_route: web-research
-    confusability: 0.137
-    prompt: "I need a thorough, well-cited research synthesis on running the **Neon serverless Postgres\
-      \ driver (`@neondatabase/serverless`) with Drizzle ORM on AWS Lambda / Vercel serverless functions**\
-      \ — specifically the tradeoff between the HTTP driver and the WebSocket Pool driver, and connection-pooling\
-      \ pitfalls. This is for a critical architecture decision (an ADR) about whether to introduce interactive\
-      \ transactions.\n\nContext: Next.js app on Vercel (which runs on AWS Lambda). Currently using `drizzle-orm/neon-http`\
-      \ (the `neon()` HTTP driver) — stateless, no pooling. We need to commit two table writes (a row\
-      \ + an \"outbox\" event row) **atomically**. We're deciding between: (a) staying on the HTTP driver\
-      \ and using an atomic multi-statement batch/array-transaction, vs (b) switching to `drizzle-orm/neon-serverless`\
-      \ (the WebSocket `Pool`) to get interactive `db.transaction(async tx => {...})`.\n\nResearch and\
-      \ report, with citations + dates, on:\n\n1. **HTTP driver (`neon()` over HTTPS) transaction capabilities**:\
-      \ The `@neondatabase/serverless` HTTP client exposes a `sql.transaction([q1, q2, ...])` array form.\
-      \ Confirm: does it execute all statements in a SINGLE atomic Postgres transaction (BEGIN…COMMIT)\
-      \ in ONE HTTP round-trip? What are its documented LIMITATIONS — specifically, can it do INTERACTIVE\
-      \ transactions (read a result, then decide the next query within the same transaction)? Quote Neon's\
-      \ docs on \"interactive transactions are not supported over HTTP.\"\n\n2. **WebSocket Pool driver\
-      \ on AWS Lambda — the pooling problem**: This is the crux. Research the known issues with using\
-      \ `Pool` from `@neondatabase/serverless` (or node-postgres `Pool` generally) in AWS Lambda / serverless:\n\
-      \   - Why does a module-scope `Pool` behave badly across Lambda freeze/thaw cycles? (frozen event\
-      \ loop, dead sockets on thaw, idle-timeout disconnects)\n   - The \"connection multiplication\"\
-      \ problem: each concurrent Lambda execution environment has its own pool → max_connections × concurrency\
-      \ can exhaust Postgres connection limits.\n   - What does Neon OFFICIALLY recommend for the WebSocket\
-      \ driver in serverless? (e.g., create a `Pool`/`Client` per-request and `await pool.end()` in a\
-      \ finally block? use `ctx.waitUntil`? avoid Pool entirely?) Quote their docs/guidance.\n   - Does\
-      \ Neon's connection pooler (PgBouncer, the `-pooler` host) change this calculus?\n\n3. **Vercel-specific\
-      \ guidance**: What does Vercel and/or Neon recommend for Postgres connections in Vercel Functions\
-      \ specifically? Is the HTTP driver the recommended default for serverless, with WebSocket reserved\
-      \ for sessions/interactive transactions? Cite the Neon \"Vercel\" and \"serverless driver\" docs.\n\
-      \n4. **Drizzle `db.batch()` over neon-http**: Does `drizzle-orm/neon-http` support a `db.batch([...])`\
-      \ API, and does it map to Neon's atomic array-transaction (single transaction, single round-trip)?\
-      \ Cite the Drizzle \"Batch API\" docs and note which drivers support it (LibSQL, Neon, D1…). Does\
-      \ `.returning()` work inside a batch?\n\n5. **Interactive transactions over neon-serverless**: Confirm\
-      \ `drizzle-orm/neon-serverless` (`Pool`) supports full interactive `db.transaction(async (tx) =>\
-      \ {...})`, and that `drizzle-orm/neon-http` does NOT (it throws / is limited). \n\n6. **Recommendation\
-      \ framing**: Summarize the decision factors a team should weigh: serverless-friendliness (no connection\
-      \ lifecycle) vs the need for interactive (read-then-write) transactions. When is the HTTP+batch\
-      \ approach sufficient, and when is the WebSocket Pool genuinely required?\n\nPrefer official sources:\
-      \ Neon docs (neon.tech/docs, especially \"serverless driver\", \"Neon on Vercel\", \"connection\
-      \ pooling\"), the `@neondatabase/serverless` GitHub README, Drizzle ORM docs (orm.drizzle.team —\
-      \ \"batch\", \"neon\" sections), and Vercel docs. Quote exact passages and cite URLs + dates. Note\
-      \ any version-specific behavior. Be thorough and adversarial — if sources conflict on whether Pool\
-      \ is safe on Lambda, surface the conflict."

--- a/.claude/eval/tasks/mined/web-research.yaml
+++ b/.claude/eval/tasks/mined/web-research.yaml
@@ -3,8 +3,8 @@ _generated_by: shape_tasks.py from .claude/eval/mined/corpus.jsonl
 _needs_review: true
 _note: Auto-mined §5 candidates. Curate to 5, then merge into tasks/per-agent/web-research.yaml alongside
   golden + adversarial buckets.
-_mined_available: 4
-_mined_emitted: 4
+_mined_available: 7
+_mined_emitted: 5
 execution:
 - id: mined-web-research-exec-1
   kind: execution
@@ -68,59 +68,42 @@ execution:
     accordingly. …
 - id: mined-web-research-exec-2
   kind: execution
-  prompt: "I need a thorough, well-cited research synthesis on running the **Neon serverless Postgres\
-    \ driver (`@neondatabase/serverless`) with Drizzle ORM on AWS Lambda / Vercel serverless functions**\
-    \ — specifically the tradeoff between the HTTP driver and the WebSocket Pool driver, and connection-pooling\
-    \ pitfalls. This is for a critical architecture decision (an ADR) about whether to introduce interactive\
-    \ transactions.\n\nContext: Next.js app on Vercel (which runs on AWS Lambda). Currently using `drizzle-orm/neon-http`\
-    \ (the `neon()` HTTP driver) — stateless, no pooling. We need to commit two table writes (a row +\
-    \ an \"outbox\" event row) **atomically**. We're deciding between: (a) staying on the HTTP driver\
-    \ and using an atomic multi-statement batch/array-transaction, vs (b) switching to `drizzle-orm/neon-serverless`\
-    \ (the WebSocket `Pool`) to get interactive `db.transaction(async tx => {...})`.\n\nResearch and report,\
-    \ with citations + dates, on:\n\n1. **HTTP driver (`neon()` over HTTPS) transaction capabilities**:\
-    \ The `@neondatabase/serverless` HTTP client exposes a `sql.transaction([q1, q2, ...])` array form.\
-    \ Confirm: does it execute all statements in a SINGLE atomic Postgres transaction (BEGIN…COMMIT) in\
-    \ ONE HTTP round-trip? What are its documented LIMITATIONS — specifically, can it do INTERACTIVE transactions\
-    \ (read a result, then decide the next query within the same transaction)? Quote Neon's docs on \"\
-    interactive transactions are not supported over HTTP.\"\n\n2. **WebSocket Pool driver on AWS Lambda\
-    \ — the pooling problem**: This is the crux. Research the known issues with using `Pool` from `@neondatabase/serverless`\
-    \ (or node-postgres `Pool` generally) in AWS Lambda / serverless:\n   - Why does a module-scope `Pool`\
-    \ behave badly across Lambda freeze/thaw cycles? (frozen event loop, dead sockets on thaw, idle-timeout\
-    \ disconnects)\n   - The \"connection multiplication\" problem: each concurrent Lambda execution environment\
-    \ has its own pool → max_connections × concurrency can exhaust Postgres connection limits.\n   - What\
-    \ does Neon OFFICIALLY recommend for the WebSocket driver in serverless? (e.g., create a `Pool`/`Client`\
-    \ per-request and `await pool.end()` in a finally block? use `ctx.waitUntil`? avoid Pool entirely?)\
-    \ Quote their docs/guidance.\n   - Does Neon's connection pooler (PgBouncer, the `-pooler` host) change\
-    \ this calculus?\n\n3. **Vercel-specific guidance**: What does Vercel and/or Neon recommend for Postgres\
-    \ connections in Vercel Functions specifically? Is the HTTP driver the recommended default for serverless,\
-    \ with WebSocket reserved for sessions/interactive transactions? Cite the Neon \"Vercel\" and \"serverless\
-    \ driver\" docs.\n\n4. **Drizzle `db.batch()` over neon-http**: Does `drizzle-orm/neon-http` support\
-    \ a `db.batch([...])` API, and does it map to Neon's atomic array-transaction (single transaction,\
-    \ single round-trip)? Cite the Drizzle \"Batch API\" docs and note which drivers support it (LibSQL,\
-    \ Neon, D1…). Does `.returning()` work inside a batch?\n\n5. **Interactive transactions over neon-serverless**:\
-    \ Confirm `drizzle-orm/neon-serverless` (`Pool`) supports full interactive `db.transaction(async (tx)\
-    \ => {...})`, and that `drizzle-orm/neon-http` does NOT (it throws / is limited). \n\n6. **Recommendation\
-    \ framing**: Summarize the decision factors a team should weigh: serverless-friendliness (no connection\
-    \ lifecycle) vs the need for interactive (read-then-write) transactions. When is the HTTP+batch approach\
-    \ sufficient, and when is the WebSocket Pool genuinely required?\n\nPrefer official sources: Neon\
-    \ docs (neon.tech/docs, especially \"serverless driver\", \"Neon on Vercel\", \"connection pooling\"\
-    ), the `@neondatabase/serverless` GitHub README, Drizzle ORM docs (orm.drizzle.team — \"batch\", \"\
-    neon\" sections), and Vercel docs. Quote exact passages and cite URLs + dates. Note any version-specific\
-    \ behavior. Be thorough and adversarial — if sources conflict on whether Pool is safe on Lambda, surface\
-    \ the conflict."
+  prompt: "I'm designing a Claude Code \"skill\" (a reusable instruction file) for a solo developer's\
+    \ GitHub-issue workflow. I need authoritative research on the distinction between two practices: **issue/bug\
+    \ triage** vs **backlog grooming (a.k.a. backlog refinement)**.\n\nPlease research the web across\
+    \ at least 3-5 credible sources (Atlassian, agile/scrum guides, GitHub's own docs, engineering blogs,\
+    \ Marty Cagan/SVPG, Mountain Goat Software, etc.) and synthesize answers to these specific questions:\n\
+    \n1. **Definitions & boundaries**: What is \"triage\" vs \"backlog grooming/refinement\"? Where does\
+    \ each begin and end? What activities belong to each?\n\n2. **Triage specifics**: Is triage fundamentally\
+    \ about *incoming* items (new bug reports, externally-created issues, support tickets) — i.e., deciding\
+    \ accept/reject/route/severity? Or does \"triage\" also apply to periodically re-examining items you\
+    \ created yourself?\n\n3. **Backlog grooming specifics**: What are the canonical activities of backlog\
+    \ refinement? (e.g., removing stale/obsolete items, re-prioritizing, adding detail/estimates, breaking\
+    \ down large items, ensuring items are \"ready\" for planning). \n\n4. **Staleness / obsolescence**:\
+    \ What do best-practice sources say about detecting and closing stale issues — issues superseded by\
+    \ completed work, no longer relevant, or duplicates? Any heuristics (age thresholds, \"definition\
+    \ of ready\", etc.)?\n\n5. **Decision outcomes**: When refining a single backlog item, what are the\
+    \ canonical possible outcomes/dispositions? (e.g., close-as-obsolete, close-as-duplicate, re-prioritize,\
+    \ add-detail, split, accept-into-sprint/roadmap, keep-but-defer, needs-more-info).\n\n6. **Solo developer\
+    \ context**: Does the triage-vs-grooming distinction collapse for a solo developer who creates ALL\
+    \ their own issues (no external/inbound issues to accept or reject)? Is there published guidance on\
+    \ lightweight/solo backlog management?\n\n7. **Cadence & batching**: Best practices on how often to\
+    \ groom, and whether to process items one-at-a-time vs in batch sessions.\n\n8. **\"Definition of\
+    \ Ready\"**: Explain this concept and what criteria make a backlog item \"ready\" to be pulled into\
+    \ planned work.\n\nReturn a structured synthesis with clear headers per question, cite which source\
+    \ supports each claim, and flag any disagreements between sources. Be concrete and practical, not\
+    \ vague. End with a short \"bottom line\" on whether triage and grooming are genuinely separate activities\
+    \ or a continuum."
   provenance:
-    agent_id: a46828e7d8aae69bf
-    session_id: be00031d-a0ac-46eb-9486-4150781a5a8b
+    agent_id: adb5b1fb13335f9b8
+    session_id: cb0123e9-fc16-4a30-b496-7aee490b7806
     model: claude-opus-4-8
-    latency_s: 269.32
-    tokens_total: 983751
-    n_tool_uses: 46
-    source_file: /Users/sam/.claude/projects/-Users-sam-workspace-rekurve-rekurve/be00031d-a0ac-46eb-9486-4150781a5a8b/subagents/agent-a46828e7d8aae69bf.jsonl
-  sample_output_excerpt: I have comprehensive material from all official sources. The one remaining gap
-    is a verbatim quote of Drizzle's exact `neon-http` transaction error string. I've used 5 WebSearch
-    + 8 WebFetch (at budget on both). I have a corroborating Drizzle docs quote ("Querying over HTTP is
-    faster for single, non-interactive transactions") plus the repo's own confirmation that neon-http
-    transactions are non-int …
+    latency_s: 30.77
+    tokens_total: 125057
+    n_tool_uses: 8
+    source_file: /Users/sam/.claude/projects/-Users-sam-workspace-rekurve-rekurve/cb0123e9-fc16-4a30-b496-7aee490b7806/subagents/agent-adb5b1fb13335f9b8.jsonl
+  sample_output_excerpt: 'Good initial coverage. Now let me fetch the key Atlassian sources and search
+    for the remaining specific topics: stale issue handling, solo developer guidance, and cadence/batching.'
 - id: mined-web-research-exec-3
   kind: execution
   prompt: 'I need a thorough, current (as of 2026) research report on integrating OpenTelemetry (OTEL)
@@ -280,6 +263,61 @@ execution:
 
     **No — a single BetterAuth `rateLimit` config cannot fully replace a heterogeneous custom limiter
     that''s used outsi …'
+- id: mined-web-research-exec-5
+  kind: execution
+  prompt: "I need a thorough, well-cited research synthesis on running the **Neon serverless Postgres\
+    \ driver (`@neondatabase/serverless`) with Drizzle ORM on AWS Lambda / Vercel serverless functions**\
+    \ — specifically the tradeoff between the HTTP driver and the WebSocket Pool driver, and connection-pooling\
+    \ pitfalls. This is for a critical architecture decision (an ADR) about whether to introduce interactive\
+    \ transactions.\n\nContext: Next.js app on Vercel (which runs on AWS Lambda). Currently using `drizzle-orm/neon-http`\
+    \ (the `neon()` HTTP driver) — stateless, no pooling. We need to commit two table writes (a row +\
+    \ an \"outbox\" event row) **atomically**. We're deciding between: (a) staying on the HTTP driver\
+    \ and using an atomic multi-statement batch/array-transaction, vs (b) switching to `drizzle-orm/neon-serverless`\
+    \ (the WebSocket `Pool`) to get interactive `db.transaction(async tx => {...})`.\n\nResearch and report,\
+    \ with citations + dates, on:\n\n1. **HTTP driver (`neon()` over HTTPS) transaction capabilities**:\
+    \ The `@neondatabase/serverless` HTTP client exposes a `sql.transaction([q1, q2, ...])` array form.\
+    \ Confirm: does it execute all statements in a SINGLE atomic Postgres transaction (BEGIN…COMMIT) in\
+    \ ONE HTTP round-trip? What are its documented LIMITATIONS — specifically, can it do INTERACTIVE transactions\
+    \ (read a result, then decide the next query within the same transaction)? Quote Neon's docs on \"\
+    interactive transactions are not supported over HTTP.\"\n\n2. **WebSocket Pool driver on AWS Lambda\
+    \ — the pooling problem**: This is the crux. Research the known issues with using `Pool` from `@neondatabase/serverless`\
+    \ (or node-postgres `Pool` generally) in AWS Lambda / serverless:\n   - Why does a module-scope `Pool`\
+    \ behave badly across Lambda freeze/thaw cycles? (frozen event loop, dead sockets on thaw, idle-timeout\
+    \ disconnects)\n   - The \"connection multiplication\" problem: each concurrent Lambda execution environment\
+    \ has its own pool → max_connections × concurrency can exhaust Postgres connection limits.\n   - What\
+    \ does Neon OFFICIALLY recommend for the WebSocket driver in serverless? (e.g., create a `Pool`/`Client`\
+    \ per-request and `await pool.end()` in a finally block? use `ctx.waitUntil`? avoid Pool entirely?)\
+    \ Quote their docs/guidance.\n   - Does Neon's connection pooler (PgBouncer, the `-pooler` host) change\
+    \ this calculus?\n\n3. **Vercel-specific guidance**: What does Vercel and/or Neon recommend for Postgres\
+    \ connections in Vercel Functions specifically? Is the HTTP driver the recommended default for serverless,\
+    \ with WebSocket reserved for sessions/interactive transactions? Cite the Neon \"Vercel\" and \"serverless\
+    \ driver\" docs.\n\n4. **Drizzle `db.batch()` over neon-http**: Does `drizzle-orm/neon-http` support\
+    \ a `db.batch([...])` API, and does it map to Neon's atomic array-transaction (single transaction,\
+    \ single round-trip)? Cite the Drizzle \"Batch API\" docs and note which drivers support it (LibSQL,\
+    \ Neon, D1…). Does `.returning()` work inside a batch?\n\n5. **Interactive transactions over neon-serverless**:\
+    \ Confirm `drizzle-orm/neon-serverless` (`Pool`) supports full interactive `db.transaction(async (tx)\
+    \ => {...})`, and that `drizzle-orm/neon-http` does NOT (it throws / is limited). \n\n6. **Recommendation\
+    \ framing**: Summarize the decision factors a team should weigh: serverless-friendliness (no connection\
+    \ lifecycle) vs the need for interactive (read-then-write) transactions. When is the HTTP+batch approach\
+    \ sufficient, and when is the WebSocket Pool genuinely required?\n\nPrefer official sources: Neon\
+    \ docs (neon.tech/docs, especially \"serverless driver\", \"Neon on Vercel\", \"connection pooling\"\
+    ), the `@neondatabase/serverless` GitHub README, Drizzle ORM docs (orm.drizzle.team — \"batch\", \"\
+    neon\" sections), and Vercel docs. Quote exact passages and cite URLs + dates. Note any version-specific\
+    \ behavior. Be thorough and adversarial — if sources conflict on whether Pool is safe on Lambda, surface\
+    \ the conflict."
+  provenance:
+    agent_id: a46828e7d8aae69bf
+    session_id: be00031d-a0ac-46eb-9486-4150781a5a8b
+    model: claude-opus-4-8
+    latency_s: 269.32
+    tokens_total: 983751
+    n_tool_uses: 46
+    source_file: /Users/sam/.claude/projects/-Users-sam-workspace-rekurve-rekurve/be00031d-a0ac-46eb-9486-4150781a5a8b/subagents/agent-a46828e7d8aae69bf.jsonl
+  sample_output_excerpt: I have comprehensive material from all official sources. The one remaining gap
+    is a verbatim quote of Drizzle's exact `neon-http` transaction error string. I've used 5 WebSearch
+    + 8 WebFetch (at budget on both). I have a corroborating Drizzle docs quote ("Querying over HTTP is
+    faster for single, non-interactive transactions") plus the repo's own confirmation that neon-http
+    transactions are non-int …
 routing:
   positives:
   - id: mined-web-research-route-pos-1
@@ -334,47 +372,32 @@ routing:
   - id: mined-web-research-route-pos-2
     kind: routing
     expect_invoke: true
-    prompt: "I need a thorough, well-cited research synthesis on running the **Neon serverless Postgres\
-      \ driver (`@neondatabase/serverless`) with Drizzle ORM on AWS Lambda / Vercel serverless functions**\
-      \ — specifically the tradeoff between the HTTP driver and the WebSocket Pool driver, and connection-pooling\
-      \ pitfalls. This is for a critical architecture decision (an ADR) about whether to introduce interactive\
-      \ transactions.\n\nContext: Next.js app on Vercel (which runs on AWS Lambda). Currently using `drizzle-orm/neon-http`\
-      \ (the `neon()` HTTP driver) — stateless, no pooling. We need to commit two table writes (a row\
-      \ + an \"outbox\" event row) **atomically**. We're deciding between: (a) staying on the HTTP driver\
-      \ and using an atomic multi-statement batch/array-transaction, vs (b) switching to `drizzle-orm/neon-serverless`\
-      \ (the WebSocket `Pool`) to get interactive `db.transaction(async tx => {...})`.\n\nResearch and\
-      \ report, with citations + dates, on:\n\n1. **HTTP driver (`neon()` over HTTPS) transaction capabilities**:\
-      \ The `@neondatabase/serverless` HTTP client exposes a `sql.transaction([q1, q2, ...])` array form.\
-      \ Confirm: does it execute all statements in a SINGLE atomic Postgres transaction (BEGIN…COMMIT)\
-      \ in ONE HTTP round-trip? What are its documented LIMITATIONS — specifically, can it do INTERACTIVE\
-      \ transactions (read a result, then decide the next query within the same transaction)? Quote Neon's\
-      \ docs on \"interactive transactions are not supported over HTTP.\"\n\n2. **WebSocket Pool driver\
-      \ on AWS Lambda — the pooling problem**: This is the crux. Research the known issues with using\
-      \ `Pool` from `@neondatabase/serverless` (or node-postgres `Pool` generally) in AWS Lambda / serverless:\n\
-      \   - Why does a module-scope `Pool` behave badly across Lambda freeze/thaw cycles? (frozen event\
-      \ loop, dead sockets on thaw, idle-timeout disconnects)\n   - The \"connection multiplication\"\
-      \ problem: each concurrent Lambda execution environment has its own pool → max_connections × concurrency\
-      \ can exhaust Postgres connection limits.\n   - What does Neon OFFICIALLY recommend for the WebSocket\
-      \ driver in serverless? (e.g., create a `Pool`/`Client` per-request and `await pool.end()` in a\
-      \ finally block? use `ctx.waitUntil`? avoid Pool entirely?) Quote their docs/guidance.\n   - Does\
-      \ Neon's connection pooler (PgBouncer, the `-pooler` host) change this calculus?\n\n3. **Vercel-specific\
-      \ guidance**: What does Vercel and/or Neon recommend for Postgres connections in Vercel Functions\
-      \ specifically? Is the HTTP driver the recommended default for serverless, with WebSocket reserved\
-      \ for sessions/interactive transactions? Cite the Neon \"Vercel\" and \"serverless driver\" docs.\n\
-      \n4. **Drizzle `db.batch()` over neon-http**: Does `drizzle-orm/neon-http` support a `db.batch([...])`\
-      \ API, and does it map to Neon's atomic array-transaction (single transaction, single round-trip)?\
-      \ Cite the Drizzle \"Batch API\" docs and note which drivers support it (LibSQL, Neon, D1…). Does\
-      \ `.returning()` work inside a batch?\n\n5. **Interactive transactions over neon-serverless**: Confirm\
-      \ `drizzle-orm/neon-serverless` (`Pool`) supports full interactive `db.transaction(async (tx) =>\
-      \ {...})`, and that `drizzle-orm/neon-http` does NOT (it throws / is limited). \n\n6. **Recommendation\
-      \ framing**: Summarize the decision factors a team should weigh: serverless-friendliness (no connection\
-      \ lifecycle) vs the need for interactive (read-then-write) transactions. When is the HTTP+batch\
-      \ approach sufficient, and when is the WebSocket Pool genuinely required?\n\nPrefer official sources:\
-      \ Neon docs (neon.tech/docs, especially \"serverless driver\", \"Neon on Vercel\", \"connection\
-      \ pooling\"), the `@neondatabase/serverless` GitHub README, Drizzle ORM docs (orm.drizzle.team —\
-      \ \"batch\", \"neon\" sections), and Vercel docs. Quote exact passages and cite URLs + dates. Note\
-      \ any version-specific behavior. Be thorough and adversarial — if sources conflict on whether Pool\
-      \ is safe on Lambda, surface the conflict."
+    prompt: "I'm designing a Claude Code \"skill\" (a reusable instruction file) for a solo developer's\
+      \ GitHub-issue workflow. I need authoritative research on the distinction between two practices:\
+      \ **issue/bug triage** vs **backlog grooming (a.k.a. backlog refinement)**.\n\nPlease research the\
+      \ web across at least 3-5 credible sources (Atlassian, agile/scrum guides, GitHub's own docs, engineering\
+      \ blogs, Marty Cagan/SVPG, Mountain Goat Software, etc.) and synthesize answers to these specific\
+      \ questions:\n\n1. **Definitions & boundaries**: What is \"triage\" vs \"backlog grooming/refinement\"\
+      ? Where does each begin and end? What activities belong to each?\n\n2. **Triage specifics**: Is\
+      \ triage fundamentally about *incoming* items (new bug reports, externally-created issues, support\
+      \ tickets) — i.e., deciding accept/reject/route/severity? Or does \"triage\" also apply to periodically\
+      \ re-examining items you created yourself?\n\n3. **Backlog grooming specifics**: What are the canonical\
+      \ activities of backlog refinement? (e.g., removing stale/obsolete items, re-prioritizing, adding\
+      \ detail/estimates, breaking down large items, ensuring items are \"ready\" for planning). \n\n\
+      4. **Staleness / obsolescence**: What do best-practice sources say about detecting and closing stale\
+      \ issues — issues superseded by completed work, no longer relevant, or duplicates? Any heuristics\
+      \ (age thresholds, \"definition of ready\", etc.)?\n\n5. **Decision outcomes**: When refining a\
+      \ single backlog item, what are the canonical possible outcomes/dispositions? (e.g., close-as-obsolete,\
+      \ close-as-duplicate, re-prioritize, add-detail, split, accept-into-sprint/roadmap, keep-but-defer,\
+      \ needs-more-info).\n\n6. **Solo developer context**: Does the triage-vs-grooming distinction collapse\
+      \ for a solo developer who creates ALL their own issues (no external/inbound issues to accept or\
+      \ reject)? Is there published guidance on lightweight/solo backlog management?\n\n7. **Cadence &\
+      \ batching**: Best practices on how often to groom, and whether to process items one-at-a-time vs\
+      \ in batch sessions.\n\n8. **\"Definition of Ready\"**: Explain this concept and what criteria make\
+      \ a backlog item \"ready\" to be pulled into planned work.\n\nReturn a structured synthesis with\
+      \ clear headers per question, cite which source supports each claim, and flag any disagreements\
+      \ between sources. Be concrete and practical, not vague. End with a short \"bottom line\" on whether\
+      \ triage and grooming are genuinely separate activities or a continuum."
   - id: mined-web-research-route-pos-3
     kind: routing
     expect_invoke: true
@@ -505,6 +528,50 @@ routing:
       Report under 800 words. Lead with the answer to "can a single BetterAuth `rateLimit` config truly
       replace a heterogeneous custom limiter that''s used both inside *and* outside auth flows", then
       back it up with evidence. Cite each source inline.'
+  - id: mined-web-research-route-pos-5
+    kind: routing
+    expect_invoke: true
+    prompt: "I need a thorough, well-cited research synthesis on running the **Neon serverless Postgres\
+      \ driver (`@neondatabase/serverless`) with Drizzle ORM on AWS Lambda / Vercel serverless functions**\
+      \ — specifically the tradeoff between the HTTP driver and the WebSocket Pool driver, and connection-pooling\
+      \ pitfalls. This is for a critical architecture decision (an ADR) about whether to introduce interactive\
+      \ transactions.\n\nContext: Next.js app on Vercel (which runs on AWS Lambda). Currently using `drizzle-orm/neon-http`\
+      \ (the `neon()` HTTP driver) — stateless, no pooling. We need to commit two table writes (a row\
+      \ + an \"outbox\" event row) **atomically**. We're deciding between: (a) staying on the HTTP driver\
+      \ and using an atomic multi-statement batch/array-transaction, vs (b) switching to `drizzle-orm/neon-serverless`\
+      \ (the WebSocket `Pool`) to get interactive `db.transaction(async tx => {...})`.\n\nResearch and\
+      \ report, with citations + dates, on:\n\n1. **HTTP driver (`neon()` over HTTPS) transaction capabilities**:\
+      \ The `@neondatabase/serverless` HTTP client exposes a `sql.transaction([q1, q2, ...])` array form.\
+      \ Confirm: does it execute all statements in a SINGLE atomic Postgres transaction (BEGIN…COMMIT)\
+      \ in ONE HTTP round-trip? What are its documented LIMITATIONS — specifically, can it do INTERACTIVE\
+      \ transactions (read a result, then decide the next query within the same transaction)? Quote Neon's\
+      \ docs on \"interactive transactions are not supported over HTTP.\"\n\n2. **WebSocket Pool driver\
+      \ on AWS Lambda — the pooling problem**: This is the crux. Research the known issues with using\
+      \ `Pool` from `@neondatabase/serverless` (or node-postgres `Pool` generally) in AWS Lambda / serverless:\n\
+      \   - Why does a module-scope `Pool` behave badly across Lambda freeze/thaw cycles? (frozen event\
+      \ loop, dead sockets on thaw, idle-timeout disconnects)\n   - The \"connection multiplication\"\
+      \ problem: each concurrent Lambda execution environment has its own pool → max_connections × concurrency\
+      \ can exhaust Postgres connection limits.\n   - What does Neon OFFICIALLY recommend for the WebSocket\
+      \ driver in serverless? (e.g., create a `Pool`/`Client` per-request and `await pool.end()` in a\
+      \ finally block? use `ctx.waitUntil`? avoid Pool entirely?) Quote their docs/guidance.\n   - Does\
+      \ Neon's connection pooler (PgBouncer, the `-pooler` host) change this calculus?\n\n3. **Vercel-specific\
+      \ guidance**: What does Vercel and/or Neon recommend for Postgres connections in Vercel Functions\
+      \ specifically? Is the HTTP driver the recommended default for serverless, with WebSocket reserved\
+      \ for sessions/interactive transactions? Cite the Neon \"Vercel\" and \"serverless driver\" docs.\n\
+      \n4. **Drizzle `db.batch()` over neon-http**: Does `drizzle-orm/neon-http` support a `db.batch([...])`\
+      \ API, and does it map to Neon's atomic array-transaction (single transaction, single round-trip)?\
+      \ Cite the Drizzle \"Batch API\" docs and note which drivers support it (LibSQL, Neon, D1…). Does\
+      \ `.returning()` work inside a batch?\n\n5. **Interactive transactions over neon-serverless**: Confirm\
+      \ `drizzle-orm/neon-serverless` (`Pool`) supports full interactive `db.transaction(async (tx) =>\
+      \ {...})`, and that `drizzle-orm/neon-http` does NOT (it throws / is limited). \n\n6. **Recommendation\
+      \ framing**: Summarize the decision factors a team should weigh: serverless-friendliness (no connection\
+      \ lifecycle) vs the need for interactive (read-then-write) transactions. When is the HTTP+batch\
+      \ approach sufficient, and when is the WebSocket Pool genuinely required?\n\nPrefer official sources:\
+      \ Neon docs (neon.tech/docs, especially \"serverless driver\", \"Neon on Vercel\", \"connection\
+      \ pooling\"), the `@neondatabase/serverless` GitHub README, Drizzle ORM docs (orm.drizzle.team —\
+      \ \"batch\", \"neon\" sections), and Vercel docs. Quote exact passages and cite URLs + dates. Note\
+      \ any version-specific behavior. Be thorough and adversarial — if sources conflict on whether Pool\
+      \ is safe on Lambda, surface the conflict."
   negatives:
   - id: mined-web-research-route-neg-1
     kind: routing
@@ -531,39 +598,6 @@ routing:
       \ with verbatim type signatures where possible and links to the source docs sections. Include code\
       \ snippets for `customRules` and `secondaryStorage`."
   - id: mined-web-research-route-neg-2
-    kind: routing
-    expect_invoke: false
-    actual_route: web-lookup
-    confusability: 0.164
-    prompt: 'I''m implementing PostHog Error Tracking + Insight alerts in a Next.js 15 app deployed on
-      Vercel. I need authoritative, up-to-date info on:
-
-
-      1. **Server-only PostHog config** — design doc says `POSTHOG_KEY` and `POSTHOG_HOST` must be server-only
-      (never exposed to client). But the standard PostHog Next.js setup uses `NEXT_PUBLIC_POSTHOG_KEY`
-      for the client SDK because the project key is *publicly safe to expose* (it''s not a write-API secret).
-      Can `posthog-js` (browser SDK) be initialized without exposing the key to the client? What''s the
-      current PostHog recommendation for Next.js 15 App Router as of late 2025/2026? Resolve the tension.
-
-
-      2. **PostHog Vercel Integration for source maps** — how is this set up? Is it a one-click marketplace
-      install, or does it require any code/config changes (e.g., `next.config.ts` setting)? What env vars
-      does it inject? Does it conflict with us managing `POSTHOG_KEY` manually?
-
-
-      3. **Error tracking + alerts** — confirm PostHog Error Tracking is GA and supports webhook destinations
-      for alerts. What''s the alert configuration UI/API like — can it be done purely in the PostHog dashboard,
-      or via config-as-code?
-
-
-      4. **`posthog-js` vs `posthog-node` setup for Next.js App Router** — what''s the canonical 2026
-      setup with `instrumentation.ts`, root layout, server components, and route handlers? Include code
-      snippets.
-
-
-      Quote the PostHog docs directly where possible, cite URLs, note version dates. Use context7 if useful.
-      Aim for ~500 words, include code snippets.'
-  - id: mined-web-research-route-neg-3
     kind: routing
     expect_invoke: false
     actual_route: web-lookup
@@ -599,3 +633,60 @@ routing:
 
 
       Under 400 words.'
+  - id: mined-web-research-route-neg-3
+    kind: routing
+    expect_invoke: false
+    actual_route: codebase-analyzer
+    confusability: 0.124
+    prompt: 'I''m planning a refactor to mirror the email dispatch Inngest pattern for SMS. I need a precise,
+      file:line-cited trace of how the email dispatch worker pattern works end-to-end. Please analyze
+      these files:
+
+
+      - `src/inngest/functions/messages/dispatch-email.ts`
+
+      - `src/inngest/functions/messages/reconcile-missed-engagement.ts`
+
+      - `src/inngest/functions/index.ts` (how functions are registered)
+
+      - `src/inngest/channels.ts` and `src/inngest/client.ts` (event/channel definitions)
+
+      - `src/server/outbox/index.ts` (the MESSAGE_EVENTS / HUBSPOT_EMAIL_EVENTS constants, and any helper
+      to enqueue outbox events)
+
+      - `src/server/api/routers/messages.ts` (the `approve` and `editAndApprove` mutations — how they
+      write the status flip + outbox event atomically)
+
+      - `src/server/db/schema/message-queue.ts` (the schema, including the `dispatching_at` fence column)
+
+
+      For each, report with file:line citations:
+
+
+      1. **dispatch-email worker**: How does it subscribe to the event and filter to `channel === "email"`?
+      What are its discrete `step.run` stages in order (status re-verification / "verify-still-approved",
+      the dispatching_at fence, the provider/Graph call, the conversation row write, the `messageQueue.sentAt`
+      stamp)? How does the cancellation / "verify still approved" step work? How does `step.waitForEvent`
+      work for the engagement reconciliation, and what''s the timeout, and what fires on timeout (reconcile-missed-engagement)?
+
+
+      2. **Event contract**: What is the exact shape of the `message.approval-requested` event payload
+      (all `data` fields)? What does the worker read from it? What is the event name string constant and
+      where is it defined?
+
+
+      3. **Registration**: How is `dispatchEmail` registered in the functions index? What''s the naming/id
+      convention for Inngest function ids?
+
+
+      4. **Router atomic write**: How exactly do `approve` / `editAndApprove` perform the atomic status-flip
+      + outbox enqueue (the `db.batch()` call)? What''s written to the outbox row? Is there anything email-specific
+      in the router, or is it channel-agnostic?
+
+
+      5. **Outbox helpers**: What''s the signature of whatever enqueues an outbox event, and what columns
+      does the outbox row have?
+
+
+      Be exhaustive and precise — quote the key lines. This is for mirroring the exact pattern into a
+      new `dispatch-sms` function.'

--- a/.claude/scripts/block-env-file-read.sh
+++ b/.claude/scripts/block-env-file-read.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# Pre-tool hook for Claude Code. Blocks Read and Bash tool calls that would
+# expose .env file contents. Reads the tool invocation from stdin as JSON.
+#
+# .env files hold secrets — use `make env_pull` to sync env vars from Vercel.
+# Escape hatch for the user: run commands directly via the `!` prefix in the
+# Claude prompt — hooks do not run on user-invoked shell commands.
+
+INPUT=$(cat)
+TOOL=$(echo "$INPUT" | jq -r '.tool_name')
+
+if [ "$TOOL" = "Read" ]; then
+  FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
+  if [ -z "$FILE_PATH" ]; then
+    exit 0
+  fi
+  BASENAME=$(basename "$FILE_PATH")
+  # Match .env, .env.local, .env.production, etc. but not .envrc or .environment
+  if echo "$BASENAME" | grep -qE '^\.env(\.[a-zA-Z0-9_.-]+)?$'; then
+    echo "BLOCKED: Reading '$FILE_PATH' is not allowed — .env files may contain secrets. Use \`make env_pull\` to sync env vars from Vercel." >&2
+    exit 2
+  fi
+fi
+
+if [ "$TOOL" = "Bash" ]; then
+  COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command')
+  # Check each line for a .env filename appearing as a path token.
+  # Matches: cat .env, head /app/.env.local, grep SECRET .env.production
+  # Does not match: NODE_ENV=, process.env.FOO, cat .envrc, cat .environment
+  ENV_PATTERN='(^|[[:space:]]|/|"|'"'"')\.env(\.[a-zA-Z0-9_.-]+)?([[:space:]]|$|[";'"'"'|&>])'
+  while IFS= read -r line; do
+    if echo "$line" | grep -qE "$ENV_PATTERN"; then
+      echo "BLOCKED: The command references a .env file — .env files may contain secrets. Use \`make env_pull\` to sync env vars from Vercel." >&2
+      exit 2
+    fi
+  done <<< "$COMMAND"
+fi
+
+exit 0

--- a/.claude/scripts/tsc-check.sh
+++ b/.claude/scripts/tsc-check.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# PostToolUse hook. Reads file_path from the Edit/Write/MultiEdit tool input,
+# no-ops for non-TypeScript files, then runs tsc --noEmit over the whole project.
+
+FILE=$(jq -r '.tool_input.file_path // empty')
+
+case "$FILE" in
+  *.ts|*.tsx) ;;
+  *) exit 0 ;;
+esac
+
+cd "$CLAUDE_PROJECT_DIR" && tsc --noEmit

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -18,6 +18,19 @@
           {
             "type": "command",
             "command": "$CLAUDE_PROJECT_DIR/.claude/scripts/block-dangerous-git.sh"
+          },
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/scripts/block-env-file-read.sh"
+          }
+        ]
+      },
+      {
+        "matcher": "Read",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/scripts/block-env-file-read.sh"
           }
         ]
       }
@@ -29,6 +42,10 @@
           {
             "type": "command",
             "command": "$CLAUDE_PROJECT_DIR/.claude/scripts/biome-format.sh"
+          },
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/scripts/tsc-check.sh"
           }
         ]
       }

--- a/.claude/skills/roadmap-review/SKILL.md
+++ b/.claude/skills/roadmap-review/SKILL.md
@@ -1,22 +1,29 @@
 ---
 name: roadmap-review
-description: Collaborative review and prioritization of GitHub Project issues for pre-PMF startups. Use when you need to reassess priorities, restructure milestones, or ensure work aligns with validation goals. Especially useful when capacity changes or strategy shifts.
+description: Collaborative review, grooming, and scheduling of GitHub Project issues for pre-PMF startups. Use to reassess priorities, restructure milestones, close stale or superseded issues, judge whether an issue is ready to plan, or (re)build the roadmap timeline — Start/End dates, implementation order, and developer capacity — on the board. Especially useful when capacity changes, strategy shifts, or after completing major work.
 model: opus
 effort: max
 ---
 
-# Roadmap Review & Prioritization
+# Roadmap Review, Grooming & Scheduling
 
 ## Overview
 
-Help founders review and restructure their GitHub Project to focus on what matters most for reaching product-market fit. Uses collaborative questioning to understand constraints, then proposes specific issue and milestone changes.
+Help founders review and restructure their GitHub Project to focus on what matters most for reaching product-market fit. Three altitudes, one pass:
+
+1. **Groom** — work the open backlog issue-by-issue: is it stale (superseded by completed work → close), not ready (needs a split / acceptance criteria / a spike), or ready to plan?
+2. **Prioritize** — sequence the ready survivors against the single PMF goal and real capacity.
+3. **Schedule** — write the resulting timeline back to the board: Start/End dates, implementation order, and the developer's concurrent-capacity ceiling.
+
+This skill **recommends** — it writes a prioritization doc and STOPs. It makes **no GitHub changes itself**; the `github-project` agent applies them on the founder's explicit OK (see [Applying the changes](#applying-the-changes)).
 
 **When to use:**
 - Feeling overwhelmed by too many priorities
 - Capacity has changed (more or less time available)
 - Strategy shift (e.g., moving from building to validating)
-- Quarterly/monthly planning
-- After completing a major milestone
+- Stale backlog — issues that may be superseded by shipped work, or "is this ready to plan?"
+- The roadmap timeline/dates are out of sync with the real plan
+- Quarterly/monthly planning, or after completing a major milestone
 
 ## Pre-PMF Prioritization Framework
 
@@ -60,173 +67,182 @@ Help founders review and restructure their GitHub Project to focus on what matte
 
 ## The Review Process
 
-### Step 1: Gather Context
+### Step 1 — Gather Context
 
-Fetch the current state of the GitHub Project:
+Fetch the current state of the GitHub Project **and** the completed-work corpus needed to detect "superseded by shipped work":
 
 ```bash
-# List all projects
-gh project list --owner <owner> --format json
+# Open issues + project fields (the live board)
+gh project item-list 2 --owner samjmarshall --format json --limit 200
+gh project field-list 2 --owner samjmarshall --format json
+gh issue list --repo samjmarshall/rekurve --state all --json number,title,state,createdAt,updatedAt,milestone,labels --limit 200
 
-# Get project items with all fields
-gh project item-list <project-number> --owner <owner> --format json --limit 100
-
-# Get project field definitions
-gh project field-list <project-number> --owner <owner> --format json
-
-# List issues with milestones
-gh issue list --repo <owner>/<repo> --state all --json number,title,state,milestone,labels --limit 100
+# Completed-work corpus (bounded ~6 months) — the comparison set for staleness
+gh issue list --repo samjmarshall/rekurve --state closed --json number,title,closedAt,labels --limit 200
+gh pr list   --repo samjmarshall/rekurve --state merged --json number,title,mergedAt,files   --limit 200
+git log --since="6 months ago" --oneline
 ```
 
 Also read:
-- `thoughts/docs/` - Non-technical project docs (strategy, messaging, pilot feedback)
-- `thoughts/designs/` - Recent design decisions
+- `thoughts/docs/` — non-technical project docs (strategy, messaging, pilot feedback)
+- `thoughts/designs/` + `docs/adr/` — recent decisions and pivots (these tell you which areas changed)
 
-### Step 2: Collaborative Discovery (One Question at a Time)
+### Step 2 — Health Pass (grooming — runs *before* discovery)
+
+The discovery questions only matter for prioritizing *ready* survivors, so groom first. Don't deep-dive all N issues — filter cheaply, investigate only the suspicious.
+
+**2a. Heuristic pre-filter → candidates.** Flag an issue as a candidate by cheap signals:
+- *Staleness:* age by **`createdAt`** ≥ ~90 days — **not `updatedAt`**: a board-wide field write (e.g. a scheduling pass that sets/clears dates) resets `updatedAt` on dozens of issues at once, so it under-flags genuinely-old work; count `updatedAt` as activity only when it reflects a substantive edit. **OR** the issue sits in an area a recent pivot touched (infer from recent ADRs / `thoughts/designs/` / strategy docs), **OR** it overlaps a lot of recently-Done work — **this overlap signal is load-bearing**: a *recently-created* issue can still be superseded by shipped work (e.g. a seeder issue filed after the seeder merged), which the age clock alone misses. Draw staleness candidates from corpus-overlap, not age alone.
+- *Readiness:* missing Priority or Size, Size = XL, or no acceptance criteria. **Exempt epics / umbrella issues** (label `epic`) — they're envelopes (Step 5), not splittable work, so XL or no-Size doesn't flag them.
+
+Issues that pass the filter clean are **assumed Ready** — no deep-dive.
+
+**2b. Deep-dive candidates only.** For each candidate, investigate whether shipped work already covers it: spawn `codebase-locator` + `codebase-analyzer` to check whether the feature exists, and search the closed-issue / merged-PR corpus for the same scope. Run candidates in parallel. Each returns one verdict:
+- `superseded-by #X` / `delivered-by PR #X` — **with** merged-PR or commit evidence. (The deliverer is often a **PR not linked to the issue**, not a superseding issue — e.g. a CI feature an issue asked for, shipped by an unrelated PR. Cite that PR/commit, not a phantom issue number.)
+- `still-relevant`
+- `uncertain`
+
+**2c. Safety rail.** An `uncertain` verdict → **Needs-investigation**, *never* Remove. A borderline issue is never recommended for closure without clear evidence.
+
+**2d. Categorize — flat 5-bucket, precedence-ordered (first match wins):**
+
+1. **Remove (stale)** — superseded / already-delivered / no-longer-relevant / duplicate. Tag `superseded-by #X` *or* `delivered-by PR #X` with merged-PR or commit evidence.
+2. **Needs-investigation (not ready)** — relevant but not plannable. Reason from a light set: *under-specified* (no acceptance criteria) · *too coarse* (Size XL / multi-week → must be split) · *has unknowns* (needs a spike). Also catches `uncertain` staleness.
+3. **Ready** — passes to discovery + prioritization (Active Now / Blocked / Post-PMF, below).
+
+The readiness bar is deliberately light — the whole test is **"Could work start on this tomorrow without another decision?"** If no → Needs-investigation. Don't impose a heavy Definition-of-Ready; it stalls a solo dev.
+
+### Step 3 — Collaborative Discovery (one question at a time)
+
+Run *only for the Ready survivors* — sequencing decisions. One question at a time, multiple-choice where possible.
 
 **Question 1: Current Reality**
 > "What stage is your [current priority] at?"
-> A) Haven't started
-> B) In progress but early
-> C) Actively building
-> D) Live and getting data
+> A) Haven't started · B) In progress but early · C) Actively building · D) Live and getting data
 
 **Question 2: Blockers**
 > "What's blocking you from [the most important thing]?"
-> A) Nothing - just hadn't prioritized it
-> B) Need to finish [dependency] first
-> C) Don't feel ready - need to build more
-> D) Time/capacity constraints
-> E) Something else
+> A) Nothing — just hadn't prioritized it · B) Need to finish [dependency] first · C) Don't feel ready — need to build more · D) Time/capacity · E) Something else
 
-**Question 3: Capacity**
+**Question 3: Capacity (weekly hours)**
 > "How many hours per week can you dedicate to this?"
-> A) Less than 5 hours
-> B) 5-10 hours
-> C) 10-20 hours
-> D) 20+ hours
+> A) <5 · B) 5-10 · C) 10-20 · D) 20+
+> *(This is `H`, the scheduler's weekly-hours input in Step 5.)*
 
 **Question 4: Time Constraints**
 > "Any upcoming time off or constraints I should know about?"
-> (Open-ended - capture specific dates)
+> (Open-ended — capture specific dates; the scheduler skips these windows.)
 
 **Question 5: Warm Leads**
 > "Do you have any warm leads or prospects ready to engage?"
-> A) Yes, [details]
-> B) Some possibilities but not confirmed
-> C) No, need to find them
+> A) Yes, [details] · B) Some possibilities but not confirmed · C) No, need to find them
 
 **Question 6: Validation of Approach**
 > "Does focusing 100% on [recommended priority] feel right?"
-> A) Yes
-> B) Mostly, but [concern]
-> C) I'm hesitant because [reason]
-> D) I disagree because [reason]
+> A) Yes · B) Mostly, but [concern] · C) Hesitant because [reason] · D) Disagree because [reason]
 
-### Step 3: Categorize Issues
+**Question 7: Concurrent capacity (WIP limit)**
+> "How many issues can you genuinely have in flight at once?"
+> A) 1 — strict single-thread · B) 2 — one main + one small parallel (typical solo) · C) 3+
+> *(Default 2. This is the scheduler's WIP input. For a solo dev, parallel lanes don't add throughput — see Step 5.)*
 
-Based on discovery, categorize every open issue:
+Also confirm **every Ready issue has a Size** (XS/S/M/L). Missing Size or Size = XL → send it back to **Needs-investigation** (not schedulable until sized/split) — **except epics**, which are envelopes (Step 5), not sized work.
 
-**Category 1: Active Now**
-- Directly supports current pilot/customer
-- Can be done with current capacity
-- Has clear timeline and deliverable
+### Step 4 — Prioritize the Ready survivors
 
-**Category 2: Blocked/Waiting**
-- Depends on something else completing first
-- Keep in backlog with dependency noted
+Sort the Ready issues into:
 
-**Category 3: Post-PMF (Deprioritize)**
-- Assumes paying customers exist
-- About scaling, efficiency, or marketing
-- "Nice to have" but not validation-critical
+- **Active Now** — directly supports the current pilot/customer, doable with current capacity, clear deliverable.
+- **Blocked/Waiting** — depends on something else first; keep in backlog with the dependency noted.
+- **Post-PMF / Post-Pilot (Deprioritize)** — assumes paying customers, about scaling/efficiency/marketing, or "nice to have" but not validation-critical.
 
-**Category 4: Remove**
-- No longer relevant to strategy
-- Duplicate of another issue
-- Solved by a different approach
+(Remove and Needs-investigation were already separated in Step 2.)
 
-### Step 4: Propose Changes
+### Step 5 — Scheduling Pass
 
-Present changes in sections, validating each:
+Turn the prioritized **Active Now** list into a real timeline. Inputs: the Active-Now issues in priority order; each one's Size; weekly hours `H` (Q3); time-off windows (Q4); WIP limit (Q7, default 2).
 
-**Section 1: Issues to Deprioritize**
-List issues moving to Post-PMF backlog with:
-- Issue number and title
-- Current milestone
-- Rationale (one line)
+**Procedure:**
 
-**Section 2: Issues to Keep Active**
-List issues remaining active with:
-- Issue number and title
-- Proposed timing (week/dates)
-- Priority (P1/P2)
-- Dependencies
+1. **Size → effort-hours:** `XS=2 · S=4 · M=8 · L=20`. (XL never reaches here — Step 2 routed it to Needs-investigation. A Ready issue with no Size is not schedulable.)
+2. **Daily rate** = `H / 5` working days.
+3. **Walk the issues in priority order** on a calendar clock starting the next working day (or an explicit start date), skipping weekends + time-off windows:
+   - `duration_days = ceil(effort_hours / daily_rate)`
+   - `Start` = next free working day in lane 1; `End` = `Start + duration_days − 1` working day.
+4. **WIP overlay:** default everything to **lane 1** (sequential). Mark an XS/S item as a *fill-in parallel* to the current lane-1 item to place it in **lane 2**, overlapping — capped so at most `WIP` bars overlap on any day.
+   - ⚠ **Throughput stays `H`/week.** For a solo dev, parallel lanes do **not** add hours — the overlay buys *visibility of a slotted-in small task*, not speed. **The only real compression lever is Size, not WIP.** If one large item dominates the sprint (as the two L legal drafts did on 2026-06-08), flag it for re-sizing or splitting rather than reaching for parallelism.
+5. **Epics / umbrella containers** aren't scheduled as work — **envelope** them: `Start` = earliest child start, `End` = latest child end.
+6. **Make the capacity reality explicit.** Sum the effort and compare the computed span to the prose plan, e.g. *"this '4-week' plan is really ~7.5 weeks at 15 h/wk"*. Surfacing that gap is the point of writing the schedule back — it's what catches an over-optimistic sprint before it's committed.
+7. **Parked issues** (Remove / Needs-investigation / Blocked / Post-PMF) get **dates cleared** — a dateless issue correctly drops off the Roadmap view (Just-in-Time: dateless = not-yet-scheduled).
 
-**Section 3: Milestone Cleanup**
-- Which milestones are active vs paused
-- Any milestones to remove
+**Output** — a **Schedule** table: `issue · Size · lane · Start · End`, plus the total span and the capacity-reality note.
 
-**Section 4: Weekly Focus**
-- Simple table showing week-by-week focus
-- Accounting for capacity constraints and time off
+### Step 6 — Propose Changes (section by section)
 
-### Step 5: Confirm and Document
+Present in sections, validating each before continuing:
 
-After user approves each section, write complete roadmap prioritization to:
+1. **Remove candidates** — issue, `superseded-by #X` / `delivered-by PR #X`, one-line evidence, recommended close.
+2. **Needs-investigation** — issue, the gap (under-specified / too coarse / has unknowns), suggested next action (spike / split / add acceptance criteria), and a pointer to `/write_tickets`. (The skill drafts nothing — recommendation only.)
+3. **Deprioritize** — issues moving to Post-PMF / Post-Pilot: number, title, current milestone, one-line rationale.
+4. **Keep Active** — issue, proposed Priority, dependencies.
+5. **Schedule** — the Step-5 table (Start/End per Active-Now issue + epic envelopes).
+6. **Milestone cleanup** — which milestones are active vs paused vs removed.
+7. **Weekly Focus** — week-by-week table for the human's reading (the board carries the machine-readable dates).
+
+### Step 7 — Confirm & Document
+
+After the founder approves each section, write the full prioritization to:
 `thoughts/roadmap/YYYY-MM-DD-roadmap-prioritization.md`
 
-Include:
-- Context and constraints discovered
-- Strategic rationale
-- Complete list of changes
-- Implementation checklist
-- Success criteria
+Include: context/constraints discovered · strategic rationale · the 5-bucket results (Remove / Needs-investigation / Deprioritize / Keep-Active) · the **Schedule** table · milestone restructure · weekly focus · an **implementation checklist** for the `github-project` apply step · success criteria.
 
-## Issue Field Updates
+## Applying the changes
 
-When deprioritizing issues, update these fields:
+**The skill makes NO GitHub changes.** It writes the doc and STOPs. After the founder approves, hand the changes to the **`github-project` agent** to apply (on the founder's explicit OK). Map each bucket to board actions:
 
-**Move to Post-PMF:**
-- Milestone: "Post-PMF: Scaling"
-- Priority: (clear/remove)
-- Iteration: (clear/remove)
-- Start Date: (clear/remove)
-- End Date: (clear/remove)
+| Bucket | Board action |
+|---|---|
+| **Remove** | Close as `not_planned`; record the `superseded-by #X` / `delivered-by PR #X` evidence in a closing comment. |
+| **Needs-investigation** | Leave open in Backlog; **no date**; recommend `/write_tickets` to the founder. |
+| **Active Now** | Set Priority; set Status → Ready/In progress; set **Start + End dates** per the Schedule table. |
+| **Blocked** | Status → Blocked; note the dependency; no date until unblocked. |
+| **Deprioritize / Post-PMF / Post-Pilot** | Set milestone; **clear** Priority, Start date, End date, Iteration. |
+| **Iteration field** | **Dropped** — clear it everywhere. Iterations can't be created via API (UI-only); the board runs one timeline via dates, not two. |
 
-**Keep in current milestone but deprioritize:**
-- Priority: (clear/remove)
-- Iteration: (clear/remove)
-- Start Date: (clear/remove)
-- End Date: (clear/remove)
-- Keep milestone unchanged
+**This project's Projects v2 IDs** (Project #2, `PVT_kwHOAHz9qs4AjXIr`; re-introspect with `gh project field-list` if they drift):
 
-**Update active issues:**
-- Priority: P1 or P2
-- Iteration: Appropriate week
-- Start Date: Specific date
-- End Date: Specific date
+| Field | ID | Notes |
+|---|---|---|
+| Start date (DATE) | `PVTF_lAHOAHz9qs4AjXIrzgbvEgA` | `gh project item-edit --field-id … --date YYYY-MM-DD`; `--clear` to empty |
+| End date (DATE) | `PVTF_lAHOAHz9qs4AjXIrzgbvEgE` | same |
+| Iteration | `PVTIF_lAHOAHz9qs4AjXIrzgbvEf8` | clear everywhere |
+| Size | `PVTSSF_lAHOAHz9qs4AjXIrzgbvEf0` | XS `eff732af` · S `9592a5a3` · M `9728cbdc` · L `c53df028` · XL `7b141a16` |
+| Priority | `PVTSSF_lAHOAHz9qs4AjXIrzgbvEfw` | P0 `79628723` · P1 `0a877460` · P2 `da944a9c` |
+| Status | `PVTSSF_lAHOAHz9qs4AjXIrzgbvEfE` | Backlog `f75ad846` · Ready `08afe404` · In progress `47fc9ee4` · In review `4cc61d42` · Done `98236657` · Blocked `ea0591e4` |
 
 ## Key Principles
 
-- **One question at a time**: Don't overwhelm with multiple questions
-- **Multiple choice preferred**: Easier to answer than open-ended
+- **One question at a time**: don't overwhelm with multiple questions.
+- **Multiple choice preferred**: easier to answer than open-ended.
+- **Evidence before closure**: never recommend Remove without merged-PR/commit evidence; `uncertain` → Needs-investigation.
+- **Light readiness bar**: "could work start tomorrow without another decision?" — nothing heavier.
+- **Sizing is the schedule's only real lever** (for a solo dev): WIP/parallelism buys visibility, not throughput. Re-size or split the long pole instead.
 - **Challenge assumptions**: "Do you really need X before Y?"
-- **Protect focus**: Fewer priorities = faster progress
-- **Respect constraints**: Work within real capacity, not ideal
-- **Validate incrementally**: Check each section before continuing
+- **Protect focus**: fewer priorities = faster progress.
+- **Validate incrementally**: check each section before continuing.
 
 ## After Documentation
 
-**STOP after writing the design document. Do NOT:**
-- Make any GitHub changes automatically
-- Create implementation plans
-- Execute any commands
+**STOP after writing the prioritization document.** The skill does **not**:
+- Make any GitHub changes (no close, no field edits, no date writes, no milestone moves)
+- Create implementation plans or tickets
 
-The user will use `/create_plan` or direct commands to implement the changes.
+The founder reviews the doc, then explicitly directs the **`github-project` agent** to apply the changes (per [Applying the changes](#applying-the-changes)), and uses `/write_tickets` for Needs-investigation items.
 
 ## References
 
+- Grooming design: `thoughts/designs/2026-06-07-backlog-grooming-in-roadmap-review.md`
+- Scheduling / timeline design: `thoughts/designs/2026-06-08-roadmap-scheduling-timeline-writeback.md`
 - [OpenView: Pre-PMF Product Management](https://openviewpartners.com/blog/the-pre-pmf-guide-to-product-management/)
 - [First Round: How Superhuman Found PMF](https://review.firstround.com/how-superhuman-built-an-engine-to-find-product-market-fit/)
 - [Paul Graham: Do Things That Don't Scale](https://paulgraham.com/ds.html)

--- a/.claude/skills/subagent-eval/AUTHORING.md
+++ b/.claude/skills/subagent-eval/AUTHORING.md
@@ -23,8 +23,11 @@ description: <what>. Use when <when>. Not for <when-not, with reciprocal redirec
 tools: Bash, Read          # locator (search-first); analyzer is `Read, Bash`
 color: <distinct from siblings>
 model: sonnet              # ALWAYS start here — never assume opus; let the head-to-head decide
+# effort: high            # OPTIONAL — omit to take the model's tier default; set only when the head-to-head shows a level wins
 ---
 ```
+
+Like `model`, `effort` is a frontmatter setting the head-to-head tunes on data — but it's **frontmatter-only** (there is no per-spawn override, so the harness tests it via Path 2, not the model sweep; see [REFERENCE.md](REFERENCE.md) § Model & effort decision). Omit it unless a level proves out; `web-research.md` ships `effort: max` as the one precedent.
 
 **The description is the routing signal** — the only thing the planner sees when choosing tools. <60 words, third person, what / when / when-not, with **reciprocal redirects** that keep the family coherent. The load-bearing boundary across the suite: docs-* = decided architecture & shipped features (authoritative) · thoughts-* = transient ideas/designs/plans (speculative) · codebase-* = code · web-* = the web. When you add an agent, tighten the siblings' when-not clauses to point at it.
 

--- a/.claude/skills/subagent-eval/REFERENCE.md
+++ b/.claude/skills/subagent-eval/REFERENCE.md
@@ -59,7 +59,7 @@ Prove the harness's *logic* with **zero agents** before spending a real run — 
 
 This is how the routing + execution harnesses were de-risked before every launch (2026-06-03). Re-run it after every harness edit — it's free.
 
-## Model decision rule
+## Model & effort decision rule
 
 Default **sonnet** for every agent. Adopt **opus** only if, on the deciding (variance-controlled) axis, `mean(opus) ≥ mean(sonnet) + 0.05` AND opus isn't dragged by over-templating. Bar haiku for anything needing anti-hallucination discipline (§14.1: haiku could not follow the CRITICAL rules in 2026-05-04 testing).
 
@@ -67,6 +67,21 @@ Default **sonnet** for every agent. Adopt **opus** only if, on the deciding (var
 - `codebase-analyzer` = **opus** — deep CODE tracing rewards it.
 - `thoughts-analyzer`, `docs-analyzer` = **sonnet** — on PROSE distillation, opus over-templates/pads (appends unrequested sections), losing scope/length points faster than its grounding edge earns. Don't reason "analyzer = deep = opus".
 - Nuance: opus's padding is **open-ended-distillation-shaped** — on a pointed "what is X and its Status?" it was clean; on "summarize this as shipped" it padded. Sonnet still wins (opus = no upside + higher cost).
+
+### Effort — the second axis
+
+Effort (`output_config.effort`) is a co-equal execution axis: per Opus 4.8 guidance it's "a dimension to test, not a fixed setting." It is **not symmetric with model**:
+
+- **Switching is symmetric** — set `effort:` in the agent's frontmatter, exactly like `model:` (`.claude/agents/web-research.md` ships `model: opus` + `effort: max` as precedent; it's the only agent that sets effort — the rest take their model's tier default).
+- **Testing is not** — there is **no per-spawn `effort` override** on the Agent tool or Workflow `agent()` (both expose per-spawn `model`, neither exposes `effort`; confirmed 2026-06-07). So you cannot put effort cells in `CANDS` and sweep them in one Workflow run the way you sweep model. Two routes:
+  - **Path 2 (works today):** run the head-to-head once per `effort:` value — edit the frontmatter, restart to re-register, re-run — and compare the recorded per-run JSON across runs. Heavier, and the agent file changes between runs, so it carries the mid-run file-mutation/provenance caveat (§ Safety review): verify provenance before blaming a sub-agent.
+  - **Path 1 (filed prerequisite):** a per-spawn `effort` opt mirroring `model` would let effort join `CANDS` and sweep in a single run. It's a harness change, not a skill change.
+
+**Decision rule (2-D generalisation of the model rule):** across all `(model, effort)` cells, take the best mean; adopt the **cheapest cell within 0.05 of it**, quality first. Cost ranks by **model tier, then effort level**. A higher effort earns its keep only at `mean ≥ incumbent + 0.05` — the same bar as a model bump.
+
+**Authoritative support set (use it; don't probe).** Per the `claude-api` skill (`platform.claude.com/docs/…/effort`): effort works on Opus 4.5/4.6/4.7/4.8 and Sonnet 4.6; **Sonnet 4.6 supports only `low`/`medium`/`high`**, `max` is Opus-tier (4.6+), `xhigh` is Opus 4.7+, Haiku 4.5 errors entirely, and `high` == omitting effort. It's a known static table — set frontmatter from it, and rely on it rather than Claude Code's `/effort` menu, which may surface levels a model doesn't support. An invalid `(model, effort)` cell just fails the spawn; that's the only check needed.
+
+**Blind spot.** You can't observe the effort a sub-agent actually used (same limitation as `tool_uses`, §6.3). Two same-model effort cells landing within ~0.02 mean at indistinguishable token spend may be effectively equivalent — treat that as a soft "no measurable difference" flag, not a detector.
 
 ## Judge-prompt pattern
 

--- a/.claude/skills/subagent-eval/SKILL.md
+++ b/.claude/skills/subagent-eval/SKILL.md
@@ -10,7 +10,7 @@ Prove a sub-agent change with evidence before shipping it. Run three times to da
 ## When to use
 
 - **Optimise** — a sub-agent's prompt is being edited and the change needs proving.
-- **Re-validate** — a new model shipped; re-check which model each agent should run.
+- **Re-validate** — a new model (or effort level) shipped; re-check which model **and effort** each agent should run.
 - **Compare** — does a specialist actually beat the native `Explore` baseline?
 - **Create** — authoring a new agent: read **[AUTHORING.md](AUTHORING.md)** first, then enter this loop.
 
@@ -25,12 +25,13 @@ This is a multi-agent `Workflow` (opt-in — it spends real tokens). Say "use a 
    - Write a **verified oracle** for each — confirm every expected path/value against the tree *now*.
    - ☐ Include at least one HARD task with headroom. Near-ceiling tasks don't discriminate — a well-curated repo makes even `Explore@haiku` score ~1.0 (see `docs-*` example).
 3. **Run the head-to-head.** Adapt **[harness-template.js](harness-template.js)** and launch via `Workflow`. Candidates per task: native baseline (`Explore` @ its production model, usually haiku), specialist @ `sonnet`, specialist @ `opus`.
+   - ☐ **Effort is a second axis, but not a per-spawn candidate.** Unlike `model`, there is **no per-spawn `effort` override** (see REFERENCE.md § Model & effort decision), so you can't add effort cells to `CANDS` and sweep them in one run. To test effort *today*, run the head-to-head once per `effort:` frontmatter value — edit `.claude/agents/<name>.md`, restart to re-register, re-run — then compare the recorded per-run JSON (Path 2; mind the mid-run file-mutation/provenance caveat). The per-spawn `effort` opt that would let effort mirror the model sweep in one run is filed as a prerequisite.
    - ☐ **Variance-control the deciding axis**: ≥3 runs × ≥2 judges per cell for any model decision. 1 run scouts a locate, but never flip a model from a single-run cell — a lone run can fabricate (the `ln` incident) and swing the mean; the harness now flags an n<3 promotion as inconclusive. Set the harness `DECIDING_KINDS` to THIS agent's archetype — **not literally `analyze`**; a third archetype (e.g. `pattern`) also needs per-agent **contract discriminators** added to the judge (REFERENCE.md "Scoring a new agent's contract").
    - ☐ Judges are **blinded** (no candidate id) and **verify every claimed path/Status/citation against the tree** before scoring. See REFERENCE.md.
    - ☐ Registry gotcha: a just-created agent is NOT in the session's hot registry — either restart to register, or use the harness's adopt-on-disk bootstrap. See REFERENCE.md.
    - ☐ Script placement: paste the harness inline (or keep it in `/tmp`); never save an adapted copy under `.claude/eval/` — its top-level `return` trips Biome and blocks the husky pre-commit. See REFERENCE.md.
    - ☐ **Dry-run first (zero agents)**: validate the harness logic with stubbed hooks before launching — see REFERENCE.md "Validate the harness before launch". Re-run after every harness edit; it's free and catches syntax + aggregation bugs.
-4. **Decide each model quality-first.** Default `sonnet`. Adopt `opus` for an agent ONLY if `mean(opus) ≥ mean(sonnet) + 0.05` AND it isn't dragged by over-templating. Model choice is **task-shaped, not class-shaped** — see REFERENCE.md § Model decision.
+4. **Decide each model and effort quality-first.** Default `sonnet` at the model's tier-default effort. Adopt a costlier cell — a higher model class, or a higher effort level — ONLY if it clears the same bar: `mean(candidate) ≥ mean(incumbent) + 0.05` AND it isn't dragged by over-templating. Among cells within 0.05 of the best, pick the **cheapest**: cost ranks by model tier first, then effort level. Model and effort choices are **task-shaped, not class-shaped** — see REFERENCE.md § Model & effort decision.
 5. **Wire routing** (if creating/changing an agent's role). Add it to the command fan-outs (`create_plan.md`, `brainstorm.md`, `iterate_plan.md`) and tighten reciprocal when-not redirects in sibling agents' descriptions.
 6. **Verify + safety.**
    - ☐ `make check` via **@agent-codebase-verification** (never run `make` directly).
@@ -39,7 +40,7 @@ This is a multi-agent `Workflow` (opt-in — it spends real tokens). Say "use a 
 
 ## References
 
-- **[REFERENCE.md](REFERENCE.md)** — §6.3 rubric, §6.4 aggregation, model-decision rule, judge-prompt pattern, registry/bootstrap gotcha, safety checklist, lessons from the runs.
+- **[REFERENCE.md](REFERENCE.md)** — §6.3 rubric, §6.4 aggregation, model & effort decision rule, judge-prompt pattern, registry/bootstrap gotcha, safety checklist, lessons from the runs.
 - **[AUTHORING.md](AUTHORING.md)** — how to write a new agent before validating it.
 - **[harness-template.js](harness-template.js)** — parameterized `Workflow` head-to-head for the **§6.3 execution** pass; fill the tasks/oracles/candidates and launch.
 - **[routing-harness-template.js](routing-harness-template.js)** — the **§6.2 routing** pass: scores `description`s with no candidate execution — blinded judges route probes among the on-disk descriptions and rate scope-clarity + verbosity. See REFERENCE.md §6.2.

--- a/.claude/skills/subagent-eval/harness-template.js
+++ b/.claude/skills/subagent-eval/harness-template.js
@@ -53,6 +53,9 @@ const TASKS = [
   { id: 'ANALYZE-1', kind: 'analyze', agent: '«family»-analyzer', prompt: '«…»', oracle: '«verified; the discriminating detail»' },
 ]
 
+// `model` is a per-spawn override, so it sweeps in one run. `effort` is NOT — there is no
+// per-spawn effort opt today, so don't add effort cells here expecting them to take; test effort
+// via Path 2 (one run per `effort:` frontmatter value). See REFERENCE.md § Model & effort decision.
 const CANDS = [
   { id: 'explore-haiku', kind: 'baseline', model: 'haiku' },  // production baseline — always registered
   { id: 'specialist-sonnet', kind: 'specialist', model: 'sonnet' },


### PR DESCRIPTION
## What & why

Validates the `roadmap-review` grooming Health Pass with a live dry-run (1 evidence-backed Remove, safety rail held on 7 false-close traps), hardens it with 3 prompt fixes surfaced by the run, adds a `github-project` board-operator agent, and extends `subagent-eval` to treat `effort` as a co-equal tuning axis — all tooling/markdown, no `src/` touched.

**Changes:**

- **`roadmap-review` skill + `/review_roadmap` command** — folds grooming (Step 2 Health Pass) and scheduling (Step 5) into one skill, validated by a read-only dry-run against the live board. Three prompt bugs fixed: (1) Step 1 now fetches `createdAt`+`updatedAt`; Step 2a ages off `createdAt` — a board-wide field write resets `updatedAt` on all touched issues and would under-flag genuinely stale work. (2) Staleness candidates come from corpus-overlap, not the age clock alone; epics are exempt from the XL-split / missing-Size readiness flags. (3) Remove evidence may cite `delivered-by PR #X`, not only `superseded-by #issue`.
- **`github-project` agent** — `gh`-driven Projects v2 operator: queries state, computes milestone/field deltas, applies only the named mutations, returns distilled facts — never raw bodies or list dumps. Sonnet; validated head-to-head vs the Explore baseline with four prompt fixes.
- **`subagent-eval` skill** — documents `effort` as a co-equal tuning axis alongside `model`. Effort is frontmatter-only (no per-spawn override today), so it's tested via Path 2. Generalises the decision rule to `(model, effort)` cells; cheapest cell within 0.05 of best wins. Records Sonnet 4.6's supported effort set (`low`/`medium`/`high` only).
- **Eval task corpus** — refreshed from newer real sub-agent transcripts; added `docs-analyzer` and `docs-locator` corpora.
