### PR TITLE
fix(outbox): reduce sweep cron from per-minute to hourly

### DIFF
--- a/src/inngest/functions/outbox/sweep.ts
+++ b/src/inngest/functions/outbox/sweep.ts
@@ -47,7 +47,14 @@ export async function runSweep(step: Step): Promise<void> {
   }
 }
 
+// Hourly, not per-minute: the post-commit `inngest.send` is the fast path that
+// delivers ~every event in real time; this sweep is only the backstop for the
+// rare event whose post-commit send failed (ADR-014 — cadence is "a tunable
+// knob, not a contract"). A per-minute query kept Neon's compute from ever
+// autosuspending (scale-to-zero), pinning it ~24/7 and driving DB usage to
+// quota. Hourly lets the compute idle between sweeps; worst-case recovery for a
+// failed publish is bounded by this interval.
 export const outboxSweep = inngest.createFunction(
-  { id: "outbox-sweep", triggers: { cron: "* * * * *" } },
+  { id: "outbox-sweep", triggers: { cron: "0 * * * *" } },
   ({ step }) => runSweep(step),
 );


### PR DESCRIPTION
The outbox-sweep cron ran every minute (`* * * * *`), querying Neon on
every fire. That constant 60s liveness kept Neon's compute from ever
autosuspending (scale-to-zero), pinning it ~24/7 and driving monthly DB
usage toward quota. It was also the most frequent caller of
/api/inngest, so the most frequent victim of the Vercel function-timeout
504s when a Neon HTTP call ran slow.

Per ADR-014 the sweep cadence is "a tunable knob, not a contract": the
post-commit inngest.send is the real-time fast path; the sweep is only
the backstop for the rare event whose post-commit send failed. Hourly
lets the compute idle between sweeps; worst-case recovery for a failed
publish is bounded by the interval, which is acceptable pre-PMF.

https://claude.ai/code/session_01L2dmGvbAhmkJAqDuRfgLA3