### PR TITLE
fix(inngest): stop /api/inngest 504s and per-minute Neon liveness

### DIFF
--- a/src/app/api/inngest/route.ts
+++ b/src/app/api/inngest/route.ts
@@ -5,4 +5,12 @@ import { functions } from "~/inngest/functions";
 
 export const dynamic = "force-dynamic";
 
+// Give Inngest steps headroom. Without this the route ran on Vercel's ~15s
+// default, so a slow-but-completing step (e.g. a Neon cold-resume after the
+// compute had autosuspended) was killed mid-flight and surfaced as `504 Vercel
+// Runtime Timeout` bursts — which Inngest then retried, amplifying the burst.
+// 300s is Inngest's recommended value for Vercel and the Pro-plan ceiling.
+// https://www.inngest.com/docs/deploy/vercel
+export const maxDuration = 300;
+
 export const { GET, POST, PUT } = serve({ client: inngest, functions });

--- a/src/inngest/functions/outbox/sweep.ts
+++ b/src/inngest/functions/outbox/sweep.ts
@@ -3,23 +3,32 @@ import { and, eq, isNull, lt, sql } from "drizzle-orm";
 import { inngest } from "~/inngest/client";
 import { db } from "~/server/db";
 import { outbox } from "~/server/db/schema/outbox";
+import { withDbTimeout } from "~/server/db/with-timeout";
 
 // biome-ignore lint/suspicious/noExplicitAny: Inngest serialises step results via JSON (Jsonify<T> ≠ T)
 type Step = { run: (id: string, fn: () => Promise<any>) => Promise<any> };
 
+// Bound each Neon HTTP call so a hung query fails fast as a retriable step error
+// instead of burning the function budget and 504-ing. Generous enough to absorb
+// a cold-resume (the hourly cadence means the compute is usually suspended when
+// the sweep fires), far below the route's 300s `maxDuration`.
+const DB_TIMEOUT_MS = 20_000;
+
 export async function runSweep(step: Step): Promise<void> {
   const rows = await step.run("select-unprocessed", () =>
-    db
-      .select()
-      .from(outbox)
-      .where(
-        and(
-          isNull(outbox.processedAt),
-          lt(outbox.createdAt, sql`now() - interval '30 seconds'`),
-        ),
-      )
-      .orderBy(outbox.createdAt)
-      .limit(100),
+    withDbTimeout("outbox-sweep:select", DB_TIMEOUT_MS, () =>
+      db
+        .select()
+        .from(outbox)
+        .where(
+          and(
+            isNull(outbox.processedAt),
+            lt(outbox.createdAt, sql`now() - interval '30 seconds'`),
+          ),
+        )
+        .orderBy(outbox.createdAt)
+        .limit(100),
+    ),
   );
 
   for (const row of rows) {
@@ -30,18 +39,22 @@ export async function runSweep(step: Step): Promise<void> {
           name: row.eventName,
           data: row.payload as Record<string, unknown>,
         });
-        await db
-          .update(outbox)
-          .set({ processedAt: sql`now()` })
-          .where(and(eq(outbox.id, row.id), isNull(outbox.processedAt)));
+        await withDbTimeout("outbox-sweep:mark-processed", DB_TIMEOUT_MS, () =>
+          db
+            .update(outbox)
+            .set({ processedAt: sql`now()` })
+            .where(and(eq(outbox.id, row.id), isNull(outbox.processedAt))),
+        );
       } catch (err) {
-        await db
-          .update(outbox)
-          .set({
-            attempts: sql`${outbox.attempts} + 1`,
-            lastError: String(err),
-          })
-          .where(eq(outbox.id, row.id));
+        await withDbTimeout("outbox-sweep:record-error", DB_TIMEOUT_MS, () =>
+          db
+            .update(outbox)
+            .set({
+              attempts: sql`${outbox.attempts} + 1`,
+              lastError: String(err),
+            })
+            .where(eq(outbox.id, row.id)),
+        );
       }
     });
   }

--- a/src/inngest/functions/outbox/sweep.ts
+++ b/src/inngest/functions/outbox/sweep.ts
@@ -47,7 +47,14 @@ export async function runSweep(step: Step): Promise<void> {
   }
 }
 
+// Hourly, not per-minute: the post-commit `inngest.send` is the fast path that
+// delivers ~every event in real time; this sweep is only the backstop for the
+// rare event whose post-commit send failed (ADR-014 — cadence is "a tunable
+// knob, not a contract"). A per-minute query kept Neon's compute from ever
+// autosuspending (scale-to-zero), pinning it ~24/7 and driving DB usage to
+// quota. Hourly lets the compute idle between sweeps; worst-case recovery for a
+// failed publish is bounded by this interval.
 export const outboxSweep = inngest.createFunction(
-  { id: "outbox-sweep", triggers: { cron: "* * * * *" } },
+  { id: "outbox-sweep", triggers: { cron: "0 * * * *" } },
   ({ step }) => runSweep(step),
 );

--- a/src/server/db/with-timeout.ts
+++ b/src/server/db/with-timeout.ts
@@ -1,0 +1,33 @@
+/**
+ * Bounds the latency of a DB operation so a hung Neon HTTP request fails fast
+ * with a catchable error instead of running until Vercel's function timeout
+ * (which surfaces as a `504 Vercel Runtime Timeout`). The Neon serverless HTTP
+ * driver exposes no per-statement timeout when used through Drizzle, so we race
+ * the operation against a timer at the application layer.
+ *
+ * The underlying fetch is not aborted — in a serverless invocation it is
+ * discarded when the instance freezes after the response is sent. The point is
+ * to reject promptly so an Inngest step reports a *retriable* error (and Inngest
+ * retries it later with backoff, by which time a cold compute is warm) rather
+ * than burning the whole function budget and 504-ing.
+ */
+export class DbTimeoutError extends Error {
+  constructor(label: string, ms: number) {
+    super(`DB operation "${label}" exceeded ${ms}ms`);
+    this.name = "DbTimeoutError";
+  }
+}
+
+export function withDbTimeout<T>(
+  label: string,
+  ms: number,
+  operation: () => Promise<T>,
+): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new DbTimeoutError(label, ms)), ms);
+  });
+  return Promise.race([operation(), timeout]).finally(() =>
+    clearTimeout(timer),
+  );
+}


### PR DESCRIPTION
## Why

Two linked production incidents on `/api/inngest`, both traced to the outbox sweep:

1. **5xx errors** — bursts of `504 Vercel Runtime Timeout` on `POST /api/inngest` (production/`main`, e.g. ~23:28–23:32 and ~02:21–02:28). The route set no `maxDuration`, so it ran on Vercel's ~15s default; a slow-but-completing step (e.g. a Neon **cold-resume** after the compute had autosuspended) was killed mid-flight, and Inngest's retries of the timed-out request amplified each failure into a burst.
2. **Neon at 80% of monthly quota** — `outboxSweep` ran `* * * * *` (every minute). Production logs confirmed `/api/inngest` firing ~1×/min, 24/7. The cost wasn't the query, it was **liveness**: a DB hit every 60s never let Neon's compute autosuspend (scale-to-zero), pinning it ~24/7. Every other Inngest function is event-driven and sparse pre-PMF, so the sweep was the entire constant baseline.

Diagnosis was confirmed against Vercel runtime logs (504 cluster in production; the every-minute 206 sweep cadence; no `NeonDbError`/5xx in production otherwise).

## What changed

- **Sweep cadence `* * * * *` → `0 * * * *` (hourly).** ADR-014 explicitly calls the sweep cadence *"a tunable knob, not a contract"* — the post-commit `inngest.send` is the real-time fast path; the sweep is only the backstop for the rare event whose post-commit send failed. Hourly lets Neon idle between sweeps; worst-case recovery for a failed publish is bounded by the interval, which is acceptable pre-PMF.
- **`export const maxDuration = 300` on the serve route** (Inngest's recommended Vercel value) so steps have headroom and a normal cold-resume isn't killed at the default.
- **`withDbTimeout` helper** (`src/server/db/with-timeout.ts`) — races a DB op against a timer so a hung Neon HTTP call fails fast as a *retriable* step error instead of burning the (now larger) function budget and 504-ing. Inngest retries later, by which point a cold compute is warm. Applied to the sweep's DB calls with a 20s bound (generous for a cold-resume, far below the 300s `maxDuration`).

## Verification

- `make check` (lint + typecheck) — pass
- `make test` (Rstest unit tests) — pass
- Existing sweep unit + integration tests unchanged and still green (the timeout wrapper is transparent when the DB resolves promptly).

## Follow-ups (not in this PR)

- Confirm in the Neon console that compute-active-hours drop after deploy — the empirical proof the per-minute sweep was the usage driver.
- Preview deployments separately throw `NeonDbError` step errors (206/400, not 5xx) on feature branches — a different, lower-priority issue.
- Optionally extend the per-query timeout to the other DB-touching workers (or the `db` client) and set Inngest checkpointing `maxRuntime` ~20–40% below `maxDuration`.

https://claude.ai/code/session_01L2dmGvbAhmkJAqDuRfgLA3

---
_Generated by [Claude Code](https://claude.ai/code/session_01L2dmGvbAhmkJAqDuRfgLA3)_